### PR TITLE
Add monsters registries and schemas with spawn-year data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,6 @@ packages = [
   "mutants.registries",
   "mutants.services",
   "mutants.data",
+  "mutants.schemas",
   "mutants.ui"
 ]

--- a/src/mutants/registries/monsters_catalog.py
+++ b/src/mutants/registries/monsters_catalog.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_CATALOG_PATH = "state/monsters/catalog.json"
+
+# EXP formula (can be adjusted later in one place)
+def exp_for(level: int, exp_bonus: int = 0) -> int:
+    return max(0, 100 * int(level) + int(exp_bonus))
+
+class MonstersCatalog:
+    """
+    Read-only base monster definitions. Load once; fast lookups by monster_id.
+    """
+    def __init__(self, monsters: List[Dict[str, Any]]):
+        self._list = monsters
+        self._by_id: Dict[str, Dict[str, Any]] = {m["monster_id"]: m for m in monsters}
+
+    def get(self, monster_id: str) -> Optional[Dict[str, Any]]:
+        return self._by_id.get(monster_id)
+
+    def require(self, monster_id: str) -> Dict[str, Any]:
+        m = self.get(monster_id)
+        if not m:
+            raise KeyError(f"Unknown monster_id: {monster_id}")
+        return m
+
+    def list_spawnable(self, year: Optional[int] = None) -> List[Dict[str, Any]]:
+        out = []
+        for m in self._list:
+            if not m.get("spawnable", True):
+                continue
+            if year is None:
+                out.append(m)
+            else:
+                years = m.get("spawn_years", [2000, 3000])
+                if len(years) == 2 and int(years[0]) <= int(year) <= int(years[1]):
+                    out.append(m)
+        return out
+
+def _validate_base_monster(m: Dict[str, Any]) -> None:
+    """Lightweight checks (no external deps). Raises ValueError on obvious issues."""
+    req_fields = ["monster_id","name","stats","hp_max","armour_class","level",
+                  "innate_attack","spawn_years","spawnable","taunt"]
+    for f in req_fields:
+        if f not in m:
+            raise ValueError(f"monster missing required field: {f}")
+    stats = m["stats"]
+    for a in ("str","int","wis","dex","con","cha"):
+        if a not in stats:
+            raise ValueError(f"stats missing {a}")
+    if not isinstance(m["spawn_years"], (list, tuple)) or len(m["spawn_years"]) != 2:
+        raise ValueError("spawn_years must be [min_year, max_year]")
+    ia = m["innate_attack"]
+    for f in ("name","power_base","power_per_level"):
+        if f not in ia:
+            raise ValueError(f"innate_attack missing {f}")
+    # ok
+
+def load_monsters_catalog(path: str = DEFAULT_CATALOG_PATH) -> MonstersCatalog:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Missing monsters catalog at {p}")
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict) and "monsters" in data:
+        monsters = data["monsters"]
+    elif isinstance(data, list):
+        monsters = data
+    else:
+        raise ValueError('catalog must be a list of monsters or {"monsters": [...]}')
+
+    # Lightweight validation (DEV-friendly; raise on structural errors)
+    for m in monsters:
+        _validate_base_monster(m)
+
+    return MonstersCatalog(monsters)

--- a/src/mutants/registries/monsters_instances.py
+++ b/src/mutants/registries/monsters_instances.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+import json, random, uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from mutants.io.atomic import atomic_write_json
+from mutants.registries.monsters_catalog import MonstersCatalog, exp_for
+
+DEFAULT_INSTANCES_PATH = "state/monsters/instances.json"
+FALLBACK_INSTANCES_PATH = "state/monsters.json"  # optional fallback; rarely used
+
+class MonstersInstances:
+    """
+    Mutable live monsters. Each entry is a dict:
+    {
+      instance_id, monster_id, pos:[year,x,y],
+      hp:{current,max}, armour_class, level, ions, riblets,
+      inventory:[{item_id|instance_id, qty?}] (<=4),
+      armour_wearing: item_id|instance_id|null,
+      readied_spell: spell_id|null,
+      target_player_id: str|null, target_monster_id: str|null,
+      taunt: str
+    }
+    """
+    def __init__(self, path: str, items: List[Dict[str, Any]]):
+        self._path = Path(path)
+        self._items: List[Dict[str, Any]] = items
+        self._by_id: Dict[str, Dict[str, Any]] = {m["instance_id"]: m for m in items if "instance_id" in m}
+        self._dirty = False
+
+    # ---------- Queries ----------
+    def get(self, instance_id: str) -> Optional[Dict[str, Any]]:
+        return self._by_id.get(instance_id)
+
+    def list_all(self) -> Iterable[Dict[str, Any]]:
+        return list(self._items)
+
+    def list_at(self, year: int, x: int, y: int) -> Iterable[Dict[str, Any]]:
+        return (m for m in self._items if m.get("pos") == [int(year), int(x), int(y)])
+
+    # ---------- Mutations ----------
+    def _add(self, inst: Dict[str, Any]) -> Dict[str, Any]:
+        self._items.append(inst)
+        self._by_id[inst["instance_id"]] = inst
+        self._dirty = True
+        return inst
+
+    def create_instance(
+        self,
+        base: Dict[str, Any],
+        pos: Tuple[int,int,int],
+        *,
+        rng: Optional[random.Random] = None,
+        level: Optional[int] = None,
+        ions: Optional[int] = None,
+        riblets: Optional[int] = None,
+        starter_items: Optional[List[Dict[str, Any]]] = None,  # [{item_id|instance_id, qty?}]
+        starter_armour: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Create a live monster from a catalog base. Randomizes ions/riblets within
+        min/max if not provided. Seeds HP/max, AC, level. Copies taunt.
+        """
+        rr = rng or random.Random()
+        year, x, y = map(int, pos)
+        instance_id = f"{base['monster_id']}#{uuid.uuid4().hex[:8]}"
+
+        lvl = int(level if level is not None else base.get("level", 1))
+        ions_rng = (int(base.get("ions_min", 0)), int(base.get("ions_max", 0)))
+        rib_rng = (int(base.get("riblets_min", 0)), int(base.get("riblets_max", 0)))
+        ions_val = int(ions if ions is not None else rr.randint(*ions_rng))
+        rib_val = int(riblets if riblets is not None else rr.randint(*rib_rng))
+
+        inv = list(starter_items or [])
+        if not inv:
+            # Simple seeding from catalog (<=4)
+            for iid in base.get("starter_items", [])[:4]:
+                inv.append({"item_id": iid})
+
+        armour_wearing = starter_armour if starter_armour is not None else base.get("starter_armour", None)
+
+        inst: Dict[str, Any] = {
+            "instance_id": instance_id,
+            "monster_id": base["monster_id"],
+            "pos": [year, x, y],
+            "hp": {"current": int(base["hp_max"]), "max": int(base["hp_max"])},
+            "armour_class": int(base["armour_class"]),
+            "level": lvl,
+            "ions": ions_val,
+            "riblets": rib_val,
+            "inventory": inv[:4],
+            "armour_wearing": armour_wearing,
+            "readied_spell": None,
+            "target_player_id": None,
+            "target_monster_id": None,
+            "taunt": base.get("taunt", ""),
+            # Copy innate attack block for quick access (optional, but handy for combat)
+            "innate_attack": {
+                "name": base["innate_attack"]["name"],
+                "power_base": int(base["innate_attack"]["power_base"]),
+                "power_per_level": int(base["innate_attack"]["power_per_level"]),
+                # Per-monster message template; tokens: {monster}, {target}, {damage}
+                "message": base["innate_attack"].get(
+                    "message",
+                    "{monster} strikes {target} for {damage} damage!"
+                )
+            },
+            "spells": list(base.get("spells", [])),
+        }
+        return self._add(inst)
+
+    def set_target_player(self, instance_id: str, player_id: Optional[str]) -> None:
+        m = self._by_id[instance_id]; m["target_player_id"] = player_id; self._dirty = True
+
+    def set_target_monster(self, instance_id: str, other_id: Optional[str]) -> None:
+        m = self._by_id[instance_id]; m["target_monster_id"] = other_id; self._dirty = True
+
+    # ---------- Persistence ----------
+    def save(self) -> None:
+        if self._dirty:
+            atomic_write_json(self._path, self._items)
+            self._dirty = False
+
+def load_monsters_instances(path: str = DEFAULT_INSTANCES_PATH) -> MonstersInstances:
+    primary = Path(path)
+    fallback = Path(FALLBACK_INSTANCES_PATH)
+    target = primary if primary.exists() else (fallback if fallback.exists() else primary)
+    if not target.exists():
+        return MonstersInstances(str(target), [])
+    with target.open("r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError:
+            data = []
+    if isinstance(data, dict) and "instances" in data:
+        items = data["instances"]
+    elif isinstance(data, list):
+        items = data
+    else:
+        items = []
+    return MonstersInstances(str(target), items)

--- a/src/mutants/schemas/__init__.py
+++ b/src/mutants/schemas/__init__.py
@@ -1,0 +1,2 @@
+# JSON schema definitions for various registries.
+

--- a/src/mutants/schemas/monsters_catalog.schema.json
+++ b/src/mutants/schemas/monsters_catalog.schema.json
@@ -1,0 +1,48 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "monster_id", "name", "stats", "hp_max", "armour_class", "level",
+      "innate_attack", "spawn_years", "spawnable", "taunt"
+    ],
+    "properties": {
+      "monster_id": {"type":"string"},
+      "name": {"type":"string"},
+      "stats": {
+        "type":"object",
+        "required":["str","int","wis","dex","con","cha"],
+        "properties": {
+          "str":{"type":"integer"}, "int":{"type":"integer"},
+          "wis":{"type":"integer"}, "dex":{"type":"integer"},
+          "con":{"type":"integer"}, "cha":{"type":"integer"}
+        }
+      },
+      "hp_max": {"type":"integer","minimum":1},
+      "armour_class": {"type":"integer","minimum":0},
+      "level": {"type":"integer","minimum":1},
+      "ions_min": {"type":"integer","minimum":0},
+      "ions_max": {"type":"integer","minimum":0},
+      "riblets_min": {"type":"integer","minimum":0},
+      "riblets_max": {"type":"integer","minimum":0},
+      "exp_bonus": {"type":"integer"},
+      "innate_attack": {
+        "type":"object",
+        "required":["name","power_base","power_per_level"],
+        "properties":{
+          "name":{"type":"string"},
+          "power_base":{"type":"integer"},
+          "power_per_level":{"type":"integer"},
+          "message":{"type":"string"}
+        }
+      },
+      "spells": {"type":"array", "items":{"type":"string"}},
+      "starter_items": {"type":"array","maxItems":4,"items":{"type":"string"}},
+      "starter_armour": {"type":["string","null"]},
+      "spawn_years": {"type":"array","minItems":2,"maxItems":2,"items":{"type":"integer"}},
+      "spawnable": {"type":"boolean"},
+      "taunt": {"type":"string"}
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/mutants/schemas/monsters_instances.schema.json
+++ b/src/mutants/schemas/monsters_instances.schema.json
@@ -1,0 +1,35 @@
+{
+  "type": "array",
+  "items": {
+    "type":"object",
+    "required":["instance_id","monster_id","pos","hp","armour_class","level","ions","riblets"],
+    "properties":{
+      "instance_id":{"type":"string"},
+      "monster_id":{"type":"string"},
+      "pos":{"type":"array","minItems":3,"maxItems":3,"items":[{"type":"integer"},{"type":"integer"},{"type":"integer"}]},
+      "hp":{"type":"object","required":["current","max"],"properties":{"current":{"type":"integer"},"max":{"type":"integer"}}},
+      "armour_class":{"type":"integer"},
+      "level":{"type":"integer"},
+      "ions":{"type":"integer","minimum":0},
+      "riblets":{"type":"integer","minimum":0},
+      "inventory":{"type":"array","maxItems":4,"items":{"type":"object","properties":{"item_id":{"type":"string"},"instance_id":{"type":"string"},"qty":{"type":"integer","minimum":1}},"additionalProperties":false}},
+      "armour_wearing":{"type":["string","null"]},
+      "readied_spell":{"type":["string","null"]},
+      "target_player_id":{"type":["string","null"]},
+      "target_monster_id":{"type":["string","null"]},
+      "taunt":{"type":"string"},
+      "innate_attack":{
+        "type":"object",
+        "properties":{
+          "name":{"type":"string"},
+          "power_base":{"type":"integer"},
+          "power_per_level":{"type":"integer"},
+          "message":{"type":"string"}
+        },
+        "additionalProperties": true
+      },
+      "spells":{"type":"array","items":{"type":"string"}}
+    },
+    "additionalProperties": false
+  }
+}

--- a/tests/registries/test_monsters.py
+++ b/tests/registries/test_monsters.py
@@ -1,0 +1,97 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure src is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from mutants.registries.monsters_catalog import load_monsters_catalog, exp_for
+from mutants.registries.monsters_instances import load_monsters_instances
+
+SAMPLE_MONSTERS = [
+    {
+        "monster_id": "ghoul",
+        "name": "Ghoul",
+        "stats": {"str": 12, "int": 6, "wis": 6, "dex": 10, "con": 10, "cha": 4},
+        "hp_max": 18,
+        "armour_class": 1,
+        "level": 3,
+        "ions_min": 50,
+        "ions_max": 150,
+        "riblets_min": 10,
+        "riblets_max": 40,
+        "exp_bonus": 0,
+        "innate_attack": {
+            "name": "Claws",
+            "power_base": 2,
+            "power_per_level": 1,
+            "message": "{monster} rakes {target} with claws for {damage} damage!",
+        },
+        "spells": ["poison_weapon"],
+        "starter_items": ["monster_bait"],
+        "starter_armour": None,
+        "spawn_years": [2000, 2100],
+        "spawnable": True,
+        "taunt": "The ghoul hisses.",
+    },
+    {
+        "monster_id": "mud_monster",
+        "name": "Mud-Monster-3482",
+        "stats": {"str": 10, "int": 4, "wis": 4, "dex": 8, "con": 12, "cha": 3},
+        "hp_max": 14,
+        "armour_class": 1,
+        "level": 2,
+        "ions_min": 20,
+        "ions_max": 60,
+        "riblets_min": 5,
+        "riblets_max": 25,
+        "exp_bonus": 0,
+        "innate_attack": {
+            "name": "Mud Sling",
+            "power_base": 1,
+            "power_per_level": 1,
+            "message": "{monster} throws mud at {target} for {damage} damage!",
+        },
+        "spells": [],
+        "starter_items": [],
+        "starter_armour": None,
+        "spawn_years": [2000, 2050],
+        "spawnable": True,
+        "taunt": "Glorp.",
+    },
+]
+
+
+def _write_catalog(tmp_path: Path) -> Path:
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text(json.dumps(SAMPLE_MONSTERS))
+    return catalog_path
+
+
+def test_catalog_and_exp(tmp_path: Path) -> None:
+    catalog_path = _write_catalog(tmp_path)
+    cat = load_monsters_catalog(str(catalog_path))
+    ghoul = cat.require("ghoul")
+    assert ghoul["name"] == "Ghoul"
+    spawnable_ids = {m["monster_id"] for m in cat.list_spawnable(2000)}
+    assert {"ghoul", "mud_monster"} <= spawnable_ids
+    assert exp_for(3) == 300
+    assert exp_for(3, 25) == 325
+
+
+def test_instances_create_and_save(tmp_path: Path) -> None:
+    catalog_path = _write_catalog(tmp_path)
+    cat = load_monsters_catalog(str(catalog_path))
+    base = cat.require("mud_monster")
+    instances_path = tmp_path / "instances.json"
+    insts = load_monsters_instances(str(instances_path))
+    inst = insts.create_instance(base, pos=(2000, 0, 0))
+    assert inst["hp"]["current"] == base["hp_max"]
+    assert inst["hp"]["max"] == base["hp_max"]
+    assert inst["armour_class"] == base["armour_class"]
+    assert inst["level"] == base["level"]
+    assert inst["taunt"] == base["taunt"]
+    assert inst["innate_attack"]["message"] == base["innate_attack"]["message"]
+    insts.save()
+    saved = json.loads(instances_path.read_text())
+    assert saved[0]["instance_id"] == inst["instance_id"]


### PR DESCRIPTION
## Summary
- add monsters catalog with EXP function and spawn-year filtering
- manage live monsters with instances registry and atomic persistence
- document monster data with JSON schemas and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c5d3a71c832bb9b86d828532a872