### PR TITLE
Add movement and look commands with room rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,6 @@ packages = [
   "mutants.services",
   "mutants.data",
   "mutants.schemas",
-  "mutants.ui"
+  "mutants.ui",
+  "mutants.commands"
 ]

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+from mutants.registries.world import (
+    BASE_BOUNDARY,
+    BASE_GATE,
+    BASE_TERRAIN,
+    DELTA,
+    GATE_CLOSED,
+    GATE_LOCKED,
+)
+from mutants.ui.viewmodels import RoomVM
+
+
+def _active(state: Dict[str, Any]) -> Dict[str, Any]:
+    aid = state.get("active_id")
+    for p in state.get("players", []):
+        if p.get("id") == aid:
+            return p
+    return state["players"][0]
+
+
+def register(dispatch: Dict[str, Callable[[str], None]], ctx: Dict[str, Any]) -> None:
+    """Register movement and look commands on *dispatch* using *ctx*."""
+
+    def bind(cmds: List[str], dir_code: str) -> None:
+        def cmd(_arg: str) -> None:
+            move(dir_code, ctx)
+
+        for c in cmds:
+            dispatch[c] = cmd
+
+    bind(["north", "n"], "N")
+    bind(["south", "s"], "S")
+    bind(["east", "e"], "E")
+    bind(["west", "w"], "W")
+
+    dispatch["look"] = lambda _arg: look_current(ctx)
+
+
+def move(dir_code: str, ctx: Dict[str, Any]) -> None:
+    """Attempt to move the active player in direction *dir_code*."""
+    p = _active(ctx["player_state"])
+    year, x, y = p.get("pos", [2000, 0, 0])
+    world = ctx["world_loader"](year)
+    tile = world.get_tile(x, y)
+    if not tile:
+        return
+
+    edge = tile["edges"].get(dir_code, {"base": 0, "gate_state": 0})
+    base = edge.get("base", 0)
+    gate_state = edge.get("gate_state", 0)
+
+    msg = None
+    if base == BASE_BOUNDARY:
+        msg = "A boundary blocks your way."
+    elif base == BASE_TERRAIN:
+        msg = "Terrain blocks your way."
+    elif base == BASE_GATE:
+        if gate_state == GATE_CLOSED:
+            msg = "The gate is closed."
+        elif gate_state == GATE_LOCKED:
+            msg = "The gate is locked."
+
+    if msg:
+        print(msg)
+        look_current(ctx)
+        return
+
+    dx, dy = DELTA[dir_code]
+    p["pos"][1] = x + dx
+    p["pos"][2] = y + dy
+    look_current(ctx)
+
+
+def look_current(ctx: Dict[str, Any]) -> None:
+    """Render the current room for the active player."""
+    vm = build_room_vm(ctx)
+    lines = ctx["render"](vm)
+    for line in lines:
+        print(line)
+
+
+def build_room_vm(ctx: Dict[str, Any]) -> RoomVM:
+    state = ctx["player_state"]
+    p = _active(state)
+    year, x, y = p.get("pos", [2000, 0, 0])
+    world = ctx["world_loader"](year)
+    tile = world.get_tile(x, y)
+
+    headers = ctx.get("headers", [])
+    idx = int(tile.get("header_idx", 0)) if tile else 0
+    header = headers[idx] if 0 <= idx < len(headers) else ""
+
+    dirs = {}
+    if tile:
+        for d in ("N", "S", "E", "W"):
+            e = tile["edges"].get(d, {})
+            dirs[d] = {k: e.get(k) for k in ("base", "gate_state", "key_type")}
+
+    monsters_here: List[Dict[str, str]] = []
+    mon_reg = ctx.get("monsters")
+    if mon_reg:
+        try:
+            for m in mon_reg.list_at(year, x, y):  # type: ignore[attr-defined]
+                name = m.get("name") or m.get("monster_id", "?")
+                monsters_here.append({"name": name})
+        except Exception:
+            pass
+
+    ground_items: List[Dict[str, str]] = []
+    items_reg = ctx.get("items")
+    if items_reg and hasattr(items_reg, "list_at"):
+        try:
+            for it in items_reg.list_at(year, x, y):  # type: ignore[attr-defined]
+                name = it.get("name") or it.get("item_id", "?")
+                ground_items.append({"name": name})
+        except Exception:
+            pass
+
+    vm: RoomVM = {
+        "header": header,
+        "coords": {"x": x, "y": y},
+        "dirs": dirs,
+        "monsters_here": monsters_here,
+        "ground_items": ground_items,
+        "events": [],
+        "shadows": [],
+        "flags": {"dark": bool(tile.get("dark")) if tile else False},
+    }
+    return vm

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -1,0 +1,50 @@
+import pytest
+
+from mutants.bootstrap.lazyinit import ensure_player_state
+from mutants.commands.move import register
+from mutants.data.room_headers import ROOM_HEADERS
+from mutants.registries.world import load_year
+from mutants.ui.renderer import render
+from mutants.__main__ import active
+
+
+def make_ctx():
+    state = ensure_player_state()
+    ctx = {
+        "player_state": state,
+        "world_loader": load_year,
+        "monsters": None,
+        "items": None,
+        "headers": ROOM_HEADERS,
+        "render": lambda vm: render(vm),
+    }
+    dispatch = {}
+    register(dispatch, ctx)
+    return ctx, dispatch, state
+
+
+def test_look_renders_room(capsys):
+    ctx, dispatch, state = make_ctx()
+    dispatch["look"]("")
+    out = capsys.readouterr().out
+    assert "Graffiti lines the city walls." in out
+
+
+def test_move_north_updates_position_and_renders(capsys):
+    ctx, dispatch, state = make_ctx()
+    p = active(state)
+    p["pos"] = [2000, 0, 0]
+    dispatch["north"]("")
+    out = capsys.readouterr().out
+    assert p["pos"] == [2000, 0, 1]
+    assert "You're in an abandoned building." in out
+
+
+def test_boundary_blocks_movement(capsys):
+    ctx, dispatch, state = make_ctx()
+    p = active(state)
+    p["pos"] = [2000, 14, 0]
+    dispatch["east"]("")
+    out = capsys.readouterr().out
+    assert p["pos"] == [2000, 14, 0]
+    assert "A boundary blocks your way." in out


### PR DESCRIPTION
## Summary
- add movement command module with north/south/east/west and look
- render rooms through UI pipeline after moving or looking
- wire commands into REPL with context setup
- test movement and look behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1cb657eac832b984e3fa833e70c5d