### PR TITLE
feat: bootstrap runtime and discover world years

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -58,6 +58,18 @@
 - **Monsters (instances)**: `state/monsters/instances.json`; registry `registries/monsters_instances.py` (create_instance, targets, save).
 - **Player state**: ensured by `bootstrap/lazyinit.py` (DEX→AC via `dex // 10`).
 
+## Bootstrap & Discovery (no hard-coded years)
+
+- `bootstrap/runtime.ensure_runtime()` runs at startup (from `app/context.py`):
+  - ensures `state/` dirs
+  - ensures `items/instances.json` and `monsters/instances.json`
+  - ensures `state/ui/themes/bbs.json` and `mono.json` (JSON themes)
+  - discovers world years from `state/world/*.json`
+  - if none exist, **creates a minimal world** using `state/config.json` or defaults (`default_world_year=2000`, `default_world_size=30`)
+- `registries/world.list_years()` reports available years; `load_nearest_year(y)` picks the closest.
+- `bootstrap/lazyinit.ensure_player_state()` maps template `start_pos[0]` to the **nearest** existing year, so templates can always say `2000` without going stale.
+- All modules read `player.pos[0]` at runtime; no code assumes `2000`.
+
 ## IO helpers
 - `io/atomic.py` — `atomic_write_json()` and `read_json()` (tmp → fsync → replace).
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,38 @@
+# Mutants — Architecture Overview (Human-Readable)
+
+This is the plain-English tour of how the game starts, reads your input, updates state, and prints what you see.
+
+## Startup
+1) `python -m mutants` runs a tiny entrypoint that starts the REPL.
+2) The REPL asks the **app context** to build everything it needs.
+3) The app context calls `ensure_runtime()`:
+   - makes `state/` folders if missing,
+   - creates empty `items/instances.json` and `monsters/instances.json` if missing,
+   - writes theme JSONs (bbs/mono) if missing,
+   - looks for worlds in `state/world/*.json`; if none, creates a minimal world (defaults come from `state/config.json`).
+4) Player state is created (or loaded). If the template wants year `2000` but you don’t have it, we pick the **nearest** year that does exist.
+
+## The Game Loop (REPL)
+- **Read**: get your command (e.g., `n`).
+- **Eval**: a simple router maps `n` to the move handler; the handler uses the world registry to check edges and updates your `(x,y)` if allowed. It doesn’t print— it **pushes a feedback message** like “The gate is locked.”
+- **Print**: we build a view of the room (header, compass, directions, ground, etc.), drain any feedback messages, and render everything using the current theme (colors live in JSON).
+
+This repeats each turn.
+
+## Where things live
+- **REPL**: `repl/loop.py` (the metronome), `repl/dispatch.py` (command router).
+- **Commands**: `commands/*.py` (movement, theme, logs, etc.).
+- **App context**: `app/context.py` (wires player state, world loader, renderer, theme, feedback bus).
+- **UI**: `ui/renderer.py` (layout), `ui/formatters.py` (phrasing), `ui/themes.py` (loads colors), `ui/styles.py` (token names), `ui/wrap.py` (80-col lists).
+- **Feedback & logs**: `ui/feedback.py` (message queue), `ui/logsink.py` (ring buffer + `state/logs/game.log`).
+- **Registries**: `registries/world.py` (maps), `registries/items_*`, `registries/monsters_*`.
+- **Bootstrap**: `bootstrap/lazyinit.py` (player), `bootstrap/runtime.py` (state dirs/files, themes, world discovery or minimal world creation).
+- **Runtime data**: `state/world/<year>.json`, `state/items/*.json`, `state/monsters/*.json`, `state/ui/themes/*.json`, `state/logs/game.log`.
+
+## Future-proofing choices
+- No hard-coded year: world **discovery** + **nearest year** when needed.
+- Themes are JSON so you can change colors without code.
+- Feedback messages are structured and rendered in a distinct block—easy to spot and log.
+- Adding more years/monsters/items just means dropping more JSON—no code edits.
+
+That’s the system in a nutshell. If it prints weird, try `theme mono`; if commands seem ignored, check `log`; and if a template’s start year doesn’t exist, the runtime will map it for you.

--- a/src/mutants/bootstrap/runtime.py
+++ b/src/mutants/bootstrap/runtime.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+import json, re
+from pathlib import Path
+from typing import Dict, List, Optional, Iterable
+from mutants.io.atomic import atomic_write_json
+
+STATE = Path("state")
+WORLD_DIR = STATE / "world"
+ITEMS_DIR = STATE / "items"
+MONS_DIR = STATE / "monsters"
+THEMES_DIR = STATE / "ui" / "themes"
+LOGS_DIR = STATE / "logs"
+CONFIG_PATH = STATE / "config.json"
+
+# ---------- public API ----------
+def ensure_runtime() -> Dict:
+    """
+    Idempotent startup bootstrap:
+      - ensure dirs exist
+      - ensure instances.json exist (items/monsters)
+      - ensure themes exist (bbs.json, mono.json)
+      - discover world years; if none, create a minimal world using config defaults
+      - return a dict of discovered info (years, config, theme files)
+    """
+    ensure_dirs([WORLD_DIR, ITEMS_DIR, MONS_DIR, THEMES_DIR, LOGS_DIR])
+    cfg = read_config()
+    ensure_instances_files()
+    created_themes = ensure_theme_files(cfg.get("default_theme", "bbs"))
+    years = discover_world_years()
+    if not years:
+        year = int(cfg.get("default_world_year", 2000))
+        size = int(cfg.get("default_world_size", 30))
+        create_minimal_world(year=year, size=size)
+        years = [year]
+    return {"config": cfg, "years": sorted(years), "themes_created": created_themes}
+
+def discover_world_years() -> List[int]:
+    yrs = []
+    for p in WORLD_DIR.glob("*.json"):
+        m = re.fullmatch(r"(\d{3,4})\.json", p.name)
+        if m:
+            try:
+                yrs.append(int(m.group(1)))
+            except ValueError:
+                pass
+    return sorted(set(yrs))
+
+# ---------- helpers ----------
+def ensure_dirs(paths: Iterable[Path]) -> None:
+    for p in paths:
+        p.mkdir(parents=True, exist_ok=True)
+
+def read_config() -> Dict:
+    if CONFIG_PATH.exists():
+        try:
+            return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+    return {}
+
+def ensure_instances_files() -> None:
+    for path in [ITEMS_DIR / "instances.json", MONS_DIR / "instances.json"]:
+        if not path.exists():
+            atomic_write_json(path, [])
+
+def ensure_theme_files(default_theme: str = "bbs") -> Dict[str, bool]:
+    created = {"bbs": False, "mono": False}
+    bbs = THEMES_DIR / "bbs.json"
+    mono = THEMES_DIR / "mono.json"
+    if not bbs.exists():
+        atomic_write_json(bbs, _default_bbs_theme())
+        created["bbs"] = True
+    if not mono.exists():
+        atomic_write_json(mono, {"WIDTH": 80})
+        created["mono"] = True
+    return created
+
+def _default_bbs_theme() -> Dict[str, str]:
+    # Keep tokens minimal; renderer tolerates missing tokens by treating them as unstyled.
+    return {
+        "WIDTH": 80,
+        "HEADER":"\u001b[1;37m","COMPASS_LABEL":"\u001b[36m","COORDS":"\u001b[37m",
+        "DIR":"\u001b[36m","DESC_CONT":"\u001b[37m","DESC_TERRAIN":"\u001b[33m",
+        "DESC_BOUNDARY":"\u001b[2;37m","DESC_GATE_OPEN":"\u001b[32m",
+        "DESC_GATE_CLOSED":"\u001b[33m","DESC_GATE_LOCKED":"\u001b[1;31m",
+        "LABEL":"\u001b[1;37m","ITEM":"\u001b[37m","MONSTER":"\u001b[35m","SHADOWS_LABEL":"\u001b[34m",
+        "FEED_SYS_OK":"\u001b[32m","FEED_SYS_WARN":"\u001b[33m","FEED_SYS_ERR":"\u001b[1;31m",
+        "FEED_MOVE":"\u001b[36m","FEED_BLOCK":"\u001b[33m","FEED_COMBAT":"\u001b[1;35m",
+        "FEED_CRIT":"\u001b[95m","FEED_TAUNT":"\u001b[90m","FEED_LOOT":"\u001b[32m",
+        "FEED_SPELL":"\u001b[36m","FEED_DEBUG":"\u001b[2;37m","RESET":"\u001b[0m"
+    }
+
+def create_minimal_world(year: int, size: int = 30) -> None:
+    """
+    Create a simple square world with boundaries on the outer rim and open cells inside.
+    Tiles include JSON 'pos': [year, x, y] and minimal edge records.
+    """
+    half = size // 2
+    tiles = []
+    for y in range(-half, half):
+        for x in range(-half, half):
+            edges = {}
+            for dir_code, dx, dy in (("N",0,1),("S",0,-1),("E",1,0),("W",-1,0)):
+                nx, ny = x + dx, y + dy
+                on_border = (nx < -half or nx >= half or ny < -half or ny >= half)
+                base = 2 if on_border else 0  # 2=boundary, 0=open
+                edges[dir_code] = {"base": base, "gate_state": 0, "key_type": None, "spell_block": 0}
+            tiles.append({
+                "pos": [year, x, y],
+                "header_idx": 0,
+                "store_id": None,
+                "dark": False,
+                "area_locked": False,
+                "edges": edges
+            })
+    data = {"year": year, "size": size, "tiles": tiles}
+    atomic_write_json(WORLD_DIR / f"{year}.json", data)

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -25,7 +25,7 @@ def _active(state: Dict[str, Any]) -> Dict[str, Any]:
 def move(dir_code: str, ctx: Dict[str, Any]) -> None:
     """Attempt to move the active player in direction *dir_code*."""
     p = _active(ctx["player_state"])
-    year, x, y = p.get("pos", [2000, 0, 0])
+    year, x, y = p.get("pos", [0, 0, 0])
     world = ctx["world_loader"](year)
     tile = world.get_tile(x, y)
     if not tile:

--- a/src/mutants/registries/world.py
+++ b/src/mutants/registries/world.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from mutants.io.atomic import atomic_write_json
+from mutants.bootstrap.runtime import discover_world_years
 
 WORLD_DIR = Path("state/world")
 
@@ -339,6 +340,18 @@ def load_year(year: int) -> YearWorld:
     if _default_world_registry is None:
         _default_world_registry = WorldRegistry()
     return _default_world_registry.load_year(year)
+
+
+def list_years() -> list[int]:
+    return discover_world_years()
+
+
+def load_nearest_year(target: int):
+    years = list_years()
+    if not years:
+        raise FileNotFoundError("No world years found under state/world")
+    best = min(years, key=lambda y: abs(y - int(target)))
+    return load_year(best)
 
 def save_all() -> None:
     global _default_world_registry

--- a/src/mutants/ui/themes.py
+++ b/src/mutants/ui/themes.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from typing import Dict
 
 
+DEFAULTS = {"WIDTH": 80, "RESET": "\x1b[0m"}
+
+
 @dataclass
 class Theme:
     name: str
@@ -15,10 +18,10 @@ class Theme:
 
 def load_theme(path: str) -> Theme:
     p = Path(path)
-    with p.open("r", encoding="utf-8") as f:
-        data = json.load(f)
-    width = int(data.pop("WIDTH", 80))
-    if "RESET" not in data:
-        data["RESET"] = "\x1b[0m"
-    name = p.stem
-    return Theme(name=name, palette=data, width=width)
+    data: Dict[str, str] = {}
+    if p.exists():
+        data = json.loads(p.read_text(encoding="utf-8"))
+    palette = {**DEFAULTS, **{k: str(v) for k, v in data.items() if k != "WIDTH"}}
+    width = int(data.get("WIDTH", DEFAULTS["WIDTH"]))
+    name = p.stem if p.exists() else "default"
+    return Theme(name=name, palette=palette, width=width)


### PR DESCRIPTION
## Summary
- bootstrap runtime directories, world discovery, and minimal world creation
- map player start year to nearest world and auto-pick theme path
- document bootstrap/discovery and add human-readable architecture overview

## Testing
- `pytest -q`
- `PYTHONPATH=./src python -m mutants`


------
https://chatgpt.com/codex/tasks/task_e_68c21328e678832ba7e76d9d1314c948