### PR TITLE
Remove plus sign from compass coordinates

### DIFF
--- a/src/mutants/ui/formatters.py
+++ b/src/mutants/ui/formatters.py
@@ -31,8 +31,9 @@ def format_header(text: str) -> Segments:
 
 
 def format_compass(x: int, y: int) -> Segments:
-    east = f"{x:+d}E"
-    north = f"{y:+d}N"
+    # Display coordinates without '+' for non-negative values (match BBS logs)
+    east = f"{x}E"
+    north = f"{y}N"
     return [(COMPASS_LABEL, "Compass:"), ("", " "), (COORDS, f"({east} : {north})")]
 
 

--- a/tests/ui/test_renderer_examples.py
+++ b/tests/ui/test_renderer_examples.py
@@ -86,7 +86,7 @@ class RendererExamplesTest(unittest.TestCase):
         lines = renderer.token_debug_lines(EX_B)
         expected = [
             "<HEADER>The market square is littered with debris.</HEADER>",
-            "<COMPASS_LABEL>Compass:</COMPASS_LABEL> <COORDS>(+3E : +0N)</COORDS>",
+            "<COMPASS_LABEL>Compass:</COMPASS_LABEL> <COORDS>(3E : 0N)</COORDS>",
             "<DIR>north</DIR>  - <DESC_TERRAIN>terrain blocks the way.</DESC_TERRAIN>",
             "<DIR>south</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
             "<DIR>east</DIR>   - <DESC_GATE_CLOSED>closed gate.</DESC_GATE_CLOSED>",
@@ -107,7 +107,7 @@ class RendererExamplesTest(unittest.TestCase):
         lines = renderer.token_debug_lines(EX_C)
         expected = [
             "<HEADER>A cold draft flows through the alley.</HEADER>",
-            "<COMPASS_LABEL>Compass:</COMPASS_LABEL> <COORDS>(+0E : +5N)</COORDS>",
+            "<COMPASS_LABEL>Compass:</COMPASS_LABEL> <COORDS>(0E : 5N)</COORDS>",
             "<DIR>north</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
             "<DIR>south</DIR>  - <DESC_GATE_LOCKED>locked gate (key 4).</DESC_GATE_LOCKED>",
             "<DIR>east</DIR>   - <DESC_CONT>area continues.</DESC_CONT>",


### PR DESCRIPTION
## Summary
- show compass coordinates without a leading '+' for non-negative values
- update renderer example tests for new compass format

## Testing
- ⚠️ `git fetch origin` (no remote configured)
- ✅ `pytest -q tests/ui/test_renderer_examples.py`
- ✅ `pytest -q`
- ✅ `python - <<'PY'` (format_compass functional check)

------
https://chatgpt.com/codex/tasks/task_e_68c2c19eb7cc832ba0cb0223378bffe6