### PR TITLE
Fix direction list filter to show open exits

### DIFF
--- a/src/mutants/ui/renderer.py
+++ b/src/mutants/ui/renderer.py
@@ -44,11 +44,12 @@ def render_token_lines(
     coords = vm["coords"]
     lines.append(fmt.format_compass(coords["x"], coords["y"]))
 
-    # Show only "relevant" directions (non-open): gates/boundaries/terrain.
+    # Show only open/continuous directions (plain tiles): omit obstacles.
     dirs = vm.get("dirs", {})
     for d in c.DIR_ORDER:
         edge = dirs.get(d, {"base": 0})
-        if edge.get("base", 0) != 0:
+        # Plain/open edges have base == 0; blocked/gates/boundaries are non-zero.
+        if edge.get("base", 0) == 0:
             lines.append(fmt.format_direction_line(d, edge))
 
     lines.append([("", "***")])

--- a/tests/ui/test_renderer_examples.py
+++ b/tests/ui/test_renderer_examples.py
@@ -71,7 +71,9 @@ class RendererExamplesTest(unittest.TestCase):
         expected = [
             "<HEADER>Broken glass covers the road.</HEADER>",
             "<COMPASS_LABEL>Compass:</COMPASS_LABEL> <COORDS>(-1E : -2N)</COORDS>",
-            "<DIR>east</DIR>  - <DESC_GATE_OPEN>open gate.</DESC_GATE_OPEN>",
+            "<DIR>north</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
+            "<DIR>south</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
+            "<DIR>west</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
             "***",
             "<LABEL>On the ground lies:</LABEL>",
             "<ITEM>A Broken-Weapon.</ITEM>",
@@ -84,9 +86,7 @@ class RendererExamplesTest(unittest.TestCase):
         expected = [
             "<HEADER>The market square is littered with debris.</HEADER>",
             "<COMPASS_LABEL>Compass:</COMPASS_LABEL> <COORDS>(3E : 0N)</COORDS>",
-            "<DIR>north</DIR>  - <DESC_TERRAIN>terrain blocks the way.</DESC_TERRAIN>",
-            "<DIR>east</DIR>  - <DESC_GATE_CLOSED>closed gate.</DESC_GATE_CLOSED>",
-            "<DIR>west</DIR>  - <DESC_BOUNDARY>boundary.</DESC_BOUNDARY>",
+            "<DIR>south</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
             "***",
             "<MONSTER>Ghoul is here.</MONSTER>",
             "<MONSTER>Sasquatch-331 is here.</MONSTER>",
@@ -103,7 +103,9 @@ class RendererExamplesTest(unittest.TestCase):
         expected = [
             "<HEADER>A cold draft flows through the alley.</HEADER>",
             "<COMPASS_LABEL>Compass:</COMPASS_LABEL> <COORDS>(0E : 5N)</COORDS>",
-            "<DIR>south</DIR>  - <DESC_GATE_LOCKED>locked gate (key 4).</DESC_GATE_LOCKED>",
+            "<DIR>north</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
+            "<DIR>east</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
+            "<DIR>west</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
             "***",
             "<SHADOWS_LABEL>You see shadows to the west.</SHADOWS_LABEL>",
         ]


### PR DESCRIPTION
## Summary
- show only open directions in renderer instead of blocked edges
- update renderer example tests for open-exit filtering

## Testing
- `pytest`
- `timeout 5 python -m mutants | tee /tmp/mutants_run.txt`
- `grep -n "area continues" /tmp/mutants_run.txt`
- `grep -E "blocks the way\." /tmp/mutants_run.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c2d7478f3c832b89cc3820d5af5f9d