### PR TITLE
Lock navigation descriptors and separator

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -52,6 +52,14 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 * **Guardrail:** With `MUTANTS_DEV=1`, the renderer asserts if a non-open edge appears in `dirs_open`; otherwise it logs a warning and drops it. This prevents downstream refactors (formatting/color) from resurrecting blocked rows.
 * **Separation of concerns:** Movement failures should surface via feedback lines (e.g., “You’re blocked!”) rather than as direction rows.
 
+### Locked Literals and Descriptors
+* Canonical literals and descriptors live in `src/mutants/ui/uicontract.py`:
+  - `COMPASS_PREFIX = "Compass: "`
+  - `DIR_LINE_FMT = "{:<5} - {}"`
+  - `SEPARATOR_LINE = "***"`
+  - Direction descriptors (closed set): `area continues.`, `wall of ice.`, `ion force field.`, `open gate.`, `closed gate.`
+* The formatter normalizes open edges to `area continues.`; any future non-open wording must come from the same closed set.
+
 ## Feedback and logs (diagnostics)
 - `ui/feedback.py` — **Feedback Bus** (structured events):
   - `.push(kind, text, **meta)`; `.drain()`; `.subscribe(listener)`.

--- a/src/mutants/ui/renderer.py
+++ b/src/mutants/ui/renderer.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 
 from . import constants as c
 from . import formatters as fmt
+from . import uicontract as UC
 from . import styles as st
 from .viewmodels import RoomVM
 from .wrap import wrap_list
@@ -68,9 +69,11 @@ def render_token_lines(
             else:
                 logger.warning("ui: dropped non-open edge in dirs_open: %s", d)
             continue
-        lines.append(fmt.format_direction_line(d, edge))
+        lines.append(fmt.format_direction_segments(d, edge))
 
-    lines.append([("", "***")])
+    sep_line = [("", UC.SEPARATOR_LINE)]
+    if not lines or lines[-1] != sep_line:
+        lines.append(sep_line)
 
     # Monsters present
     monsters = vm.get("monsters_here", [])
@@ -150,7 +153,10 @@ def render(
             else:
                 logger.warning("ui: dropped non-open edge in dirs_open: %s", d)
             continue
-        lines.append(fmt.format_direction_line_colored(d, edge))
+        lines.append(fmt.format_direction_line(d, edge))
+
+    if not lines or lines[-1] != UC.SEPARATOR_LINE:
+        lines.append(UC.SEPARATOR_LINE)
 
     monsters = vm.get("monsters_here", [])
     for m in monsters:

--- a/src/mutants/ui/uicontract.py
+++ b/src/mutants/ui/uicontract.py
@@ -1,0 +1,36 @@
+# UI Contract constants for navigation frame and direction descriptors.
+#
+# We lock a finite vocabulary for direction descriptors to prevent regressions.
+# The renderer/formatters should only use these values (or drop/normalize).
+#
+COMPASS_PREFIX = "Compass: "
+DIR_LINE_FMT = "{:<5} - {}"
+SEPARATOR_LINE = "***"
+
+# Canonical direction descriptors (the full set used by the original game).
+DESC_AREA_CONTINUES = "area continues."
+DESC_WALL_OF_ICE = "wall of ice."
+DESC_ION_FORCE_FIELD = "ion force field."
+DESC_OPEN_GATE = "open gate."
+DESC_CLOSED_GATE = "closed gate."
+
+# Allowed set for validation / normalization.
+ALLOWED_DIR_DESCRIPTORS = {
+    DESC_AREA_CONTINUES,
+    DESC_WALL_OF_ICE,
+    DESC_ION_FORCE_FIELD,
+    DESC_OPEN_GATE,
+    DESC_CLOSED_GATE,
+}
+
+__all__ = [
+    "COMPASS_PREFIX",
+    "DIR_LINE_FMT",
+    "SEPARATOR_LINE",
+    "DESC_AREA_CONTINUES",
+    "DESC_WALL_OF_ICE",
+    "DESC_ION_FORCE_FIELD",
+    "DESC_OPEN_GATE",
+    "DESC_CLOSED_GATE",
+    "ALLOWED_DIR_DESCRIPTORS",
+]


### PR DESCRIPTION
## Summary
- introduce `uicontract` constants to lock navigation vocabulary
- normalize open direction lines and always emit single separator
- document locked navigation frame and descriptors

## Testing
- `pytest`
- `python -m mutants <<'EOF' | tee /tmp/nav_frame.txt
look
w
look
EOF`
- `grep -E "blocks the way\." /tmp/nav_frame.txt`
- `grep -E " - area continues\." /tmp/nav_frame.txt | head -n 5`
- `grep -nE '^\*\*\*$' /tmp/nav_frame.txt`
- `awk 'prev=="***" && $0=="***"{exit 1}{prev=$0} END{if (NR>0) exit 0}' /tmp/nav_frame.txt && echo "No double separators detected"`

------
https://chatgpt.com/codex/tasks/task_e_68c311ab8ea4832b9449d29548735536