### PR TITLE
feat(ui): add ground block rendering

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -52,6 +52,12 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 * **Guardrail:** With `MUTANTS_DEV=1`, the renderer asserts if a non-open edge appears in `dirs_open`; otherwise it logs a warning and drops it. This prevents downstream refactors (formatting/color) from resurrecting blocked rows.
 * **Separation of concerns:** Movement failures should surface via feedback lines (e.g., “You’re blocked!”) rather than as direction rows.
 
+### UI Contract: Ground Block
+* **Trigger:** VM sets `has_ground=True` and provides non-empty `ground_items: List[str]`.
+* **Rendering:** Renderer prints one fixed header `On the ground lies:` followed by a comma-separated list of items, wrapped to **80 columns**, with a trailing period. See `uicontract.py` constants: `GROUND_HEADER`, `UI_WRAP_WIDTH`.
+* **Separators:** Exactly one `***` before and one `***` after the ground block. The post-direction separator is reused if already present.
+* **Guardrail:** If `has_ground=True` but `ground_items` is empty, the renderer asserts under `MUTANTS_DEV=1` or logs-and-drops in normal runs.
+
 ### Locked Literals and Descriptors
 * Canonical literals and descriptors live in `src/mutants/ui/uicontract.py`:
   - `COMPASS_PREFIX = "Compass: "`

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -44,6 +44,13 @@ We lock the navigation frame now to prevent regressions:
 - A single separator line `***` is emitted **once** after the directions block (no doubles).
 - Compass uses the canonical prefix **`Compass: `** (no plus signs on non-negative values).
 
+### Ground Block (locked behavior)
+When the VM indicates items are present on the ground, the renderer prints a **Ground block**:
+- Header literal: **`On the ground lies:`** (see `uicontract.py`).
+- A comma-separated list of items, wrapped to **80 columns**, ending with a period.
+- The block is surrounded by single `***` separators: one before (after directions) and one after.
+The VM must set `has_ground=True` **only** when `ground_items` is non-empty; otherwise the renderer drops the block and warns (or asserts in dev).
+
 ## Future-proofing choices
 - No hard-coded year: world **discovery** + **nearest year** when needed.
 - Themes are JSON so you can change colors without code.

--- a/src/mutants/ui/formatters.py
+++ b/src/mutants/ui/formatters.py
@@ -100,6 +100,7 @@ def format_shadows(dirs: List[str]) -> Segments | None:
 # --- Group-aware string formatters ---------------------------------------
 from . import groups as UG
 from . import styles as st
+import textwrap
 
 
 def format_compass_line(vm) -> str:
@@ -119,6 +120,23 @@ def format_direction_line(dir_key: str, edge: dict) -> str:
         desc = edge.get("desc", "")
         group = UG.DIR_BLOCKED
     return st.colorize_text(UC.DIR_LINE_FMT.format(word, desc), group=group)
+
+
+def format_ground_header() -> str:
+    """Fixed header for the ground block."""
+    return st.colorize_text(UC.GROUND_HEADER, group=UG.HEADER)
+
+
+def format_ground_list(items: list) -> list:
+    """
+    Comma-separated item list, wrapped to 80 cols, ends with a period.
+    Returns a list of lines (already wrapped).
+    """
+    line = ", ".join(str(x).strip() for x in items if str(x).strip())
+    if line and not line.endswith("."):
+        line += "."
+    wrapped = textwrap.fill(line, width=UC.UI_WRAP_WIDTH)
+    return wrapped.splitlines() if wrapped else []
 
 
 def format_room_title(title: str) -> str:

--- a/src/mutants/ui/renderer.py
+++ b/src/mutants/ui/renderer.py
@@ -158,15 +158,29 @@ def render(
     if not lines or lines[-1] != UC.SEPARATOR_LINE:
         lines.append(UC.SEPARATOR_LINE)
 
+    # ---- Ground Block (optional) ----
+    has_ground = bool(vm.get("has_ground", False))
+    ground_items = vm.get("ground_items") or []
+    if has_ground:
+        if not ground_items:
+            if DEV:
+                assert False, "ui: has_ground=True but ground_items is empty"
+            else:
+                logger.warning(
+                    "ui: dropping empty ground block (has_ground=True, no items)"
+                )
+        else:
+            if not lines or lines[-1] != UC.SEPARATOR_LINE:
+                lines.append(UC.SEPARATOR_LINE)
+            lines.append(fmt.format_ground_header())
+            for ln in fmt.format_ground_list(ground_items):
+                lines.append(ln)
+            lines.append(UC.SEPARATOR_LINE)
+
     monsters = vm.get("monsters_here", [])
     for m in monsters:
         name = m.get("name", "?")
         lines.append(f"{name} is here.")
-
-    items = vm.get("ground_items", [])
-    for it in items:
-        name = it.get("name", "?")
-        lines.append(f"A {name}.")
 
     events = vm.get("events", [])
     lines.extend(events)

--- a/src/mutants/ui/uicontract.py
+++ b/src/mutants/ui/uicontract.py
@@ -7,6 +7,10 @@ COMPASS_PREFIX = "Compass: "
 DIR_LINE_FMT = "{:<5} - {}"
 SEPARATOR_LINE = "***"
 
+# Ground block (header + list) and layout width
+GROUND_HEADER = "On the ground lies:"
+UI_WRAP_WIDTH = 80
+
 # Canonical direction descriptors (the full set used by the original game).
 DESC_AREA_CONTINUES = "area continues."
 DESC_WALL_OF_ICE = "wall of ice."
@@ -27,6 +31,8 @@ __all__ = [
     "COMPASS_PREFIX",
     "DIR_LINE_FMT",
     "SEPARATOR_LINE",
+    "GROUND_HEADER",
+    "UI_WRAP_WIDTH",
     "DESC_AREA_CONTINUES",
     "DESC_WALL_OF_ICE",
     "DESC_ION_FORCE_FIELD",


### PR DESCRIPTION
## Summary
- render ground items in a dedicated block with 80-col wrapped list
- expose `GROUND_HEADER` and `UI_WRAP_WIDTH` as UI contract constants
- document ground block behavior and guardrails in architecture docs

## Testing
- `pytest`
- `python -m mutants <<'EOF'
look
EOF`
- `export MUTANTS_DEV=1 && python -m mutants <<'EOF'
look
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68c3149a12a8832b8b977ab075db845b