### PR TITLE
feat(ui): render monsters and cues after ground

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -58,6 +58,14 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 * **Separators:** Exactly one `***` before and one `***` after the ground block. The post-direction separator is reused if already present.
 * **Guardrail:** If `has_ground=True` but `ground_items` is empty, the renderer asserts under `MUTANTS_DEV=1` or logs-and-drops in normal runs.
 
+### UI Contract: Monsters & Cues
+* **Monsters:** If `vm["monsters_here"]` is non-empty, render:
+  - 1 name → `"<Name> is here."`
+  - 2+ names → `"<A>, <B>, and <C> are here with you."` (serial-comma style)
+  Precede with a single `***` and append a single `***` after.
+* **Cues:** If `vm["cues_lines"]` has entries, print each string as a line; insert a single `***` **between** cue lines (not after the last). The UI does not synthesize wording—strings come from the VM.
+* **Placement:** This block appears **after** the Ground block and adheres to the single-separator rule to avoid doubles, matching the originals. 
+
 ### Locked Literals and Descriptors
 * Canonical literals and descriptors live in `src/mutants/ui/uicontract.py`:
   - `COMPASS_PREFIX = "Compass: "`

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -51,6 +51,14 @@ When the VM indicates items are present on the ground, the renderer prints a **G
 - The block is surrounded by single `***` separators: one before (after directions) and one after.
 The VM must set `has_ground=True` **only** when `ground_items` is non-empty; otherwise the renderer drops the block and warns (or asserts in dev).
 
+### Monsters & Cues (after Ground)
+- **Monsters present:** a single line is emitted:
+  - One monster: `"<Name> is here."`
+  - Multiple monsters: `"<A>, <B>, and <C> are here with you."` (comma before `and`)
+  A single `***` separator precedes this block and another follows it.
+- **Cues:** each cue (e.g., `You see shadows to the south.`) prints as a single line; a `***` separator appears **between** multiple cue lines. The VM supplies `cues_lines` already worded; the UI does not invent text.
+Placement is fixed: **Room → Compass → Directions → `***` → Ground (optional) → `***` → Monsters (optional) → `***` → Cues (optional)**. This matches the original captures’ section order. 
+
 ## Future-proofing choices
 - No hard-coded year: world **discovery** + **nearest year** when needed.
 - Themes are JSON so you can change colors without code.

--- a/src/mutants/ui/formatters.py
+++ b/src/mutants/ui/formatters.py
@@ -71,7 +71,7 @@ def format_direction_segments(dir_name: str, edge: EdgeDesc) -> Segments:
     return segments
 
 
-def format_monsters_here(monsters: List[Thing]) -> List[Segments]:
+def format_monsters_here_tokens(monsters: List[Thing]) -> List[Segments]:
     lines: List[Segments] = []
     for m in monsters:
         lines.append([(MONSTER, f"{m['name']} is here.")])
@@ -137,6 +137,40 @@ def format_ground_list(items: list) -> list:
         line += "."
     wrapped = textwrap.fill(line, width=UC.UI_WRAP_WIDTH)
     return wrapped.splitlines() if wrapped else []
+
+
+def format_monsters_here(names: list[str]) -> str:
+    """
+    Monsters presence line(s):
+      - 1 name: "<Name> is here."
+      - 2+ names: "A, B, and C are here with you." (always include comma before 'and')
+    """
+    clean = []
+    for n in names:
+        if isinstance(n, dict):
+            n = n.get("name", "")
+        s = str(n).strip()
+        if s:
+            clean.append(s)
+    if not clean:
+        return ""
+    if len(clean) == 1:
+        text = f"{clean[0]} is here."
+    elif len(clean) == 2:
+        text = f"{clean[0]}, and {clean[1]} are here with you."
+    else:
+        text = f"{', '.join(clean[:-1])}, and {clean[-1]} are here with you."
+    return st.colorize_text(text, group=UG.FEEDBACK_INFO)
+
+
+def format_cue_line(text: str) -> str:
+    """
+    Print a single cue line verbatim (caller handles separator placement).
+    Examples from originals include:
+      - "You see shadows to the south."
+      - "You hear loud sounds of yelling and screaming to the west."
+    """
+    return st.colorize_text(str(text).rstrip(), group=UG.FEEDBACK_INFO)
 
 
 def format_room_title(title: str) -> str:

--- a/src/mutants/ui/renderer.py
+++ b/src/mutants/ui/renderer.py
@@ -77,7 +77,7 @@ def render_token_lines(
 
     # Monsters present
     monsters = vm.get("monsters_here", [])
-    for segs in fmt.format_monsters_here(monsters):
+    for segs in fmt.format_monsters_here_tokens(monsters):
         lines.append(segs)
 
     items = vm.get("ground_items", [])
@@ -177,22 +177,25 @@ def render(
                 lines.append(ln)
             lines.append(UC.SEPARATOR_LINE)
 
-    monsters = vm.get("monsters_here", [])
-    for m in monsters:
-        name = m.get("name", "?")
-        lines.append(f"{name} is here.")
+    # ---- Monsters block (optional, after Ground) ----
+    monsters = vm.get("monsters_here") or []
+    if monsters:
+        if not lines or lines[-1] != UC.SEPARATOR_LINE:
+            lines.append(UC.SEPARATOR_LINE)
+        mline = fmt.format_monsters_here(monsters)
+        if mline:
+            lines.append(mline)
+            lines.append(UC.SEPARATOR_LINE)
 
-    events = vm.get("events", [])
-    lines.extend(events)
-
-    shadows = vm.get("shadows", [])
-    if shadows:
-        dirs_words = []
-        for d in ["E", "S", "W", "N"]:
-            if d in shadows:
-                dirs_words.append(fmt._dir_word(d))  # type: ignore[attr-defined]
-        if dirs_words:
-            lines.append(f"You see shadows to the {', '.join(dirs_words)}.")
+    # ---- Cues block (optional, after Monsters) ----
+    cues = vm.get("cues_lines") or []
+    if cues:
+        if not lines or lines[-1] != UC.SEPARATOR_LINE:
+            lines.append(UC.SEPARATOR_LINE)
+        for idx, cue in enumerate(cues):
+            lines.append(fmt.format_cue_line(cue))
+            if idx < len(cues) - 1 and lines[-1] != UC.SEPARATOR_LINE:
+                lines.append(UC.SEPARATOR_LINE)
 
     if feedback_events:
         for ev in feedback_events:

--- a/state/playerlivestate.json
+++ b/state/playerlivestate.json
@@ -1,1 +1,215 @@
-
+{
+  "players": [
+    {
+      "id": "player_thief",
+      "name": "Thief",
+      "class": "Thief",
+      "is_active": true,
+      "pos": [
+        2000,
+        0,
+        0
+      ],
+      "stats": {
+        "str": 15,
+        "int": 9,
+        "wis": 8,
+        "dex": 14,
+        "con": 15,
+        "cha": 16
+      },
+      "hp": {
+        "current": 18,
+        "max": 18
+      },
+      "exhaustion": 0,
+      "exp_points": 0,
+      "level": 1,
+      "riblets": 0,
+      "ions": 30000,
+      "armour": {
+        "wearing": null,
+        "armour_class": 1
+      },
+      "readied_spell": null,
+      "target_monster_id": null,
+      "inventory": [],
+      "carried_weight": 0,
+      "conditions": {
+        "poisoned": false,
+        "encumbered": false,
+        "ion_starving": false
+      },
+      "notes": ""
+    },
+    {
+      "id": "player_priest",
+      "name": "Priest",
+      "class": "Priest",
+      "is_active": false,
+      "pos": [
+        2000,
+        0,
+        0
+      ],
+      "stats": {
+        "str": 20,
+        "int": 12,
+        "wis": 13,
+        "dex": 17,
+        "con": 17,
+        "cha": 14
+      },
+      "hp": {
+        "current": 30,
+        "max": 30
+      },
+      "exhaustion": 0,
+      "exp_points": 0,
+      "level": 1,
+      "riblets": 0,
+      "ions": 30000,
+      "armour": {
+        "wearing": null,
+        "armour_class": 1
+      },
+      "readied_spell": null,
+      "target_monster_id": null,
+      "inventory": [],
+      "carried_weight": 0,
+      "conditions": {
+        "poisoned": false,
+        "encumbered": false,
+        "ion_starving": false
+      },
+      "notes": ""
+    },
+    {
+      "id": "player_wizard",
+      "name": "Wizard",
+      "class": "Wizard",
+      "is_active": false,
+      "pos": [
+        2000,
+        0,
+        0
+      ],
+      "stats": {
+        "str": 14,
+        "int": 17,
+        "wis": 17,
+        "dex": 13,
+        "con": 14,
+        "cha": 15
+      },
+      "hp": {
+        "current": 23,
+        "max": 23
+      },
+      "exhaustion": 0,
+      "exp_points": 0,
+      "level": 1,
+      "riblets": 0,
+      "ions": 30000,
+      "armour": {
+        "wearing": null,
+        "armour_class": 1
+      },
+      "readied_spell": null,
+      "target_monster_id": null,
+      "inventory": [],
+      "carried_weight": 0,
+      "conditions": {
+        "poisoned": false,
+        "encumbered": false,
+        "ion_starving": false
+      },
+      "notes": ""
+    },
+    {
+      "id": "player_warrior",
+      "name": "Warrior",
+      "class": "Warrior",
+      "is_active": false,
+      "pos": [
+        2000,
+        0,
+        0
+      ],
+      "stats": {
+        "str": 23,
+        "int": 12,
+        "wis": 14,
+        "dex": 20,
+        "con": 19,
+        "cha": 9
+      },
+      "hp": {
+        "current": 40,
+        "max": 40
+      },
+      "exhaustion": 0,
+      "exp_points": 0,
+      "level": 1,
+      "riblets": 0,
+      "ions": 30000,
+      "armour": {
+        "wearing": null,
+        "armour_class": 2
+      },
+      "readied_spell": null,
+      "target_monster_id": null,
+      "inventory": [],
+      "carried_weight": 0,
+      "conditions": {
+        "poisoned": false,
+        "encumbered": false,
+        "ion_starving": false
+      },
+      "notes": ""
+    },
+    {
+      "id": "player_mage",
+      "name": "Mage",
+      "class": "Mage",
+      "is_active": false,
+      "pos": [
+        2000,
+        0,
+        0
+      ],
+      "stats": {
+        "str": 18,
+        "int": 23,
+        "wis": 20,
+        "dex": 16,
+        "con": 15,
+        "cha": 20
+      },
+      "hp": {
+        "current": 28,
+        "max": 28
+      },
+      "exhaustion": 0,
+      "exp_points": 0,
+      "level": 1,
+      "riblets": 0,
+      "ions": 30000,
+      "armour": {
+        "wearing": null,
+        "armour_class": 1
+      },
+      "readied_spell": null,
+      "target_monster_id": null,
+      "inventory": [],
+      "carried_weight": 0,
+      "conditions": {
+        "poisoned": false,
+        "encumbered": false,
+        "ion_starving": false
+      },
+      "notes": ""
+    }
+  ],
+  "active_id": "player_thief"
+}


### PR DESCRIPTION
## Summary
- format monster presence lines and cue lines
- render monsters and cues blocks after ground with single separators
- document new Monsters & Cues UI contract

## Testing
- `pytest`
- `python -m mutants <<'EOF' | tee /tmp/monsters_cues.txt
look
EOF`
- `grep -E " is here\.| are here with you\." /tmp/monsters_cues.txt || true`
- `grep -E "^You see shadows to the " /tmp/monsters_cues.txt || true`
- `awk 'prev=="***" && $0=="***"{print "DOUBLE @ line " NR; exit 1}{prev=$0} END{if (NR>0) exit 0}' /tmp/monsters_cues.txt && echo "No double separators detected"`


------
https://chatgpt.com/codex/tasks/task_e_68c31b977268832ba8d37fb32728e9cc