### PR TITLE
Implement daily litter spawn system with docs

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -101,6 +101,16 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 - `registries/world.list_years()` reports available years; `load_nearest_year(y)` picks the closest.
 - `bootstrap/lazyinit.ensure_player_state()` maps template `start_pos[0]` to the **nearest** existing year, so templates can always say `2000` without going stale.
 - All modules read `player.pos[0]` at runtime; no code assumes `2000`.
+ 
+## Daily Litter Spawn System
+* **Inputs**: `state/items/catalog.json` (items with `"spawnable": true` and optional `"spawn": {"weight": int, "cap_per_year": int}`) and `state/items/spawn_rules.json` (`daily_target_per_year`, `max_ground_per_tile`).
+* **Algorithm** (per day):
+  1. Remove instances where `origin == "daily_litter"`.
+  2. For each year, build a weighted pool of spawnable items that have not hit `cap_per_year` (counts include existing ground items).
+  3. Choose random open tiles; skip any tile already at capacity (default six items) and place until the daily target is met.
+  4. Save instances, record today in `state/runtime/spawn_epoch.json`, log a summary line.
+* **Determinism**: RNG seeded by `YYYY-MM-DD` keeps placement stable within the day.
+* **Safety**: runs once at bootstrap; missing files/worlds merely log and skip.
 
 ## IO helpers
 - `io/atomic.py` — `atomic_write_json()` and `read_json()` (tmp → fsync → replace).
@@ -112,6 +122,7 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 - `state/playerlivestate.json`
 - `state/ui/themes/bbs.json`, `state/ui/themes/mono.json`
 - `state/logs/game.log`
+- `state/runtime/spawn_epoch.json`
 
 ## Flow examples
 - **look** → dispatch → render_room: VM from context → renderer prints.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -65,6 +65,13 @@ The VM must set `has_ground=True` **only** when `ground_items` is non-empty; oth
 - **Cues:** each cue (e.g., `You see shadows to the south.`) prints as a single line; a `***` separator appears **between** multiple cue lines. The VM supplies `cues_lines` already worded; the UI does not invent text.
 Placement is fixed: **Room → Compass → Directions → `***` → Ground (optional) → `***` → Monsters (optional) → `***` → Cues (optional)**. This matches the original captures’ section order. 
 
+## Daily Litter Spawns (once-per-day reset)
+At startup (once per calendar day), the game performs a **litter reset**:
+- Removes only items previously spawned by the system (`origin: "daily_litter"`).
+- Spawns a fixed number per year (`state/items/spawn_rules.json: daily_target_per_year`) of catalog items marked `"spawnable": true`, using per-item weights and optional per-year caps.
+- Placement rules: open tiles only and never more than six items per tile; capped items (already at limit for a year) are skipped.
+- The reset is deterministic for the day (seeded by date) and runs only at startup, so no mid-day pop-in.
+
 ## Future-proofing choices
 - No hard-coded year: world **discovery** + **nearest year** when needed.
 - Themes are JSON so you can change colors without code.

--- a/docs/daily_litter_spawns.md
+++ b/docs/daily_litter_spawns.md
@@ -1,0 +1,77 @@
+# Daily Litter Spawns — How it Works & How to Tune It
+
+This system recreates the old BBS “daily reset”: once per calendar day (on startup), it **removes yesterday’s litter** and **spawns new items** on the ground. Nothing pops in mid-day.
+
+## What Spawns (and How Often)
+
+- **Spawnable items** are defined in `state/items/catalog.json` by adding `"spawnable": true` on the catalog entry.
+- Optional spawn tuning per item (inside the same catalog entry):
+  ```json
+  {
+    "spawnable": true,
+    "spawn": { "weight": 12, "cap_per_year": 40 }
+  }
+  ```
+  `weight` (default 1) is the relative likelihood versus other spawnables.
+  `cap_per_year` (optional) is a hard limit per year on how many of this item can exist on the ground after reset. If players’ items already exceed the cap, no new copies spawn that day for that year.
+
+## Global Spawn Rules
+
+`state/items/spawn_rules.json`:
+
+```json
+{
+  "daily_target_per_year": 120,
+  "max_ground_per_tile": 6
+}
+```
+
+- `daily_target_per_year`: total items to place per year each day (spread across spawnable items by weight).
+- `max_ground_per_tile`: maximum items allowed on a single tile; the spawner never exceeds this, picking another tile if necessary.
+- Years are treated equally; we do not vary by year.
+
+## Placement Rules
+
+- **Open tiles only:** the spawner selects from open tiles reported by the world registry; blocked tiles are ignored.
+- **Ground capacity respected:** the spawner keeps a per-tile counter and skips any tile at capacity; it will not place the 7th item.
+- **Multiple spawnables may land on the same tile** if space remains; there is no one-item-per-tile restriction.
+
+## Reset Timing (No Mid-Day Pop-In)
+
+On the first startup each calendar day, the spawner runs:
+
+1. Remove yesterday’s litter only (instances with `origin: "daily_litter"`), leaving player drops intact.
+2. Spawn up to `daily_target_per_year` items per year using weights & caps.
+3. Save instances and record the date in `state/runtime/spawn_epoch.json`.
+4. Subsequent restarts that same day do nothing (idempotent).
+
+The RNG seed is the `YYYY-MM-DD` date string, so placement is deterministic for the day.
+
+## How to Adjust
+
+**Make an item spawnable / adjust prevalence**
+
+Edit `state/items/catalog.json` on the item's entry:
+
+- Add `"spawnable": true` to include it.
+- Add `"spawn": {"weight": 8}` to make it more common (lower weight → rarer).
+- Add `"spawn": {"cap_per_year": 25}` to limit how many can exist per year after reset.
+
+**Change the daily volume or tile capacity**
+
+Edit `state/items/spawn_rules.json`:
+
+- Increase/decrease `daily_target_per_year` to change total items per year.
+- Adjust `max_ground_per_tile` if ground capacity limits change.
+
+## Safety & Guarantees
+
+- The spawner never exceeds 6 items per tile; it checks capacity before adding an instance.
+- If an item already meets its `cap_per_year` from player drops, no more are spawned.
+- Only instances tagged with `origin: "daily_litter"` are removed during reset; all other items remain.
+- Missing files or worlds cause a skip with a log warning, but do not block startup.
+
+## Troubleshooting
+
+- **“No litter spawned today”**: ensure `catalog.json` entries have `"spawnable": true` and `daily_target_per_year > 0`; confirm `spawn_epoch.json` reflects today’s date.
+- **“Too many of one item”**: lower its `weight` and/or set a `cap_per_year`.

--- a/src/mutants/bootstrap/runtime.py
+++ b/src/mutants/bootstrap/runtime.py
@@ -3,6 +3,8 @@ import json, re
 from pathlib import Path
 from typing import Dict, List, Optional, Iterable
 from mutants.io.atomic import atomic_write_json
+from . import daily_litter
+import logging
 
 STATE = Path("state")
 WORLD_DIR = STATE / "world"
@@ -32,6 +34,12 @@ def ensure_runtime() -> Dict:
         size = int(cfg.get("default_world_size", 30))
         create_minimal_world(year=year, size=size)
         years = [year]
+
+    try:
+        daily_litter.run_daily_litter_reset()
+    except Exception as e:
+        logging.getLogger(__name__).warning("daily_litter skipped: %s", e)
+
     return {"config": cfg, "years": sorted(years), "themes_created": created_themes}
 
 def discover_world_years() -> List[int]:

--- a/state/items/spawn_rules.json
+++ b/state/items/spawn_rules.json
@@ -1,0 +1,4 @@
+{
+  "daily_target_per_year": 120,
+  "max_ground_per_tile": 6
+}


### PR DESCRIPTION
## Summary
- add weighted daily litter spawner with per-item yearly caps and per-tile limits
- run litter reset once per day at bootstrap via runtime.ensure_runtime
- document daily litter system and configuration

## Testing
- `python -m mutants <<'EOF'
look
EOF`
- `jq -r '.last_reset' state/runtime/spawn_epoch.json`
- `python - <<'PY'
import json,os
p="state/items/instances.json"
data=json.load(open(p)) if os.path.exists(p) else []
if isinstance(data,dict) and "instances" in data: data=data["instances"]
cnt=sum(1 for i in data if i.get("origin")=="daily_litter")
print("daily_litter instances:", cnt)
PY`
- `python - <<'PY'
import json,os,collections
p="state/items/instances.json"
data=json.load(open(p)) if os.path.exists(p) else []
if isinstance(data,dict) and "instances" in data: data=data["instances"]
counts=collections.Counter()
bad=[]
for i in data:
    pos=i.get("pos") if isinstance(i.get("pos"),dict) else None
    year=i.get("year") if i.get("year") is not None else (pos or {}).get("year")
    x=i.get("x") if i.get("x") is not None else (pos or {}).get("x")
    y=i.get("y") if i.get("y") is not None else (pos or {}).get("y")
    if year is None or x is None or y is None:
        continue
    counts[(year,x,y)]+=1
for k,v in counts.items():
    if v>6:
        bad.append((k,v))
print("tiles_over_capacity:", bad if bad else "none")
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c329b1d720832b8351af1f251de7ac