### PR TITLE
Resolve passability using two-sided edges and richer move tracing

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -84,7 +84,8 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 
 ## Passability & Dynamic Overlays
 * **Resolver**: `engine/edge_resolver.py` is the canonical decision point (`resolve(world, dynamics, year,x,y,dir, actor)` → `EdgeDecision`), used by movement and future UI.
-* **Layers** (priority high→low): actor modifiers → dynamic overlays → gates/locks → base terrain.
+* **Two-sided composition**: the resolver reads **both** the current tile’s edge and the **neighbor tile’s opposite edge** (OOB/missing ⇒ boundary). A move is allowed **only if both sides permit** (or an open gate exists and neither side blocks).
+* **Layers** (priority high→low): actor modifiers → dynamic overlays → gates/locks → base terrain. Base values may be **strings** or **numbers**; unknown/missing defaults to **boundary/blocked**.
 * **Descriptors**: normalized to the closed set `{area continues., wall of ice., ion force field., open gate., closed gate.}`.
 * **Dynamic registry**: `registries/dynamics.py` stores per-edge overlays in `state/world/dynamics.json` with TTL; spells/rods write here, resolver reads it.
 

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -36,9 +36,11 @@ def move(dir_code: str, ctx: Dict[str, Any]) -> None:
             "dir": dir_code.upper(),
             "passable": dec.passable,
             "desc": dec.descriptor,
+            "cur": {"base": dec.cur_raw.get("base"), "gate_state": dec.cur_raw.get("gate_state")},
+            "nbr": {"base": dec.nbr_raw.get("base"), "gate_state": dec.nbr_raw.get("gate_state")},
             "why": dec.reason_chain,
         }
-        logger.info("MOVE/DECISION %s", json.dumps(payload))
+        logger.info("MOVE/DECISION - %s", json.dumps(payload))
         sink = ctx.get("logsink")
         if sink is not None and hasattr(sink, "handle"):
             sink.handle({"ts": "", "kind": "MOVE/DECISION", "text": json.dumps(payload)})


### PR DESCRIPTION
## Summary
- Compose passability from both the current and neighboring tile edges, treating missing or unknown bases as blocked
- Normalize string and numeric edge bases conservatively and capture raw edge snapshots in decisions
- Expand MOVE/DECISION logging to show current and neighbor edge snapshots
- Document two-sided resolver behavior and mixed-schema base handling

## Testing
- ✅ `python -m pytest`
- ✅ `python -m mutants <<'EOF' | tee /tmp/passability.txt
logs trace move on
look
why n
n
why s
s
why e
e
logs tail 50
logs trace move off
EOF`
- ✅ `grep -E 'MOVE/DECISION' state/logs/game.log | tail -n 5`
- ✅ `grep -E 'MOVE/DECISION' state/logs/game.log | grep -Ev '"desc": "(area continues\.|wall of ice\.|ion force field\.|open gate\.|closed gate\.)"' && echo "BAD DESC FOUND" || echo "Descriptors canonical"`
- ✅ `grep -E 'SYSTEM/OK - .*: wall of ice\.' /tmp/passability.txt | grep -qi 'base=terrain' && echo "Mismatch still present" || echo "No terrain→ice mismatch detected"`


------
https://chatgpt.com/codex/tasks/task_e_68c3506fa93c832bae796c5d0f450cee