### PR TITLE
Ensure separators only between non-empty blocks

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -39,9 +39,7 @@
 - **Color Groups**: every formatted text fragment can declare a `group` (dotted string). `styles.resolve_color_for_group(group)` looks up `state/ui/colors.json` with fallback: exact → `prefix.*` → `defaults` → `"white"`. Existing color-by-name calls still work via `styles.colorize_text`.
 - **Themes**: `ui/themes.py` — loads JSON `state/ui/themes/<name>.json` → `Theme { palette, width }` (no code changes needed to tweak colors).
 - **Wrap**: `ui/wrap.py` — ANSI-aware 80-col wrapping (only list sections wrap).
-- **Renderer**: `ui/renderer.py` — orchestrates lines in fixed order:
-  Header → Compass → N/S/E/W → `***` → in-room (monsters, ground wrapped) → `***` + feedback lines (if any).
-  Renderer uses `Theme.palette` + `Theme.width`.
+- **Renderer**: `ui/renderer.py` — builds ordered blocks then joins them with a single `***` **between** blocks only (no leading/trailing or double separators).  Blocks: core (room/compass/directions), ground, monsters, cues. Renderer uses `Theme.palette` + `Theme.width`.
 
 ### Data Flow (UI)
 VM → Formatters (build strings + **group**) → Styles (resolve color by group) → Renderer (layout/output)
@@ -92,6 +90,7 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 
 #### Verification Tooling
 * **Edge sampler**: `logs verify edges [count]` samples random open tiles (current year) and checks resolver symmetry (**cur→dir** vs **neighbor→opp**). Mismatches are logged as `VERIFY/EDGE` warnings in `state/logs/game.log`, and a summary is shown in the feedback area.
+* **Separator joiner**: `logs verify separators` runs synthetic scenarios to ensure the renderer never emits leading/trailing or consecutive `***` lines. Failures log `VERIFY/SEPARATORS` warnings.
 
 ## Tracing & WHY
 * **Toggles**: `state/runtime/trace.json` stores `{"move":bool,"ui":bool}` toggled via `logs trace move on|off`.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -47,7 +47,7 @@ The `theme` command now switches two visual aspects at runtime:
 We lock the navigation frame now to prevent regressions:
 - **Direction descriptors** are a closed set of five strings: `area continues.`, `wall of ice.`, `ion force field.`, `open gate.`, `closed gate.`; see `src/mutants/ui/uicontract.py`.
 - **Rendered direction lines** are currently **open-only** (plain tiles) and use the exact format `"{dir:<5} - {desc}"` with two spaces before the dash. The open descriptor is always **`area continues.`**.
-- A single separator line `***` is emitted **once** after the directions block (no doubles).
+- The separator line `***` is inserted only **between** non-empty blocks; never at the start or end of a frame.
 - Compass uses the canonical prefix **`Compass: `** (no plus signs on non-negative values).
 
 ### Ground Block (locked behavior)
@@ -63,7 +63,13 @@ The VM must set `has_ground=True` **only** when `ground_items` is non-empty; oth
   - Multiple monsters: `"<A>, <B>, and <C> are here with you."` (comma before `and`)
   A single `***` separator precedes this block and another follows it.
 - **Cues:** each cue (e.g., `You see shadows to the south.`) prints as a single line; a `***` separator appears **between** multiple cue lines. The VM supplies `cues_lines` already worded; the UI does not invent text.
-Placement is fixed: **Room → Compass → Directions → `***` → Ground (optional) → `***` → Monsters (optional) → `***` → Cues (optional)**. This matches the original captures’ section order. 
+Placement is fixed: **Room → Compass → Directions → `***` → Ground (optional) → `***` → Monsters (optional) → `***` → Cues (optional)**. This matches the original captures’ section order.
+
+### Separators (hard rule)
+- The separator line `***` appears **only between** non-empty blocks, never at the start or end of a frame.
+- Blocks are: **(A)** Room+Compass+Directions, **(B)** Ground (if any), **(C)** Monsters (if any), **(D)** Cues (if any).  
+  The renderer first builds these blocks, then **joins** them with a single separator between adjacent blocks.  
+  Inside the **Cues** block, separators appear **between** multiple cue lines, not after the last.
 
 ## Daily Litter Spawns (once-per-day reset)
 At startup (once per calendar day), the game performs a **litter reset**:

--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -39,6 +39,14 @@ logs verify edges 200 # sample more tiles
 
 This samples random open tiles in your current year and checks the resolver’s two-sided decision (cur→dir vs neighbor→opp). It logs any mismatches to state/logs/game.log as VERIFY/EDGE lines and prints a short summary in-game.
 
+- Verify separator rules (no trailing/leading, no doubles):
+
+```
+logs verify separators
+```
+
+This runs several scenarios through the renderer’s block joiner. If issues are found, they are logged as VERIFY/SEPARATORS - ... in state/logs/game.log, and a warning is shown in-game.
+
 ## What Tracing Logs
 
 When `move` tracing is on, each attempt adds a single line to `state/logs/game.log`, e.g.:

--- a/src/mutants/commands/logs.py
+++ b/src/mutants/commands/logs.py
@@ -5,6 +5,7 @@ from typing import List
 from mutants.app import trace as traceflags
 from mutants.engine import edge_resolver as ER
 from mutants.registries import dynamics as dyn
+from mutants.ui import renderer as uirender
 import random
 import logging
 
@@ -29,6 +30,20 @@ def log_cmd(arg: str, ctx) -> None:
         traceflags.set_flag(name, on)
         state = "enabled" if on else "disabled"
         ctx["feedback_bus"].push("SYSTEM/OK", f"Trace {name} {state}.")
+        return
+    if len(parts) >= 2 and parts[0] == "verify" and parts[1] == "separators":
+        ok, failures = uirender.verify_separators_scenarios()
+        if failures:
+            for f in failures:
+                logging.getLogger(__name__).warning("VERIFY/SEPARATORS - %s", f)
+            ctx["feedback_bus"].push(
+                "SYSTEM/WARN",
+                f"Separator verify found {len(failures)} issue(s). See game.log.",
+            )
+        else:
+            ctx["feedback_bus"].push(
+                "SYSTEM/OK", f"Separator verify OK: {ok} scenarios passed."
+            )
         return
     if len(parts) >= 2 and parts[0] == "verify" and parts[1] == "edges":
         count = 64


### PR DESCRIPTION
## Summary
- Refactor UI renderer to build blocks and insert `***` only between non-empty blocks, with validation helper
- Add `logs verify separators` command and document new separator rule
- Expand docs on renderer invariants and logging utilities

## Testing
- `pytest -q`
- `python -m mutants <<'EOF'
logs verify separators
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68c371c0def4832b8cf2e13178f1b641