### PR TITLE
UI: prevent hyphen breaks in wrapping; harden item display with U+2011

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+- Fix: Ground item list no longer breaks hyphenated names across lines.
+- Hardening: Item display names render hyphens as U+2011 (no-break hyphen) to
+  resist misconfigured wrappers.
+

--- a/docs/ui_invariants.md
+++ b/docs/ui_invariants.md
@@ -1,0 +1,9 @@
+# UI Invariants
+
+- Hyphenated tokens never wrap at `-`.
+- All UI wrapping uses Python's `TextWrapper` with `break_on_hyphens=False`,
+  `break_long_words=False`, `replace_whitespace=False`, and
+  `drop_whitespace=False`.
+- Rendered item names replace ASCII hyphen with U+2011 (no-break hyphen) to
+  ensure they never split across lines.
+

--- a/src/mutants/ui/render_items.py
+++ b/src/mutants/ui/render_items.py
@@ -1,0 +1,20 @@
+"""Helpers for rendering item display names safely."""
+
+from __future__ import annotations
+
+
+def _no_break_hyphens(s: str) -> str:
+    """Replace ASCII hyphen with U+2011 (no-break hyphen) for display only."""
+
+    return s.replace("-", "\u2011")
+
+
+def display_name_for_item(name: str) -> str:
+    """Return *name* with hyphens rendered as non-breaking."""
+
+    hardened = _no_break_hyphens(name)
+    if " " in hardened:
+        first = hardened.find(" ")
+        hardened = hardened[:first] + "\u00a0" + hardened[first + 1 :]
+    return hardened
+

--- a/src/mutants/ui/renderer.py
+++ b/src/mutants/ui/renderer.py
@@ -10,6 +10,7 @@ from . import styles as st
 from .viewmodels import RoomVM
 from .wrap import wrap_list
 from . import item_display as idisp
+from . import render_items as ritems
 import os
 import logging
 from ..engine import edge_resolver as ER
@@ -113,8 +114,9 @@ def render_token_lines(
         lines.append(fmt.format_ground_label())
         names = [idisp.canonical_name(t if isinstance(t, str) else str(t)) for t in ids]
         numbered = idisp.number_duplicates(names)
-        segs = [fmt.format_item(idisp.with_article(n)) for n in numbered]
-        lines.extend(wrap_list(segs, width))
+        display = [ritems.display_name_for_item(idisp.with_article(n)) for n in numbered]
+        for line in wrap_list(display, width):
+            lines.append(fmt.format_item(line))
 
     events = vm.get("events", [])
     if events:

--- a/src/mutants/ui/wrap.py
+++ b/src/mutants/ui/wrap.py
@@ -1,78 +1,43 @@
-"""Helpers for wrapping ANSI-tagged text segments."""
+"""Helpers for wrapping UI text without breaking on hyphens."""
+
 from __future__ import annotations
 
-import re
-from typing import List
 from textwrap import TextWrapper
-
-from .styles import ITEM, Segment
-
-ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 DEFAULT_WIDTH = 80
 
-
-def visible_len(s: str) -> int:
-    """Return the printable length of *s*, ignoring ANSI codes."""
-    return len(ANSI_RE.sub("", s))
-
-
-def wrap_segments(segments: List[Segment], width: int) -> List[List[Segment]]:
-    """Hard-wrap *segments* to *width* columns preserving token boundaries."""
-    lines: List[List[Segment]] = []
-    current: List[Segment] = []
-    current_len = 0
-
-    for token, text in segments:
-        seg_len = visible_len(text)
-        if current_len + seg_len > width and current_len > 0:
-            # finish current line
-            if current and current[-1][1].endswith(" "):
-                tok, txt = current[-1]
-                current[-1] = (tok, txt.rstrip(" "))
-            lines.append(current)
-            current = []
-            current_len = 0
-
-        # skip leading spaces
-        if token == ITEM and text == " " and current_len == 0:
-            continue
-
-        if current and current[-1][0] == token:
-            current[-1] = (token, current[-1][1] + text)
-        else:
-            current.append((token, text))
-        current_len += seg_len
-
-    if current:
-        if current[-1][1].endswith(" "):
-            tok, txt = current[-1]
-            current[-1] = (tok, txt.rstrip(" "))
-        lines.append(current)
-    return lines
+# Centralized config for all UI text wrapping.
+_WRAP_KW = dict(
+    break_on_hyphens=False,
+    break_long_words=False,
+    replace_whitespace=False,
+    drop_whitespace=False,
+)
 
 
-def wrap_list(items: List[List[Segment]], width: int) -> List[List[Segment]]:
-    """Wrap a list of item segments with comma separation and trailing period."""
-    segments: List[Segment] = []
-    last_index = len(items) - 1
-    for idx, item_segments in enumerate(items):
-        for token, text in item_segments:
-            if idx < last_index:
-                segments.append((token, text + ","))
-                segments.append((token, " "))
-            else:
-                segments.append((token, text + "."))
-    return wrap_segments(segments, width)
+def wrap(text: str, width: int = DEFAULT_WIDTH) -> list[str]:
+    """Return wrapped lines of *text* with safe non-breaking defaults."""
 
-
-def wrap(text: str, width: int = DEFAULT_WIDTH) -> List[str]:
-    """Return wrapped lines of *text* without breaking on hyphens."""
-    w = TextWrapper(
-        width=width,
-        break_on_hyphens=False,
-        break_long_words=False,
-        replace_whitespace=False,
-        drop_whitespace=False,
-    )
+    w = TextWrapper(width=width, **_WRAP_KW)
     return w.wrap(text)
+
+
+def wrap_segments(segments: list[str], width: int = DEFAULT_WIDTH) -> list[str]:
+    """Wrap pre-split *segments* preserving non-breaking hyphen rules."""
+
+    w = TextWrapper(width=width, **_WRAP_KW)
+    lines: list[str] = []
+    for seg in segments:
+        if not seg:
+            continue
+        lines.extend(w.wrap(seg))
+    return [ln.rstrip() for ln in lines]
+
+
+def wrap_list(items: list[str], width: int = DEFAULT_WIDTH, sep: str = ", ") -> list[str]:
+    """Join *items* with *sep* and wrap the result with non-breaking hyphen rules."""
+
+    joined = sep.join(items) + "."
+    lines = wrap(joined, width=width)
+    return [ln.rstrip() for ln in lines]
+

--- a/tests/test_render_items.py
+++ b/tests/test_render_items.py
@@ -1,0 +1,9 @@
+from mutants.ui.render_items import _no_break_hyphens
+
+
+def test_display_name_uses_no_break_hyphen():
+    s = "A Nuclear-Decay"
+    hardened = _no_break_hyphens(s)
+    assert "-" not in hardened
+    assert "\u2011" in hardened
+

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,0 +1,29 @@
+from mutants.ui.wrap import wrap, wrap_segments, wrap_list
+
+
+def test_wrap_does_not_break_on_hyphen():
+    text = "A Nuclear-Decay, A Bottle-Cap, A Bottle-Cap (1)"
+    lines = wrap(text, width=40)
+    joined = "\n".join(lines)
+    assert "Nuclear-\nDecay" not in joined
+    assert "Bottle-\nCap" not in joined
+
+
+def test_wrap_segments_no_hyphen_break():
+    segs = [
+        "On the ground lies: ",
+        "A Nuclear-Decay, A Bottle-Cap, A Bottle-Cap (1)",
+    ]
+    lines = wrap_segments(segs, width=40)
+    joined = "\n".join(lines)
+    assert "Nuclear-\nDecay" not in joined
+    assert "Bottle-\nCap" not in joined
+
+
+def test_wrap_list_no_hyphen_break():
+    items = ["A Nuclear-Decay", "A Bottle-Cap", "A Bottle-Cap (1)"]
+    lines = wrap_list(items, width=40)
+    joined = "\n".join(lines)
+    assert "Nuclear-\nDecay" not in joined
+    assert "Bottle-\nCap" not in joined
+

--- a/tests/ui/test_renderer_examples.py
+++ b/tests/ui/test_renderer_examples.py
@@ -79,7 +79,7 @@ class RendererExamplesTest(unittest.TestCase):
             "<DIR>west</DIR>  - <DESC_CONT>area continues.</DESC_CONT>",
             "***",
             "<LABEL>On the ground lies:</LABEL>",
-            "<ITEM>A Broken-Weapon.</ITEM>",
+            "<ITEM>A Broken‑Weapon.</ITEM>",
             "<SHADOWS_LABEL>You see shadows to the east, south.</SHADOWS_LABEL>",
         ]
         self.assertEqual(lines, expected)
@@ -94,8 +94,8 @@ class RendererExamplesTest(unittest.TestCase):
             "<MONSTER>Ghoul is here.</MONSTER>",
             "<MONSTER>Sasquatch-331 is here.</MONSTER>",
             "<LABEL>On the ground lies:</LABEL>",
-            "<ITEM>A Gold-Chunk, A Bottle-Cap, A Cigarette-Butt, A Cheese, An Ion-Decay,</ITEM>",
-            "<ITEM>A Nuclear-Waste, A Light-Spear, A Monster-Bait.</ITEM>",
+            "<ITEM>A Gold‑Chunk, A Bottle‑Cap, A Cigarette‑Butt, A Cheese, An Ion‑Decay,</ITEM>",
+            "<ITEM>A Nuclear‑Waste, A Light‑Spear, A Monster‑Bait.</ITEM>",
             "The Ghoul hisses.",
             "Sasquatch-331 tightens its grip.",
         ]


### PR DESCRIPTION
## Summary
- standardize wrapping helpers to disable hyphen and long-word splits
- render item display names with U+2011 and non‑breaking spaces
- document non‑breaking wrapping rules and update examples/tests

## Testing
- `PYTHONPATH=./src pytest -q`
- `logs verify separators` *(fails: command not found)*
- `logs verify items` *(fails: command not found)*
- `logs verify getdrop` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c42f113fd0832b80554e948a1d6eab