### PR TITLE
logging(ui): add UI trace toggle, ground-line instrumentation, and wrap probe

### DIFF
--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -63,6 +63,34 @@ logs verify getdrop
 
 Executes a deterministic core path through the transfer layer (seeded RNG) to exercise overflow/swap logic. For full end-to-end checks, use manual play with ground at capacity and inventory near the cap.
 
+- **Enable UI tracing** (logs ground raw/wrapped lines when rendering):
+
+```
+logs trace ui on
+```
+
+Disable:
+
+```
+logs trace ui off
+```
+
+- **Probe the wrapper with hyphenated items**:
+
+```
+logs probe wrap [--count N] [--width W]
+```
+
+Synthesizes a long hyphenated ground list and logs wrapping diagnostics. Emits `UI/WRAP/BAD_SPLIT` if a hyphen is split across lines.
+
+- **Tail log file inside the game**:
+
+```
+logs tail [N]  # default 100
+```
+
+Prints the last `N` lines of `state/logs/game.log`.
+
 ## Debug helpers
 - **Add items to current tile** (for quick setup while testing):
   ```
@@ -86,9 +114,9 @@ This comes from the **Passability Engine**, which layers:
 
 The first matching layer decides `passable` and the **descriptor**; `why` records the chain.
 
-## Toggling UI Traces (optional future)
+## Toggling UI Traces
 
-We reserved `logs trace ui on|off` for future UI-side traces (e.g., direction list reasoning). It writes similar one-liners with a `UI/DECISION` prefix.
+`logs trace ui on|off` toggles UI-side tracing. When enabled, ground rendering logs the raw items string and the wrapped lines with the effective wrapper options. Use this to diagnose hyphen wrapping behavior.
 
 ## Files Used
 

--- a/src/mutants/app/trace.py
+++ b/src/mutants/app/trace.py
@@ -29,3 +29,26 @@ def set_flag(name: str, value: bool) -> None:
 
 def get_flag(name: str) -> bool:
     return bool(_load().get(name, False))
+
+
+# Convenience helpers for common flags
+
+
+def is_move_trace_enabled() -> bool:
+    """Return True if move tracing is enabled."""
+    return get_flag("move")
+
+
+def set_move_trace_enabled(val: bool) -> None:
+    """Enable or disable move tracing."""
+    set_flag("move", bool(val))
+
+
+def is_ui_trace_enabled() -> bool:
+    """Return True if UI tracing is enabled."""
+    return get_flag("ui")
+
+
+def set_ui_trace_enabled(val: bool) -> None:
+    """Enable or disable UI tracing."""
+    set_flag("ui", bool(val))

--- a/src/mutants/ui/logsink.py
+++ b/src/mutants/ui/logsink.py
@@ -26,7 +26,7 @@ class LogSink:
                 f.flush()
                 os.fsync(f.fileno())
 
-    def tail(self, n: int = 50) -> List[str]:
+    def tail(self, n: int = 100) -> List[str]:
         return self.buffer[-n:]
 
     def clear(self) -> None:

--- a/src/mutants/ui/wrap.py
+++ b/src/mutants/ui/wrap.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from textwrap import TextWrapper
+
+from mutants.app import trace as traceflags
 
 DEFAULT_WIDTH = 80
 
-# Centralized config for all UI text wrapping.
-_WRAP_KW = dict(
+# Centralized config for all UI text wrapping. Exposed for debug logging.
+WRAP_DEBUG_OPTS = dict(
     break_on_hyphens=False,
     break_long_words=False,
     replace_whitespace=False,
@@ -18,14 +22,14 @@ _WRAP_KW = dict(
 def wrap(text: str, width: int = DEFAULT_WIDTH) -> list[str]:
     """Return wrapped lines of *text* with safe non-breaking defaults."""
 
-    w = TextWrapper(width=width, **_WRAP_KW)
+    w = TextWrapper(width=width, **WRAP_DEBUG_OPTS)
     return w.wrap(text)
 
 
 def wrap_segments(segments: list[str], width: int = DEFAULT_WIDTH) -> list[str]:
     """Wrap pre-split *segments* preserving non-breaking hyphen rules."""
 
-    w = TextWrapper(width=width, **_WRAP_KW)
+    w = TextWrapper(width=width, **WRAP_DEBUG_OPTS)
     lines: list[str] = []
     for seg in segments:
         if not seg:
@@ -38,6 +42,18 @@ def wrap_list(items: list[str], width: int = DEFAULT_WIDTH, sep: str = ", ") -> 
     """Join *items* with *sep* and wrap the result with non-breaking hyphen rules."""
 
     joined = sep.join(items) + "."
+    if traceflags.get_flag("ui"):
+        logging.getLogger(__name__).info(
+            "UI/GROUND raw=%s", json.dumps(joined, ensure_ascii=False)
+        )
     lines = wrap(joined, width=width)
-    return [ln.rstrip() for ln in lines]
+    lines = [ln.rstrip() for ln in lines]
+    if traceflags.get_flag("ui"):
+        logging.getLogger(__name__).info(
+            "UI/GROUND wrap width=%d opts=%s lines=%s",
+            width,
+            json.dumps(WRAP_DEBUG_OPTS, sort_keys=True),
+            json.dumps(lines, ensure_ascii=False),
+        )
+    return lines
 

--- a/tests/test_logs_probe.py
+++ b/tests/test_logs_probe.py
@@ -1,0 +1,11 @@
+import logging
+
+from mutants.commands.logs import _probe_wrap
+
+
+def test_probe_wrap_logs_ok(caplog):
+    caplog.set_level(logging.INFO)
+    _probe_wrap(count=20, width=40)
+    msgs = [record.getMessage() for record in caplog.records]
+    assert any("UI/WRAP/OK" in m for m in msgs)
+    assert not any("UI/WRAP/BAD_SPLIT" in m for m in msgs)


### PR DESCRIPTION
## Summary
- add convenience UI/move trace helpers backed by state/runtime/trace.json
- log raw and wrapped ground strings with wrapper options when UI tracing is enabled
- introduce `logs probe wrap` and in-game `logs tail [N]` with 100-line default
- document UI trace toggle, wrap probe, and in-game tailing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c43d4a2fe8832ba034266d11153422