### PR TITLE
logging(ui): route wrap diagnostics via FeedbackBus; add ground-line tracing

### DIFF
--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -63,7 +63,17 @@ logs verify getdrop
 
 Executes a deterministic core path through the transfer layer (seeded RNG) to exercise overflow/swap logic. For full end-to-end checks, use manual play with ground at capacity and inventory near the cap.
 
-- **Enable UI tracing** (logs ground raw/wrapped lines when rendering):
+- **Tail log file inside the game**:
+
+```
+logs tail [N]  # default 100
+```
+
+Prints the last `N` lines of `state/logs/game.log`.
+
+### UI Trace (ground & wrap diagnostics)
+
+Enable:
 
 ```
 logs trace ui on
@@ -75,21 +85,35 @@ Disable:
 logs trace ui off
 ```
 
-- **Probe the wrapper with hyphenated items**:
+When ON, the renderer logs both the **raw ground line** and the **post-wrap lines** with the active wrapper options:
+
+- `SYSTEM/INFO - UI/GROUND raw="On the ground lies: A Nuclear-Decay, A Bottle-Cap, …"`
+- `SYSTEM/INFO - UI/GROUND wrap width=80 opts={...} lines=["…", "…"]`
+
+You can also run a synthetic wrap probe:
 
 ```
-logs probe wrap [--count N] [--width W]
+logs probe wrap --count 16 --width 80
 ```
 
-Synthesizes a long hyphenated ground list and logs wrapping diagnostics. Emits `UI/WRAP/BAD_SPLIT` if a hyphen is split across lines.
+This logs:
+- `SYSTEM/INFO - UI/PROBE raw=…`
+- `SYSTEM/INFO - UI/PROBE wrap width=80 opts={...} lines=[...]`
+- `SYSTEM/OK - UI/WRAP/OK` on success, or `SYSTEM/WARN - UI/WRAP/BAD_SPLIT ...` if a hyphen split is detected.
 
-- **Tail log file inside the game**:
+Inspect logs from in-game:
 
 ```
-logs tail [N]  # default 100
+logs tail 200
 ```
 
-Prints the last `N` lines of `state/logs/game.log`.
+…or from the shell:
+
+```
+grep -n "UI/PROBE\|UI/GROUND\|UI/WRAP" state/logs/game.log
+```
+
+**Note on terminal width:** The game wraps to **80 columns** internally. If your terminal is narrower than 80, your terminal may hard-wrap the already-wrapped lines; that visual wrap can split at hyphens even when the internal lines are correct. Always check the `UI/GROUND wrap … lines=[…]` payload to see our **internal** wrap result.
 
 ## Debug helpers
 - **Add items to current tile** (for quick setup while testing):

--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -39,6 +39,8 @@ def _resolve_header_text(tile: dict, year: int) -> str:
 # Paths
 DEFAULT_THEME_PATH = Path("state/ui/themes/bbs.json")
 
+_CURRENT_CTX: Dict[str, Any] | None = None
+
 
 def build_context() -> Dict[str, Any]:
     """Build the application context."""
@@ -72,11 +74,17 @@ def build_context() -> Dict[str, Any]:
         "renderer": renderer.render,
         "config": cfg,
     }
+    global _CURRENT_CTX
+    _CURRENT_CTX = ctx
     return ctx
 
 
 # Backwards compatibility
 build = build_context
+
+
+def current_context() -> Dict[str, Any] | None:
+    return _CURRENT_CTX
 
 
 def _active(state: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_ground_trace.py
+++ b/tests/test_ground_trace.py
@@ -1,0 +1,25 @@
+from mutants.app import context, trace
+from mutants.ui import renderer
+
+
+def test_ground_tracing_emits_events():
+    ctx = context.build_context()
+    trace.set_flag("ui", True)
+    bus = ctx["feedback_bus"]
+    bus.drain()
+    vm = {
+        "header": "",
+        "coords": {"x": 0, "y": 0},
+        "dirs": {},
+        "monsters_here": [],
+        "ground_item_ids": ["nuclear_decay", "bottle_cap"],
+        "events": [],
+        "shadows": [],
+        "flags": {"dark": False},
+    }
+    renderer.render_token_lines(vm, width=80)
+    events = bus.drain()
+    texts = [e["text"] for e in events]
+    assert any(t.startswith("UI/GROUND raw=") for t in texts)
+    assert any(t.startswith("UI/GROUND wrap") for t in texts)
+    trace.set_flag("ui", False)

--- a/tests/test_logs_probe.py
+++ b/tests/test_logs_probe.py
@@ -1,11 +1,13 @@
-import logging
-
 from mutants.commands.logs import _probe_wrap
+from mutants.app import context
 
 
-def test_probe_wrap_logs_ok(caplog):
-    caplog.set_level(logging.INFO)
-    _probe_wrap(count=20, width=40)
-    msgs = [record.getMessage() for record in caplog.records]
-    assert any("UI/WRAP/OK" in m for m in msgs)
-    assert not any("UI/WRAP/BAD_SPLIT" in m for m in msgs)
+def test_probe_wrap_logs_ok():
+    ctx = context.build_context()
+    bus = ctx["feedback_bus"]
+    bus.drain()
+    _probe_wrap(count=20, width=40, ctx=ctx)
+    events = bus.drain()
+    texts = [e["text"] for e in events]
+    assert any("UI/WRAP/OK" in t for t in texts)
+    assert not any("UI/WRAP/BAD_SPLIT" in t for t in texts)


### PR DESCRIPTION
## Summary
- Route `logs probe wrap` diagnostics through the game's FeedbackBus so UI/PROBE and UI/WRAP events reach the log sink
- Emit UI/GROUND raw and wrapped diagnostics when UI tracing is enabled, using current wrapper options
- Document UI trace usage, synthetic wrap probe, and terminal width nuances

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44a68165c832ba58b564d54bd65ba