### PR TITLE
Finalize non-breaking item display across UI; add catalog-wide wrap tests

### DIFF
--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -71,49 +71,44 @@ logs tail [N]  # default 100
 
 Prints the last `N` lines of `state/logs/game.log`.
 
-### UI Trace (ground & wrap diagnostics)
+### Diagnosing text wrapping
 
-Enable:
+Enable tracing:
 
 ```
 logs trace ui on
 ```
 
-Disable:
-
-```
-logs trace ui off
-```
-
-When ON, the renderer logs both the **raw ground line** and the **post-wrap lines** with the active wrapper options:
-
-- `SYSTEM/INFO - UI/GROUND raw="On the ground lies: A Nuclear-Decay, A Bottle-Cap, …"`
-- `SYSTEM/INFO - UI/GROUND wrap width=80 opts={...} lines=["…", "…"]`
-
-You can also run a synthetic wrap probe:
+Run a synthetic probe:
 
 ```
 logs probe wrap --count 16 --width 80
 ```
 
-This logs:
-- `SYSTEM/INFO - UI/PROBE raw=…`
-- `SYSTEM/INFO - UI/PROBE wrap width=80 opts={...} lines=[...]`
-- `SYSTEM/OK - UI/WRAP/OK` on success, or `SYSTEM/WARN - UI/WRAP/BAD_SPLIT ...` if a hyphen split is detected.
-
-Inspect logs from in-game:
+Create a long ground list to force wrapping and inspect the logged payload:
 
 ```
+debug add item nuclear_decay 12
+debug add item bottle_cap 12
+look
 logs tail 200
 ```
 
-…or from the shell:
+When tracing is on, the renderer logs both the **raw ground line** and the
+**post-wrap lines** with the active wrapper options, for example:
+
+- `SYSTEM/INFO - UI/GROUND raw="On the ground lies: A Nuclear-Decay, …"`
+- `SYSTEM/INFO - UI/GROUND wrap width=80 opts={...} lines=["…", "…"]`
+
+Terminal panes narrower than 80 columns may visually re-wrap the output and
+split at ASCII `-`, but the `lines=[...]` payload is authoritative and should
+never show a hyphen or article split after this change.
+
+Disable tracing when done:
 
 ```
-grep -n "UI/PROBE\|UI/GROUND\|UI/WRAP" state/logs/game.log
+logs trace ui off
 ```
-
-**Note on terminal width:** The game wraps to **80 columns** internally. If your terminal is narrower than 80, your terminal may hard-wrap the already-wrapped lines; that visual wrap can split at hyphens even when the internal lines are correct. Always check the `UI/GROUND wrap … lines=[…]` payload to see our **internal** wrap result.
 
 ## Debug helpers
 - **Add items to current tile** (for quick setup while testing):

--- a/docs/ui_invariants.md
+++ b/docs/ui_invariants.md
@@ -1,9 +1,10 @@
 # UI Invariants
 
-- Hyphenated tokens never wrap at `-`.
+- Hyphenated tokens never break at the hyphen, and articles stay attached to
+  the first token. Final UI strings convert "-" to U+2011 and the first space to
+  U+00A0 before wrapping. This applies uniformly to ground and inventory
+  displays; canonical names remain ASCII and unchanged.
 - All UI wrapping uses Python's `TextWrapper` with `break_on_hyphens=False`,
   `break_long_words=False`, `replace_whitespace=False`, and
   `drop_whitespace=False`.
-- Rendered item names replace ASCII hyphen with U+2011 (no-break hyphen) to
-  ensure they never split across lines.
 

--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json, os
 from ..ui import item_display as idisp
 from ..ui import wrap as uwrap
+from ..ui import render_items as ritems
 
 
 def _player_file() -> str:
@@ -21,12 +22,13 @@ def inv_cmd(arg: str, ctx):
     names = [idisp.canonical_name_from_iid(i) for i in inv]
     numbered = idisp.number_duplicates(names)
     with_articles = [idisp.with_article(n) for n in numbered]
+    display = [ritems.harden_display_nonbreak(s) for s in with_articles]
     bus = ctx["feedback_bus"]
-    if not with_articles:
+    if not display:
         bus.push("SYSTEM/OK", "You are carrying nothing.")
         return
     bus.push("SYSTEM/OK", "You are carrying:")
-    line = ", ".join(with_articles) + "."
+    line = ", ".join(display) + "."
     for ln in uwrap.wrap(line):
         bus.push("SYSTEM/OK", ln)
 

--- a/src/mutants/ui/render_items.py
+++ b/src/mutants/ui/render_items.py
@@ -3,18 +3,18 @@
 from __future__ import annotations
 
 
-def _no_break_hyphens(s: str) -> str:
-    """Replace ASCII hyphen with U+2011 (no-break hyphen) for display only."""
+def harden_display_nonbreak(s: str) -> str:
+    """Return *s* with hyphen and article hardened using non-breaking forms.
 
-    return s.replace("-", "\u2011")
+    This is UI-only and must be applied only to final display strings
+    (after article and numbering).
+    """
 
-
-def display_name_for_item(name: str) -> str:
-    """Return *name* with hyphens rendered as non-breaking."""
-
-    hardened = _no_break_hyphens(name)
+    if not s:
+        return s
+    hardened = s.replace("-", "\u2011")
     if " " in hardened:
         first = hardened.find(" ")
-        hardened = hardened[:first] + "\u00a0" + hardened[first + 1 :]
+        hardened = hardened[:first] + "\u00A0" + hardened[first + 1 :]
     return hardened
 

--- a/src/mutants/ui/renderer.py
+++ b/src/mutants/ui/renderer.py
@@ -116,7 +116,8 @@ def render_token_lines(
         lines.append(fmt.format_ground_label())
         names = [idisp.canonical_name(t if isinstance(t, str) else str(t)) for t in ids]
         numbered = idisp.number_duplicates(names)
-        display = [ritems.display_name_for_item(idisp.with_article(n)) for n in numbered]
+        display = [idisp.with_article(n) for n in numbered]
+        display = [ritems.harden_display_nonbreak(s) for s in display]
         if is_ui_trace_enabled():
             raw = "On the ground lies: " + ", ".join(display) + "."
         wrapped_lines = wrap_list(display, width)

--- a/tests/test_render_items.py
+++ b/tests/test_render_items.py
@@ -1,9 +1,10 @@
-from mutants.ui.render_items import _no_break_hyphens
+from mutants.ui.render_items import harden_display_nonbreak
 
 
-def test_display_name_uses_no_break_hyphen():
+def test_display_name_uses_non_breaking_chars():
     s = "A Nuclear-Decay"
-    hardened = _no_break_hyphens(s)
+    hardened = harden_display_nonbreak(s)
     assert "-" not in hardened
     assert "\u2011" in hardened
+    assert "\u00A0" in hardened
 

--- a/tests/test_ui_wrap_items.py
+++ b/tests/test_ui_wrap_items.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mutants.ui import item_display as idisp
+from mutants.ui import render_items as ritems
+from mutants.ui.wrap import wrap_list
+
+
+CATALOG_PATH = Path(__file__).resolve().parents[1] / "state" / "items" / "catalog.json"
+
+
+def _load_catalog_ids() -> list[str]:
+    data = json.load(CATALOG_PATH.open("r", encoding="utf-8"))
+    if isinstance(data, dict):
+        items = data.get("items", [])
+    else:
+        items = data
+    ids: list[str] = []
+    for meta in items:
+        iid = meta.get("item_id") or meta.get("id")
+        if iid:
+            ids.append(str(iid))
+    return ids
+
+
+def _build_display_names(bases: list[str]) -> list[str]:
+    out: list[str] = []
+    for base in bases:
+        duped = idisp.number_duplicates([base, base])
+        with_articles = [idisp.with_article(n) for n in duped]
+        hardened = [ritems.harden_display_nonbreak(s) for s in with_articles]
+        out.extend(hardened)
+    return out
+
+
+def test_catalog_items_do_not_break():
+    ids = _load_catalog_ids()
+    bases = [idisp.canonical_name(iid) for iid in ids]
+    display = _build_display_names(bases)
+    wrapped = wrap_list(display, width=80)
+    joined = "\n".join(wrapped)
+    assert "-\n" not in joined
+    assert "A \n" not in joined
+    assert "An \n" not in joined
+
+
+def test_fuzz_items_do_not_break():
+    fuzz = [
+        "Ion-Decay",
+        "Exo-Plate",
+        "Multi-Hyphen-Thing",
+        "Mini-XL",
+        "Rock-N-Roll",
+        "Ultra-Super-Long-Concatenation-Token",
+    ]
+    display = _build_display_names(fuzz)
+    wrapped = wrap_list(display, width=40)
+    joined = "\n".join(wrapped)
+    assert "-\n" not in joined
+    assert "A \n" not in joined
+    assert "An \n" not in joined
+


### PR DESCRIPTION
## Summary
- ensure final item display strings harden hyphens and articles against wrapping
- apply non-breaking display helper to ground and inventory renderers
- add catalog-wide and fuzz wrap tests and document logging guidance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c450d1b6dc832ba435588a392b9d51