### PR TITLE
ui(textwrap): harden final display strings to prevent hyphen breaks

### DIFF
--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -100,9 +100,11 @@ When tracing is on, the renderer logs both the **raw ground line** and the
 - `SYSTEM/INFO - UI/GROUND raw="On the ground lies: A Nuclear-Decay, …"`
 - `SYSTEM/INFO - UI/GROUND wrap width=80 opts={...} lines=["…", "…"]`
 
-Terminal panes narrower than 80 columns may visually re-wrap the output and
-split at ASCII `-`, but the `lines=[...]` payload is authoritative and should
-never show a hyphen or article split after this change.
+Final display strings replace ASCII `-` with U+2011 (no-break hyphen) and bind
+leading articles with U+00A0 (non-breaking space). These code points may not be
+obvious in your terminal, but they prevent hyphen or article splits. Terminal
+panes narrower than 80 columns may visually re-wrap the output and split at
+ASCII `-`, but the `lines=[...]` payload is authoritative.
 
 Disable tracing when done:
 

--- a/docs/ui_invariants.md
+++ b/docs/ui_invariants.md
@@ -1,9 +1,10 @@
 # UI Invariants
 
-- Hyphenated tokens never break at the hyphen, and articles stay attached to
-  the first token. Final UI strings convert "-" to U+2011 and the first space to
-  U+00A0 before wrapping. This applies uniformly to ground and inventory
-  displays; canonical names remain ASCII and unchanged.
+- Hyphenated tokens never break at `-`, and leading articles stay bound to the
+  first token. After article and numbering are applied, final display strings
+  replace `-` with U+2011 and the article space with U+00A0 before wrapping.
+  This applies uniformly to ground and inventory displays; canonical names
+  remain ASCII and unchanged.
 - All UI wrapping uses Python's `TextWrapper` with `break_on_hyphens=False`,
   `break_long_words=False`, `replace_whitespace=False`, and
   `drop_whitespace=False`.

--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import json, os
 from ..ui import item_display as idisp
 from ..ui import wrap as uwrap
-from ..ui import render_items as ritems
+from ..ui.textutils import harden_final_display
 
 
 def _player_file() -> str:
@@ -21,15 +21,13 @@ def inv_cmd(arg: str, ctx):
     inv = list(p.get("inventory") or [])
     names = [idisp.canonical_name_from_iid(i) for i in inv]
     numbered = idisp.number_duplicates(names)
-    with_articles = [idisp.with_article(n) for n in numbered]
-    display = [ritems.harden_display_nonbreak(s) for s in with_articles]
+    display = [harden_final_display(idisp.with_article(n)) for n in numbered]
     bus = ctx["feedback_bus"]
     if not display:
         bus.push("SYSTEM/OK", "You are carrying nothing.")
         return
     bus.push("SYSTEM/OK", "You are carrying:")
-    line = ", ".join(display) + "."
-    for ln in uwrap.wrap(line):
+    for ln in uwrap.wrap_list(display):
         bus.push("SYSTEM/OK", ln)
 
 

--- a/src/mutants/ui/render_items.py
+++ b/src/mutants/ui/render_items.py
@@ -2,19 +2,10 @@
 
 from __future__ import annotations
 
+from .textutils import harden_final_display
+
 
 def harden_display_nonbreak(s: str) -> str:
-    """Return *s* with hyphen and article hardened using non-breaking forms.
-
-    This is UI-only and must be applied only to final display strings
-    (after article and numbering).
-    """
-
-    if not s:
-        return s
-    hardened = s.replace("-", "\u2011")
-    if " " in hardened:
-        first = hardened.find(" ")
-        hardened = hardened[:first] + "\u00A0" + hardened[first + 1 :]
-    return hardened
+    """Backward compat wrapper for :func:`harden_final_display`."""
+    return harden_final_display(s)
 

--- a/src/mutants/ui/renderer.py
+++ b/src/mutants/ui/renderer.py
@@ -10,7 +10,7 @@ from . import styles as st
 from .viewmodels import RoomVM
 from .wrap import wrap_list, WRAP_DEBUG_OPTS
 from . import item_display as idisp
-from . import render_items as ritems
+from .textutils import harden_final_display
 import os
 import logging
 import json
@@ -116,8 +116,10 @@ def render_token_lines(
         lines.append(fmt.format_ground_label())
         names = [idisp.canonical_name(t if isinstance(t, str) else str(t)) for t in ids]
         numbered = idisp.number_duplicates(names)
-        display = [idisp.with_article(n) for n in numbered]
-        display = [ritems.harden_display_nonbreak(s) for s in display]
+        display = [
+            harden_final_display(idisp.with_article(n))
+            for n in numbered
+        ]
         if is_ui_trace_enabled():
             raw = "On the ground lies: " + ", ".join(display) + "."
         wrapped_lines = wrap_list(display, width)

--- a/src/mutants/ui/textutils.py
+++ b/src/mutants/ui/textutils.py
@@ -1,0 +1,18 @@
+import re
+
+_NO_BREAK_HYPHEN = "\u2011"  # U+2011
+_NBSP = "\u00A0"             # U+00A0
+
+_ARTICLE_RE = re.compile(r"^(A|An) ")
+
+def harden_final_display(s: str) -> str:
+    """Apply non-breaking rules to a final display string.
+
+    - Replace ASCII '-' with U+2011 no-break hyphen.
+    - Bind leading article (A/An) to next token with U+00A0.
+    """
+    if not s:
+        return s
+    s = s.replace("-", _NO_BREAK_HYPHEN)
+    s = _ARTICLE_RE.sub(lambda m: f"{m.group(1)}{_NBSP}", s)
+    return s

--- a/tests/test_ground_wrap.py
+++ b/tests/test_ground_wrap.py
@@ -1,0 +1,25 @@
+from mutants.ui.wrap import wrap_list
+from mutants.ui.textutils import harden_final_display
+
+
+def test_ground_wrap_no_hyphen_breaks_80():
+    base = "A Nuclear-Decay"
+    items = [base] + [f"{base} ({i})" for i in range(1, 12)]
+    hardened = [harden_final_display(s) for s in items]
+    lines = wrap_list(hardened, width=80)
+    joined = "\n".join(lines)
+    assert "Nuclear-\nDecay" not in joined
+
+
+def test_article_bound_with_nbsp():
+    s = harden_final_display("A Nuclear-Decay")
+    assert "\u00A0" in s
+    assert "\u2011" in s
+
+
+def test_inventory_no_hyphen_breaks():
+    items = ["A Bottle-Cap", "A Nuclear-Decay (1)"]
+    hardened = [harden_final_display(s) for s in items]
+    lines = wrap_list(hardened, width=40)
+    joined = "\n".join(lines)
+    assert "Bottle-\nCap" not in joined


### PR DESCRIPTION
## Summary
- ensure final item strings use non-breaking hyphen and space
- wrap ground and inventory lists using hardened strings
- document invariant and add tests for hyphen wrap behavior

## Testing
- `pytest -q`
- `PYTHONPATH=src python - <<'PY'
from mutants.commands.logs import log_cmd
class DummyFB:
    def push(self,k,t):
        print(f"FB:{k}:{t}")
class DummySink:
    def tail(self,n):
        return []
    def clear(self):
        pass
ctx={'feedback_bus':DummyFB(),'logsink':DummySink()}
log_cmd('verify items', ctx)
log_cmd('verify separators', ctx)
log_cmd('verify getdrop', ctx)
log_cmd('probe wrap --count 16 --width 80', ctx)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c459b3686c832b9d79ee864e48ed75