### PR TITLE
ci+docs: add wrap regression guard and document checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,6 @@ jobs:
           python-version: '3.12'
       - run: pip install -e .
       - run: python -m mutants -h || true
+      - run: pytest -q
+      - name: CI wrap check
+        run: make ci-wrap-check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.ONESHELL:
+.PHONY: run-once logs-probe guard-wrap ci-wrap-check
+
+# Boot the game once and run a UI probe in non-interactive mode
+run-once:
+	python -m mutants <<'EOF'
+	logs trace ui on
+	logs probe wrap --count 24 --width 80
+	logs tail 1
+	EOF
+
+# Just the probe (assumes the game is already warmed)
+logs-probe:
+	python -m mutants <<'EOF'
+	logs trace ui on
+	logs probe wrap --count 24 --width 80
+	logs tail 1
+	EOF
+
+# Local guard (read log file and fail on regression)
+guard-wrap:
+	./scripts/guard_wrap.py
+
+# CI convenience: run probe then guard
+ci-wrap-check: logs-probe guard-wrap

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -1,0 +1,53 @@
+# CI Checks & Gates — Mutants BBS
+
+## Why these checks exist
+Our game is intentionally conservative and deterministic. The UI presents 80-col text; small regressions (like hyphen splitting) break the feel. CI must catch these before merges.
+
+## Checks we run (and why)
+
+### 1) Unit tests (PyTest)
+- **Goal:** validate core logic (movement edge composition, item naming, transfers, wrap helpers).
+- **Why:** catches logic bugs, ensures invariants (e.g., separators only between blocks).
+
+### 2) Verifier smoke tests (optional in CI; always available locally)
+- `logs verify edges` — edge symmetry (cur→dir matches neighbor→opp).
+- `logs verify separators` — joins never produce leading/trailing/double `***`.
+- `logs verify items` — canonical naming rules (A/An, `_`→`-`, numbering).
+- **Why:** easy-to-run E2E-like guards; CI may run a subset due to time.
+
+### 3) UI Wrap Probe + Guard (NEW)
+- Non-interactive run that issues:
+
+```
+logs trace ui on
+logs probe wrap --count 24 --width 80
+```
+
+- Produces `UI/PROBE raw=…`, `UI/PROBE wrap … lines=[…]`, and either `UI/WRAP/OK` or `UI/WRAP/BAD_SPLIT`.
+- **Guard script** parses `state/logs/game.log` and **fails CI** on any hyphen-break regression.
+- **Why:** The hyphen wrap bug is subtle and easy to reintroduce by bypassing final-string hardening; the probe + guard create a robust safety net.
+
+## How to run locally
+
+### With Make
+
+```
+make logs-probe
+make guard-wrap
+```
+
+### Direct
+
+```
+python -m mutants <<'EOF'
+logs trace ui on
+logs probe wrap --count 24 --width 80
+logs tail 200
+EOF
+python scripts/guard_wrap.py
+```
+
+## Interpreting failures
+- `UI/WRAP/BAD_SPLIT` → a regression in wrapping logic or hardening path.
+- Dangling `-"` at a diagnostic line end → a line broke at an ASCII hyphen in diagnostics; fix final-string hardening or wrapper options.
+- If your terminal shows breaks but `lines=[…]` is clean → terminal pane narrower than 80 columns; engine is correct.

--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -146,3 +146,37 @@ The first matching layer decides `passable` and the **descriptor**; `why` record
 - `state/world/dynamics.json` — dynamic overlays (temporary barriers / blasted edges).
 
 These are plain JSON or text; safe to inspect or back up.
+
+## Hyphen Wrap Diagnostics (ground truth logs)
+
+When debugging text wrapping, enable UI tracing and use the probe:
+
+```
+logs trace ui on
+logs probe wrap --count 24 --width 80
+logs tail 200
+```
+
+You’ll see diagnostics like:
+- `SYSTEM/INFO - UI/PROBE raw="On the ground lies: ..."`
+- `SYSTEM/INFO - UI/PROBE wrap width=80 opts={...} lines=[ "...", "..." ]`
+- `SYSTEM/OK - UI/WRAP/OK` (or `SYSTEM/WARN - UI/WRAP/BAD_SPLIT ...`)
+
+For real game paths, force a long ground list:
+
+```
+debug add item nuclear_decay 12
+debug add item bottle_cap 12
+look
+logs tail 200
+```
+
+This logs:
+- `SYSTEM/INFO - UI/GROUND raw="..."`
+- `SYSTEM/INFO - UI/GROUND wrap width=80 opts={...} lines=[ ... ]`
+
+**Interpretation:**
+- If `lines=[…]` shows no line ending in `Nuclear-`/`Bottle-`, the engine’s wrap is correct. If your terminal pane is narrower than 80 columns, it may visually re-wrap anyway; trust the logged `lines=[…]` for ground truth.
+
+**Invariant implemented:**
+- Final display strings (after article “A/An ” and any numbering “(n)”) are hardened: ASCII `-` → U+2011 (no-break hyphen), and the article space → U+00A0 (NBSP). With `break_on_hyphens=False` and `break_long_words=False`, hyphenated tokens will not split.

--- a/docs/tests_overview.md
+++ b/docs/tests_overview.md
@@ -1,0 +1,39 @@
+# Tests Overview — Mutants BBS
+
+## Principles
+- **Determinism:** world gen, movement, and item operations have predictable results.
+- **UI invariants:** separators, 80-col wrapping, and naming rules must remain stable.
+- **Small, focused cases:** many tiny tests > a few giant ones.
+
+## What we test
+
+### Movement & Edges
+- Two-sided edge composition (cur vs neighbor) with conservative defaults.
+- `logs verify edges` mirrors this with random sampling to catch asymmetries.
+
+### Items & Naming
+- Catalog name rules: Title Case, `_`→`-`, A/An articles, numbering “(1)”, “(2)”, …
+- Ground capacity (≤6) and inventory cap (10) with overflow swap behavior.
+- **Wrap-specific:** hyphenated tokens never split at `-`; NBSP after article.
+
+### Inventory & Transfers
+- `get`/`drop` prefix targeting, no “(1)/(2)” targeting.
+- Overflow swaps: random swap to/from ground per caps.
+
+### UI & Rendering
+- Separator placement: only between blocks; never leading/trailing.
+- Wrapping to exactly 80 columns; hyphenated tokens and article binding tested.
+
+## Where to add tests
+- `tests/` mirrors source domains (e.g., `test_wrap.py`, `test_items.py`, `test_edges.py`).
+- Add a regression test per bug class (e.g., hyphen wrap): assert no `-\n` at width=80.
+
+## Running tests
+
+```
+pytest -q
+```
+
+## CI notes
+- Unit tests run by default in CI.
+- Wrap probe/guard (see docs/ci_checks.md) complements tests to catch integration-level wrap regressions.

--- a/scripts/guard_wrap.py
+++ b/scripts/guard_wrap.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Guard: fail if hyphen splitting is detected in UI wrap diagnostics.
+
+Looks for:
+- Explicit probe result 'UI/WRAP/BAD_SPLIT'
+- Any diagnostic line (UI/PROBE or UI/GROUND) with a dangling '-' at end of a wrapped diagnostic line.
+"""
+
+import sys, re, pathlib
+
+LOG = pathlib.Path("state/logs/game.log")
+if not LOG.exists():
+    print("No log file found at state/logs/game.log; ensure the game was run once.", file=sys.stderr)
+    sys.exit(2)
+
+txt = LOG.read_text(encoding="utf-8", errors="replace")
+lines = txt.splitlines()
+
+# 1) Hard fail if the probe flagged a bad split
+if any("UI/WRAP/BAD_SPLIT" in l for l in lines):
+    print("\u274c Detected UI/WRAP/BAD_SPLIT in diagnostics. Hyphen wrap regression.", file=sys.stderr)
+    sys.exit(1)
+
+# 2) Scan only our diagnostic payload lines for dangling hyphen at EOL
+diag = [l for l in lines if ("UI/PROBE" in l or "UI/GROUND" in l)]
+dangling_hyphen = any(re.search(r'-"\s*$', l) for l in diag)  # conservative check
+
+if dangling_hyphen:
+    print("\u274c Detected dangling '-' at end of diagnostic line payload. Hyphen wrap regression.", file=sys.stderr)
+    sys.exit(1)
+
+# Optionally require at least one OK probe
+ok = any("UI/WRAP/OK" in l for l in lines)
+if not ok:
+    print("\u26a0\ufe0f No probe result found. Did you run the probe? (This is not a failure by itself.)")
+
+print("\u2705 Wrap guard passed.")


### PR DESCRIPTION
## Summary
- add `scripts/guard_wrap.py` and Makefile targets to probe UI wrapping and fail on hyphen splits
- document CI checks and test strategy; expand logging guide with hyphen wrap diagnostics
- run wrap guard in CI via new `ci-wrap-check` job step

## Testing
- `pytest -q`
- `python -m mutants <<'EOF'
logs verify items
logs verify separators
logs verify getdrop
EOF`
- `make logs-probe`
- `make guard-wrap`


------
https://chatgpt.com/codex/tasks/task_e_68c460bc7194832b88d71f1377a91592