### PR TITLE
feat: add prefix routing and document argcmd

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -177,3 +177,7 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
   - `run_argcmd(ctx, spec, arg, do_action)`: trims arg; on empty+required → usage; else calls `do_action(subject)` and pushes feedback based on `ok/reason`. On success, prefers `display_name|name|item_name` from `do_action` result for `{name}`.
 * **GET/DROP adoption**: `get` and `drop` now use this runner. Failures map to specific feedback (`not_found` → “There isn’t a {subject} here.”, `inventory_empty` → “You have nothing to drop.”, `armor_cannot_drop` → “You can't drop what you're wearing.”). Success emits explicit lines (“You pick up the Skull.” / “You drop the Skull.”).
 * **Armor rule**: any **inventory** arg-kind excludes worn armor; armor is not targetable by `get/drop/look`. Only `remove` operates on the armor slot.
+
+## Router Prefix Rule (new)
+* **Rule**: tokens **≥3** letters resolve to the **unique** command whose name (or alias) starts with that prefix; **<3** works only for explicit aliases (by default `n/s/e/w`).
+* **Ambiguity**: if multiple commands match the ≥3 prefix, the router warns and does nothing.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -99,6 +99,10 @@ To keep command UX consistent, commands that take a **subject argument** now use
 - `ArgSpec` declares the **arg policy** (`required|optional|forbidden`), **message templates** (usage/invalid/success), optional **reason→message** mapping, and the **feedback kinds** for success/warn (e.g., `LOOT/PICKUP`, `LOOT/DROP`).
 - `run_argcmd` handles: trim arg → usage on empty (when required) → call `do_action(subject)` → map failure `reason` to a message → push explicit success feedback including the item name when available.
 
+### Command Prefix Rule (router)
+- All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** allow single-letter aliases (`n/s/e/w`).
+- If a ≥3 prefix is **ambiguous**, the router warns and does nothing; if **unknown**, it warns accordingly.
+
 ### Notes
 - **Worn armor is not inventory**: by design, arg kinds that reference inventory (e.g., for `drop`) exclude worn armor; only the `remove` command interacts with armor.
 - `get`/`drop` now reject empty args with usage text and emit explicit success/warn lines.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,4 +7,5 @@
   resist misconfigured wrappers.
 - Change: `get`/`drop` now require a subject argument; typing them alone shows usage instead of acting implicitly.
 - UX: `get`/`drop` emit explicit success feedback with item names, and clearer invalid messages (“There isn’t a {subject} here.” / “You’re not carrying a {subject}. ”). Worn armor remains excluded from inventory operations (only `remove` can affect armor).
+- Router: All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** keep one-letter forms (`n/s/e/w`). Ambiguous prefixes now warn and do nothing.
 

--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -67,11 +67,12 @@ Executes a deterministic core path through the transfer layer (seeded RNG) to ex
 - On **success**, `get` pushes `LOOT/PICKUP` and `drop` pushes `LOOT/DROP` with explicit item names (e.g., “You pick up the Skull.” / “You drop the Skull.”).
 - On **invalid/empty**, commands push `SYSTEM/WARN` with usage or reason-mapped messages (e.g., “There isn’t a zz here.”, “You’re not carrying a zz.”, “You have nothing to drop.”).
 
-- **Tail log file inside the game**:
+### Router messages (prefix rule)
+- **Ambiguous ≥3 prefix**: router warns with candidates (“Ambiguous command ‘dri’ (drink, drive)”).
+- **Unknown ≥3 prefix**: router warns that commands require at least 3 letters.
 
-```
-logs tail [N]  # default 100
-```
+### Tail log file inside the game
+- `logs tail [N]  # default 100`
 
 Prints the last `N` lines of `state/logs/game.log`.
 

--- a/docs/tests_overview.md
+++ b/docs/tests_overview.md
@@ -39,8 +39,8 @@ pytest -q
 - Wrap probe/guard (see docs/ci_checks.md) complements tests to catch integration-level wrap regressions.
 
 ## New core tests (argument-command)
-Add a **minimal** set of parametrized unit tests that assert **reason codes translated to the correct feedback** without spinning up the full REPL:
+Add a **minimal** set of parametrized unit tests that assert **feedback** without spinning up the full REPL:
 
 - Use `commands/argcmd.py` directly with a fake feedback bus and stub `do_action`.
 - Cover for each command: **empty arg → usage**, **invalid → reason-mapped message**, **success → explicit success** (preferring `display_name` from `do_action` result).
-- Keep assertions tight: mostly check the final feedback text for the three cases above; avoid end-to-end harnesses so adding more commands won’t churn tests.
+- Keep assertions tight: the three cases above only; avoid end-to-end harnesses so adding more commands won’t churn tests.

--- a/docs/ui_invariants.md
+++ b/docs/ui_invariants.md
@@ -15,3 +15,7 @@
 - On success, commands emit an explicit confirmation line including the resolved subject name when available.
 - **Armor**: worn armor is **not** part of inventory and is not targetable by these commands; only `remove` interacts with the armor slot.
 
+## Command Routing Invariants (new)
+- Tokens of **≥3 letters** resolve to a **unique** command by prefix; **<3** works only for explicit aliases (default: `n/s/e/w`).
+- Ambiguous ≥3 prefixes must produce a **single warning** and no action.
+

--- a/src/mutants/repl/dispatch.py
+++ b/src/mutants/repl/dispatch.py
@@ -1,31 +1,71 @@
 from __future__ import annotations
-
-from typing import Callable, Dict
+import sys
+from typing import Callable, Dict, List, Optional
 
 
 class Dispatch:
-    def __init__(self, bus) -> None:
+    """
+    Command router with case-insensitive matching and ≥3-letter unique prefix resolution.
+    <3-letter tokens are accepted only if explicitly aliased (e.g., 'n','s','e','w').
+    """
+
+    def __init__(self) -> None:
         self._cmds: Dict[str, Callable[[str], None]] = {}
-        self._alias: Dict[str, str] = {}
+        self._aliases: Dict[str, str] = {}
+        self._bus = None  # optional feedback bus
+
+    # Optional: REPL can call this after building ctx.
+    def set_feedback_bus(self, bus) -> None:
         self._bus = bus
+
+    def _warn(self, msg: str) -> None:
+        if self._bus is not None:
+            self._bus.push("SYSTEM/WARN", msg)
+        else:
+            print(msg, file=sys.stderr)
 
     def register(self, name: str, fn: Callable[[str], None]) -> None:
         self._cmds[name.lower()] = fn
 
-    def alias(self, alias_name: str, canonical: str) -> None:
-        self._alias[alias_name.lower()] = canonical.lower()
+    def alias(self, alias: str, target: str) -> None:
+        self._aliases[alias.lower()] = target.lower()
 
-    def list_commands(self) -> Dict[str, str]:
-        # returns canonical->"has_aliases?" or any metadata you like later
-        return dict(self._cmds)
+    def list_commands(self) -> List[str]:
+        return sorted(self._cmds.keys())
 
-    def call(self, token: str, arg: str = "") -> bool:
-        token = (token or "").strip().lower()
-        token = self._alias.get(token, token)
-        fn = self._cmds.get(token)
+    def _resolve_prefix(self, token: str) -> Optional[str]:
+        t = (token or "").lower()
+        # Exact alias (works for 1-letter movement)
+        if t in self._aliases:
+            return self._aliases[t]
+        # ≥3 letters → unique prefix over canonical names and their aliases
+        if len(t) >= 3:
+            candidates = set()
+            # Canonical names
+            for name in self._cmds:
+                if name.startswith(t):
+                    candidates.add(name)
+            # Aliases
+            for a, target in self._aliases.items():
+                if a.startswith(t):
+                    candidates.add(target)
+            if len(candidates) == 1:
+                return next(iter(candidates))
+            if len(candidates) > 1:
+                pretty = ", ".join(sorted(candidates))
+                self._warn(f'Ambiguous command "{token}" (did you mean: {pretty})')
+                return None
+        # <3 letters without explicit alias, or unknown ≥3 prefix
+        self._warn(f'Unknown command "{token}" (commands require at least 3 letters).')
+        return None
+
+    def call(self, token: str, arg: str) -> None:
+        name = self._resolve_prefix(token)
+        if not name:
+            return
+        fn = self._cmds.get(name)
         if not fn:
-            if token:
-                self._bus.push("SYSTEM/WARN", f"Unknown command: {token}")
-            return False
+            self._warn(f'Command handler missing for "{name}".')
+            return
         fn(arg)
-        return True
+

--- a/src/mutants/repl/loop.py
+++ b/src/mutants/repl/loop.py
@@ -8,7 +8,8 @@ from mutants.repl.help import startup_banner
 
 def main() -> None:
     ctx = build_context()
-    dispatch = Dispatch(bus=ctx["feedback_bus"])
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
 
     # Auto-register all commands in mutants.commands
     register_all(dispatch, ctx)


### PR DESCRIPTION
## Summary
- route commands by unique 3+ letter prefixes, warning on unknown or ambiguous tokens
- shift REPL to initialize dispatch without a bus and attach feedback bus afterward
- document argument-command framework and new routing semantics across architecture and logging docs

## Testing
- `pytest -q`
- `python -m mutants <<'EOF'
logs trace ui off
look
inv
inve
xyz
get
get zz
get skull
inv
get skull
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68c4ba348268832b9e3bc6b2aa523fd3