### PR TITLE
Add positional arg command runner and router prefix tests

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -92,19 +92,19 @@ At startup (once per calendar day), the game performs a **litter reset**:
 - `drop <prefix>` drops the first matching inventory item (pickup order, excluding worn armor). If ground exceeds **6**, a random ground item pops into inventory and may drop another if inventory would exceed 10.
 - `inv` prints inventory with the same naming rules as the ground list.
 
-## Argument-Command Framework (new)
-To keep command UX consistent, commands that take a **subject argument** now use a small runner:
+## Argument-Command Framework (updated)
+Commands that take a **subject argument** use a small runner to keep UX consistent:
 
-- `commands/argcmd.py` exposes `ArgSpec` and `run_argcmd(ctx, spec, arg, do_action)`.
-- `ArgSpec` declares the **arg policy** (`required|optional|forbidden`), **message templates** (usage/invalid/success), optional **reason→message** mapping, and the **feedback kinds** for success/warn (e.g., `LOOT/PICKUP`, `LOOT/DROP`).
-- `run_argcmd` handles: trim arg → usage on empty (when required) → call `do_action(subject)` → map failure `reason` to a message → push explicit success feedback including the item name when available.
+- `commands/argcmd.py` exposes `ArgSpec` + `run_argcmd(ctx, spec, arg, do_action)` for single-arg commands (e.g., GET/DROP) and `PosArgSpec` + `run_argcmd_positional(...)` for two-arg commands (e.g., POINT, THROW, and the limited `BUY ions [amount]` form).
+- `ArgSpec`/`PosArgSpec` declare the **arg policy** (`required|optional|forbidden`), **argument kinds** (e.g., `direction`, `item_in_inventory`, `integer_range`, `literal('ions')`), **message templates** (usage/invalid/success), optional **reason→message** mapping, and the **feedback kinds** for success/warn.
+- Runners handle: trim/tokenize → usage on empty/missing → parse & validate each argument → call `do_action(...)` → map failure `reason` to a message → push explicit success feedback using parsed values (e.g., `{dir}`, `{item}`, `{amt}`) or resolved item names.
 
 ### Command Prefix Rule (router)
-- All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** allow single-letter aliases (`n/s/e/w`).
+- All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** allow single-letter forms (`n/s/e/w`).
 - If a ≥3 prefix is **ambiguous**, the router warns and does nothing; if **unknown**, it warns accordingly.
 
 ### Notes
-- **Worn armor is not inventory**: by design, arg kinds that reference inventory (e.g., for `drop`) exclude worn armor; only the `remove` command interacts with armor.
+- **Worn armor is not inventory**: inventory-based arg kinds exclude worn armor; only the `remove` command interacts with armor.
 - `get`/`drop` now reject empty args with usage text and emit explicit success/warn lines.
 
 ## Item Display (canonical names)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,4 +8,5 @@
 - Change: `get`/`drop` now require a subject argument; typing them alone shows usage instead of acting implicitly.
 - UX: `get`/`drop` emit explicit success feedback with item names, and clearer invalid messages (“There isn’t a {subject} here.” / “You’re not carrying a {subject}. ”). Worn armor remains excluded from inventory operations (only `remove` can affect armor).
 - Router: All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** keep one-letter forms (`n/s/e/w`). Ambiguous prefixes now warn and do nothing.
+- Framework: Added positional-args runner for two-argument commands (POINT/THROW and the restricted `BUY ions [100000-999999]` at maintenance shops); docs and minimal tests included.
 

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -54,3 +54,6 @@ python scripts/guard_wrap.py
 ## Core command-UX checks (NEW)
 - A tiny **core** pytest file validates the argument-command runner behavior for `get`/`drop` (empty/invalid/success). It runs with the regular test job; no separate CI step is added.
 - Keep these tests minimal and stable (assert the canonical feedback lines only), so new commands don’t break CI. Additional command tests can live outside the core set and be run locally or nightly.
+
+## Router prefix checks (NEW)
+- Minimal router tests run in the same pytest job to ensure the ≥3-letter unique-prefix rule and single-letter movement aliases (`n/s/e/w`) remain stable.

--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -71,6 +71,9 @@ Executes a deterministic core path through the transfer layer (seeded RNG) to ex
 - **Ambiguous ≥3 prefix**: router warns with candidates (“Ambiguous command ‘dri’ (drink, drive)”).
 - **Unknown ≥3 prefix**: router warns that commands require at least 3 letters.
 
+### Positional-args tracing (POINT/THROW/BUY ions)
+- Two-argument commands use the same feedback bus; failures include reason codes like `invalid_direction`, `wrong_item_literal`, or `invalid_amount_range`. Success messages incorporate parsed values (e.g., “You throw the Skull north.”).
+
 ### Tail log file inside the game
 - `logs tail [N]  # default 100`
 

--- a/docs/tests_overview.md
+++ b/docs/tests_overview.md
@@ -42,5 +42,8 @@ pytest -q
 Add a **minimal** set of parametrized unit tests that assert **feedback** without spinning up the full REPL:
 
 - Use `commands/argcmd.py` directly with a fake feedback bus and stub `do_action`.
-- Cover for each command: **empty arg → usage**, **invalid → reason-mapped message**, **success → explicit success** (preferring `display_name` from `do_action` result).
+- Cover for each command: **empty/missing args → usage**, **invalid → reason-mapped message**, **success → explicit success** (preferring `display_name` from `do_action` result).
 - Keep assertions tight: the three cases above only; avoid end-to-end harnesses so adding more commands won’t churn tests.
+
+## Router tests (minimal)
+- Add tiny tests for the ≥3-letter prefix rule: accept unique ≥3 prefix, reject short non-alias tokens, keep `n/s/e/w` one-letter aliases, and warn on ambiguous ≥3 prefixes.

--- a/docs/ui_invariants.md
+++ b/docs/ui_invariants.md
@@ -19,3 +19,7 @@
 - Tokens of **≥3 letters** resolve to a **unique** command by prefix; **<3** works only for explicit aliases (default: `n/s/e/w`).
 - Ambiguous ≥3 prefixes must produce a **single warning** and no action.
 
+## Positional-Args Invariants (new)
+- Two-argument commands declare ordered arg kinds; missing args result in a **usage** message; parse errors map to stable **reason codes** (e.g., `invalid_direction`, `invalid_amount_range`, `wrong_item_literal`).
+- Inventory arg kinds **exclude worn armor**; only `remove` may act on armor.
+

--- a/tests/test_argcmd_core.py
+++ b/tests/test_argcmd_core.py
@@ -1,11 +1,9 @@
-import types
-from mutants.commands.argcmd import ArgSpec, run_argcmd
+from src.mutants.commands.argcmd import ArgSpec, run_argcmd
 
 
 class FakeBus:
     def __init__(self):
         self.events = []
-
     def push(self, kind, text, **_):
         self.events.append((kind, text))
 
@@ -22,9 +20,7 @@ def test_get_empty_arg_shows_usage():
         messages={"usage": "Type GET [item name] to pick up an item."},
         success_kind="LOOT/PICKUP",
     )
-
     run_argcmd(ctx, spec, "", lambda s: {"ok": False})
-
     assert ctx["feedback_bus"].events == [
         ("SYSTEM/WARN", "Type GET [item name] to pick up an item.")
     ]
@@ -39,11 +35,9 @@ def test_get_invalid_subject_maps_reason():
         reason_messages={"not_found": "There isn't a {subject} here."},
         success_kind="LOOT/PICKUP",
     )
-
-    run_argcmd(ctx, spec, "zz", lambda s: {"ok": False, "reason": "not_found"})
-
+    run_argcmd(ctx, spec, "baditem", lambda s: {"ok": False, "reason": "not_found"})
     assert ctx["feedback_bus"].events == [
-        ("SYSTEM/WARN", "There isn't a zz here.")
+        ("SYSTEM/WARN", "There isn't a baditem here.")
     ]
 
 
@@ -56,9 +50,7 @@ def test_drop_inventory_empty_is_preserved():
         reason_messages={"inventory_empty": "You have nothing to drop."},
         success_kind="LOOT/DROP",
     )
-
     run_argcmd(ctx, spec, "skull", lambda s: {"ok": False, "reason": "inventory_empty"})
-
     assert ctx["feedback_bus"].events == [
         ("SYSTEM/WARN", "You have nothing to drop.")
     ]
@@ -72,9 +64,7 @@ def test_drop_success_includes_name():
         messages={"success": "You drop the {name}."},
         success_kind="LOOT/DROP",
     )
-
     run_argcmd(ctx, spec, "sk", lambda s: {"ok": True, "display_name": "Skull"})
-
     assert ctx["feedback_bus"].events == [
         ("LOOT/DROP", "You drop the Skull.")
     ]

--- a/tests/test_argcmd_positional_core.py
+++ b/tests/test_argcmd_positional_core.py
@@ -1,0 +1,78 @@
+from src.mutants.commands.argcmd import PosArg, PosArgSpec, run_argcmd_positional
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+    def push(self, kind, text, **_):
+        self.events.append((kind, text))
+
+
+def _ctx():
+    return {"feedback_bus": FakeBus()}
+
+
+def test_point_usage_when_missing_args():
+    ctx = _ctx()
+    spec = PosArgSpec(
+        verb="POINT",
+        args=[PosArg("dir","direction"), PosArg("item","item_in_inventory")],
+        messages={"usage": "Type POINT [direction] [item]."},
+        reason_messages={"invalid_direction": "That isn't a valid direction."},
+        success_kind="SYSTEM/OK",
+    )
+    run_argcmd_positional(ctx, spec, "north", lambda **kw: {"ok": True})
+    # Missing item → usage
+    assert ctx["feedback_bus"].events == [("SYSTEM/WARN", "Type POINT [direction] [item].")]
+
+
+def test_point_invalid_direction_reason_mapping():
+    ctx = _ctx()
+    spec = PosArgSpec(
+        verb="POINT",
+        args=[PosArg("dir","direction"), PosArg("item","item_in_inventory")],
+        messages={"usage": "Type POINT [direction] [item]."},
+        reason_messages={"invalid_direction": "That isn't a valid direction."},
+    )
+    run_argcmd_positional(ctx, spec, "up skull", lambda **kw: {"ok": True})
+    assert ctx["feedback_bus"].events == [("SYSTEM/WARN", "That isn't a valid direction.")]
+
+
+def test_throw_success_message_uses_values():
+    ctx = _ctx()
+    spec = PosArgSpec(
+        verb="THROW",
+        args=[PosArg("dir","direction"), PosArg("item","item_in_inventory")],
+        messages={"usage": "Type THROW [direction] [item].",
+                  "success": "You throw the {item} {dir}."},
+        success_kind="COMBAT/THROW",
+    )
+    run_argcmd_positional(ctx, spec, "n skull", lambda **kw: {"ok": True})
+    assert ctx["feedback_bus"].events == [("COMBAT/THROW", "You throw the skull north.")]
+
+
+def test_buy_ions_amount_range_and_gate_messages():
+    ctx = _ctx()
+    spec = PosArgSpec(
+        verb="BUY",
+        args=[PosArg("what","literal:ions"), PosArg("amt","int_range:100000:999999")],
+        messages={"usage": "Type BUY ions [amount]."},
+        reason_messages={
+            "wrong_item_literal": "You can only buy ions here.",
+            "invalid_amount_range": "Amount must be between 100000 and 999999.",
+            "not_at_maintenance_shop": "You're not at a maintenance shop!",
+        },
+        success_kind="SHOP/BUY",
+    )
+    # Wrong literal
+    run_argcmd_positional(ctx, spec, "shields 250000", lambda **kw: {"ok": True})
+    # Bad range
+    run_argcmd_positional(ctx, spec, "ions 999", lambda **kw: {"ok": True})
+    # Gate from action (pretend we're not at shop)
+    run_argcmd_positional(ctx, spec, "ions 250000", lambda **kw: {"ok": False, "reason": "not_at_maintenance_shop"})
+    assert ctx["feedback_bus"].events == [
+        ("SYSTEM/WARN", "You can only buy ions here."),
+        ("SYSTEM/WARN", "Amount must be between 100000 and 999999."),
+        ("SYSTEM/WARN", "You're not at a maintenance shop!"),
+    ]
+

--- a/tests/test_router_prefix.py
+++ b/tests/test_router_prefix.py
@@ -1,0 +1,55 @@
+from src.mutants.repl.dispatch import Dispatch
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+    def push(self, kind, text, **_):
+        self.events.append((kind, text))
+
+
+def _dispatch():
+    d = Dispatch()
+    d.set_feedback_bus(FakeBus())
+    return d
+
+
+def test_unique_prefix_resolves():
+    d = _dispatch()
+    called = {}
+    def inv(arg):
+        called['ok'] = True
+    d.register('inventory', inv)
+    d.call('inv', '')
+    assert called.get('ok') is True
+
+
+def test_short_non_alias_warns():
+    d = _dispatch()
+    d.register('look', lambda arg: None)
+    d.call('lo', '')
+    assert d._bus.events == [
+        ('SYSTEM/WARN', 'Unknown command "lo" (commands require at least 3 letters).')
+    ]
+
+
+def test_single_letter_alias_north_ok():
+    d = _dispatch()
+    called = {}
+    def north(arg):
+        called['dir'] = 'north'
+    d.register('north', north)
+    d.alias('n', 'north')
+    d.call('n', '')
+    assert called.get('dir') == 'north'
+
+
+def test_ambiguous_prefix_warns():
+    d = _dispatch()
+    d.register('drink', lambda arg: None)
+    d.register('drive', lambda arg: None)
+    d.call('dri', '')
+    assert d._bus.events == [
+        ('SYSTEM/WARN', 'Ambiguous command "dri" (did you mean: drink, drive)')
+    ]
+


### PR DESCRIPTION
## Summary
- extend argument-command framework with positional-argument support
- document and test ≥3-letter router prefix rule
- add minimal core tests for single and two-arg command runners

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4bf4825b4832b8af5f7880034916d