### PR TITLE
Handle list-based command discovery in help

### DIFF
--- a/src/mutants/repl/help.py
+++ b/src/mutants/repl/help.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Iterable
 
 
 def startup_banner(ctx) -> str:
@@ -7,7 +8,24 @@ def startup_banner(ctx) -> str:
     )
 
 
+def _as_names(maybe_names) -> Iterable[str]:
+    """
+    Accept either a dict-like (with .keys()) or a list/iterable of names.
+    Returns an iterable of lower-cased command names.
+    """
+    if hasattr(maybe_names, "keys"):
+        names = maybe_names.keys()  # dict-like
+    else:
+        names = maybe_names  # already a list/iterable
+    return (str(n).lower() for n in names)
+
+
 def render_help(dispatch) -> str:
-    cmds = sorted(dispatch.list_commands().keys())
-    # Grouping/formatting minimal for now
-    return "Commands: " + ", ".join(cmds)
+    # Dispatch.list_commands() may return a dict-like or a list of names depending on router version.
+    names = _as_names(dispatch.list_commands())
+    cmds = sorted(names)
+    lines = []
+    lines.append("Available commands:")
+    for c in cmds:
+        lines.append(f" - {c}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Handle `Dispatch.list_commands()` returning either a dict or list when rendering help
- Show available commands one per line instead of comma-separated

## Testing
- `python -m mutants <<'EOF'
help
EOF`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4c1df9058832bb4642b7a505142f3