### PR TITLE
Restrict rendering to movement and look

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -6,8 +6,8 @@
   1) builds the **app context** (`app/context.py`);
   2) creates a **Dispatch** router (`repl/dispatch.py`);
   3) calls `commands.register_all.register_all(dispatch, ctx)` to auto-register all commands;
-  4) prints a banner; initial `render_frame(ctx)`;
-  5) for each input line: split `token arg`; `dispatch.call(token, arg)`; always `render_frame(ctx)`.
+  4) prints a banner; initial `render_frame(ctx, policy=RenderPolicy.ROOM)`;
+  5) for each input line: split `token arg`; `dispatch.call(token, arg)`; re-render **only** when the command returns `RenderPolicy.ROOM` (movement and `look`).
 
 ## App context (single source of wiring)
 - File: `app/context.py`.
@@ -16,7 +16,7 @@
 - Helpers:
   - `build_context()` returns the dict above.
   - `build_room_vm(ctx)` constructs UI data for current tile (no I/O in renderer).
-  - `render_frame(ctx)` builds RoomVM, drains bus, invokes renderer with theme palette/width, prints lines + prompt.
+  - `render_frame(ctx, policy)` builds RoomVM, drains bus, invokes renderer with theme palette/width, prints lines + prompt (when ``policy`` permits).
 
 ## Command routing
 - `repl/dispatch.py`:
@@ -30,7 +30,7 @@
   - registers `north/n`, `south/s`, `east/e`, `west/w`, `look`;
   - inspects world edges via `registries/world.py`;
   - on block: `bus.push("MOVE/BLOCKED", "...")`; on success: optionally `bus.push("MOVE/OK","...")`;
-  - **does not print**; REPL repaints after dispatch.
+  - **does not print**; REPL repaints only when the command returns ``RenderPolicy.ROOM``.
 
 ## UI stack (pure, testable)
 - **ViewModel**: `ui/viewmodels.py` — RoomVM shape consumed by renderer.
@@ -160,8 +160,8 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 - `state/runtime/spawn_epoch.json`
 
 ## Flow examples
-- **look** → dispatch → render_room: VM from context → renderer prints.
-- **n (locked gate)** → move checks edge → bus.push("MOVE/BLOCKED", "...") → render_frame shows room then a feedback block.
+- **look** → dispatch → `RenderPolicy.ROOM` → render_frame → renderer prints.
+- **n (locked gate)** → move checks edge → bus.push("MOVE/BLOCKED", "...") → `RenderPolicy.ROOM` → render_frame shows room then a feedback block.
 - **combat** (future): compute damage → use monster’s attack template → `bus.push("COMBAT/HIT", "...")` → rendered under `***`.
 
 ## Why this split?

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -15,7 +15,7 @@ This is the plain-English tour of how the game starts, reads your input, updates
 ## The Game Loop (REPL)
 - **Read**: get your command (e.g., `n`).
 - **Eval**: a simple router maps `n` to the move handler; the handler uses the world registry to check edges and updates your `(x,y)` if allowed. It doesn’t print— it **pushes a feedback message** like “The gate is locked.”
-- **Print**: we build a view of the room (header, compass, directions, ground, etc.), drain any feedback messages, and render everything using the current theme (colors live in JSON).
+- **Print**: we build a view of the room (header, compass, directions, ground, etc.), drain any feedback messages, and render everything using the current theme (colors live in JSON). The REPL now repaints **only** after movement or a `look` command (optionally with a direction).
 
 This repeats each turn.
 

--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
+from .render_policy import RenderPolicy
 
 from mutants.bootstrap.lazyinit import ensure_player_state
 from mutants.bootstrap.runtime import ensure_runtime
@@ -147,7 +148,17 @@ def build_room_vm(
     return vm
 
 
-def render_frame(ctx: Dict[str, Any]) -> None:
+def render_frame(ctx: Dict[str, Any], *, policy: RenderPolicy) -> None:
+    """Render the current room if *policy* permits.
+
+    The REPL provides a ``RenderPolicy`` guard to ensure that rendering only
+    happens after movement or explicit look commands. Calls with
+    ``RenderPolicy.NEVER`` are ignored.
+    """
+
+    if policy is not RenderPolicy.ROOM:
+        return
+
     vm = build_room_vm(
         ctx["player_state"],
         ctx["world_loader"],

--- a/src/mutants/app/render_policy.py
+++ b/src/mutants/app/render_policy.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class RenderPolicy(Enum):
+    """Rendering guard returned by commands.
+
+    Only ``ROOM`` triggers a re-render of the current room. All other
+    commands should return ``NEVER`` so the REPL can avoid unnecessary
+    painting.
+    """
+
+    NEVER = auto()
+    ROOM = auto()

--- a/src/mutants/commands/look.py
+++ b/src/mutants/commands/look.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-def look_cmd(_arg: str, ctx) -> None:
-    # The REPL loop re-renders after each command; look is a no-op.
-    pass
+from mutants.app.render_policy import RenderPolicy
+
+
+def look_cmd(_arg: str, ctx) -> RenderPolicy:
+    # Request a render; argument (optional direction) is currently ignored.
+    return RenderPolicy.ROOM
 
 
 def register(dispatch, ctx) -> None:

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 import logging
 
 from mutants.registries.world import DELTA
+from mutants.app.render_policy import RenderPolicy
 from mutants.engine import edge_resolver as ER
 from mutants.registries import dynamics as dyn
 from mutants.app import trace as traceflags
@@ -21,7 +22,7 @@ def _active(state: Dict[str, Any]) -> Dict[str, Any]:
     return state["players"][0]
 
 
-def move(dir_code: str, ctx: Dict[str, Any]) -> None:
+def move(dir_code: str, ctx: Dict[str, Any]) -> RenderPolicy:
     """Attempt to move the active player in direction *dir_code*."""
     p = _active(ctx["player_state"])
     year, x, y = p.get("pos", [0, 0, 0])
@@ -47,12 +48,13 @@ def move(dir_code: str, ctx: Dict[str, Any]) -> None:
 
     if not dec.passable:
         ctx["feedback_bus"].push("MOVE/BLOCKED", "You're blocked!")
-        return
+        return RenderPolicy.ROOM
 
     dx, dy = DELTA[dir_code]
     p["pos"][1] = x + dx
     p["pos"][2] = y + dy
     # Do not echo success movement like "You head north." Original shows next room immediately.
+    return RenderPolicy.ROOM
 
 
 def register(dispatch, ctx) -> None:

--- a/src/mutants/repl/dispatch.py
+++ b/src/mutants/repl/dispatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import sys
 from typing import Callable, Dict, List, Optional
+from mutants.app.render_policy import RenderPolicy
 
 
 class Dispatch:
@@ -59,13 +60,14 @@ class Dispatch:
         self._warn(f'Unknown command "{token}" (commands require at least 3 letters).')
         return None
 
-    def call(self, token: str, arg: str) -> None:
+    def call(self, token: str, arg: str) -> RenderPolicy:
         name = self._resolve_prefix(token)
         if not name:
-            return
+            return RenderPolicy.NEVER
         fn = self._cmds.get(name)
         if not fn:
             self._warn(f'Command handler missing for "{name}".')
-            return
-        fn(arg)
+            return RenderPolicy.NEVER
+        rv = fn(arg)
+        return rv if isinstance(rv, RenderPolicy) else RenderPolicy.NEVER
 

--- a/src/mutants/repl/loop.py
+++ b/src/mutants/repl/loop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from mutants.app.context import build_context, render_frame
+from mutants.app.render_policy import RenderPolicy
 from mutants.repl.dispatch import Dispatch
 from mutants.commands.register_all import register_all
 from mutants.repl.prompt import make_prompt
@@ -18,7 +19,7 @@ def main() -> None:
     print(startup_banner(ctx))
 
     # Initial paint
-    render_frame(ctx)
+    render_frame(ctx, policy=RenderPolicy.ROOM)
 
     while True:
         try:
@@ -28,7 +29,8 @@ def main() -> None:
             break
 
         token, _, arg = raw.strip().partition(" ")
-        handled = dispatch.call(token, arg)
+        policy = dispatch.call(token, arg)
 
-        # Always repaint; unknown commands produce a feedback event
-        render_frame(ctx)
+        # Repaint only when the command requests it
+        if policy is RenderPolicy.ROOM:
+            render_frame(ctx, policy=policy)

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -2,6 +2,7 @@ import pytest
 
 from mutants.app import context
 from mutants.app.context import render_frame
+from mutants.app.render_policy import RenderPolicy
 from mutants.commands.move import move
 from mutants.commands.look import look_cmd
 
@@ -20,8 +21,9 @@ def make_ctx():
 
 def test_look_renders_room(capsys):
     ctx = make_ctx()
-    look_cmd("", ctx)
-    render_frame(ctx)
+    policy = look_cmd("", ctx)
+    assert policy is RenderPolicy.ROOM
+    render_frame(ctx, policy=policy)
     out = capsys.readouterr().out
     assert "Graffiti lines the city walls." in out
 

--- a/tests/test_render_policy.py
+++ b/tests/test_render_policy.py
@@ -1,0 +1,22 @@
+from mutants.app import context
+from mutants.app.render_policy import RenderPolicy
+from mutants.repl.dispatch import Dispatch
+from mutants.commands.register_all import register_all
+
+
+def make_dispatch_ctx():
+    ctx = context.build_context()
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+    register_all(dispatch, ctx)
+    return dispatch, ctx
+
+
+def test_render_policy_for_commands():
+    dispatch, ctx = make_dispatch_ctx()
+
+    assert dispatch.call("north", "") is RenderPolicy.ROOM
+    assert dispatch.call("look", "") is RenderPolicy.ROOM
+    assert dispatch.call("look", "east") is RenderPolicy.ROOM
+    # Non movement/look commands should not trigger a repaint
+    assert dispatch.call("help", "") is RenderPolicy.NEVER


### PR DESCRIPTION
## Summary
- add RenderPolicy guard and enforce rendering only on movement or look commands
- update REPL, dispatch, and commands to respect RenderPolicy
- document new render behavior and cover with unit tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c54fe4edb0832ba8ff6f379a90acfe