### PR TITLE
Fix REPL render gating and add feedback flush

### DIFF
--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -164,3 +164,14 @@ def render_frame(ctx: Dict[str, Any]) -> None:
     )
     for line in lines:
         print(line)
+
+
+def flush_feedback(ctx: Dict[str, Any]) -> None:
+    events = ctx["feedback_bus"].drain()
+    if not events:
+        return
+    palette = ctx["theme"].palette
+    for ev in events:
+        token = renderer._feedback_token(ev.get("kind", ""))
+        line = st.resolve_segments([(token, ev.get("text", ""))], palette)
+        print(line)

--- a/src/mutants/commands/look.py
+++ b/src/mutants/commands/look.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 def look_cmd(_arg: str, ctx) -> None:
-    # The REPL loop re-renders after each command; look is a no-op.
+    # REPL loop triggers rendering for look; the command itself does nothing.
     pass
 
 

--- a/src/mutants/repl/dispatch.py
+++ b/src/mutants/repl/dispatch.py
@@ -59,13 +59,13 @@ class Dispatch:
         self._warn(f'Unknown command "{token}" (commands require at least 3 letters).')
         return None
 
-    def call(self, token: str, arg: str) -> None:
+    def call(self, token: str, arg: str) -> Optional[str]:
         name = self._resolve_prefix(token)
         if not name:
-            return
+            return None
         fn = self._cmds.get(name)
         if not fn:
             self._warn(f'Command handler missing for "{name}".')
-            return
+            return None
         fn(arg)
-
+        return name

--- a/src/mutants/repl/loop.py
+++ b/src/mutants/repl/loop.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from mutants.app.context import build_context, render_frame
+from mutants.app.context import build_context, render_frame, flush_feedback
 from mutants.repl.dispatch import Dispatch
 from mutants.commands.register_all import register_all
 from mutants.repl.prompt import make_prompt
@@ -30,5 +30,7 @@ def main() -> None:
         token, _, arg = raw.strip().partition(" ")
         handled = dispatch.call(token, arg)
 
-        # Always repaint; unknown commands produce a feedback event
-        render_frame(ctx)
+        if handled in {"north", "south", "east", "west", "look"}:
+            render_frame(ctx)
+        else:
+            flush_feedback(ctx)

--- a/tests/test_feedback_flush.py
+++ b/tests/test_feedback_flush.py
@@ -1,0 +1,17 @@
+from src.mutants.app.context import build_context, flush_feedback
+from src.mutants.repl.dispatch import Dispatch
+
+
+def test_flush_feedback_prints_events(capsys):
+    ctx = build_context()
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+
+    def foo_cmd(arg):
+        ctx["feedback_bus"].push("SYSTEM/OK", "foo ran")
+    dispatch.register("foo", foo_cmd)
+
+    dispatch.call("foo", "")
+    flush_feedback(ctx)
+    out = capsys.readouterr().out
+    assert "foo ran" in out

--- a/tests/test_router_prefix.py
+++ b/tests/test_router_prefix.py
@@ -44,6 +44,13 @@ def test_single_letter_alias_north_ok():
     assert called.get('dir') == 'north'
 
 
+def test_call_returns_canonical_name():
+    d = _dispatch()
+    d.register('north', lambda arg: None)
+    d.alias('n', 'north')
+    assert d.call('n', '') == 'north'
+
+
 def test_ambiguous_prefix_warns():
     d = _dispatch()
     d.register('drink', lambda arg: None)


### PR DESCRIPTION
## Summary
- render only on movement or look
- flush feedback bus immediately for other commands
- return canonical command name from dispatch and add tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c55350f7fc832baadfaa4a7efa8e4f