### PR TITLE
Outcome-driven rendering and directional look peek

### DIFF
--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -73,6 +73,8 @@ def build_context() -> Dict[str, Any]:
         "theme": theme,
         "renderer": renderer.render,
         "config": cfg,
+        "render_next": False,
+        "peek_vm": None,
     }
     global _CURRENT_CTX
     _CURRENT_CTX = ctx
@@ -148,13 +150,15 @@ def build_room_vm(
 
 
 def render_frame(ctx: Dict[str, Any]) -> None:
-    vm = build_room_vm(
-        ctx["player_state"],
-        ctx["world_loader"],
-        ctx["headers"],
-        ctx.get("monsters"),
-        ctx.get("items"),
-    )
+    vm = ctx.pop("peek_vm", None)
+    if vm is None:
+        vm = build_room_vm(
+            ctx["player_state"],
+            ctx["world_loader"],
+            ctx["headers"],
+            ctx.get("monsters"),
+            ctx.get("items"),
+        )
     events = ctx["feedback_bus"].drain()
     lines = ctx["renderer"](
         vm,

--- a/src/mutants/commands/look.py
+++ b/src/mutants/commands/look.py
@@ -1,8 +1,66 @@
 from __future__ import annotations
 
-def look_cmd(_arg: str, ctx) -> None:
-    # REPL loop triggers rendering for look; the command itself does nothing.
-    pass
+from copy import deepcopy
+from typing import Any, Dict
+
+from mutants.engine import edge_resolver as ER
+from mutants.registries import dynamics as dyn
+from mutants.registries.world import DELTA
+from mutants.app.context import build_room_vm
+
+DIR_MAP = {
+    "north": "N",
+    "n": "N",
+    "south": "S",
+    "s": "S",
+    "east": "E",
+    "e": "E",
+    "west": "W",
+    "w": "W",
+}
+
+
+def _active(state: Dict[str, Any]) -> Dict[str, Any]:
+    aid = state.get("active_id")
+    for p in state.get("players", []):
+        if p.get("id") == aid:
+            return p
+    return state["players"][0]
+
+
+def look_cmd(arg: str, ctx: Dict[str, Any]) -> None:
+    arg = (arg or "").strip().lower()
+    if not arg:
+        ctx["render_next"] = True
+        return
+
+    dir_code = DIR_MAP.get(arg)
+    if not dir_code:
+        ctx["feedback_bus"].push("LOOK/BAD_DIR", "Try north, south, east, or west.")
+        return
+
+    p = _active(ctx["player_state"])
+    year, x, y = p.get("pos", [0, 0, 0])
+    world = ctx["world_loader"](year)
+    dec = ER.resolve(world, dyn, year, x, y, dir_code, actor={})
+    if not dec.passable:
+        ctx["feedback_bus"].push("LOOK/BLOCKED", "You're blocked!")
+        return
+
+    dx, dy = DELTA[dir_code]
+    peek_state = deepcopy(ctx["player_state"])
+    p2 = _active(peek_state)
+    p2["pos"][1] = x + dx
+    p2["pos"][2] = y + dy
+    vm = build_room_vm(
+        peek_state,
+        ctx["world_loader"],
+        ctx["headers"],
+        ctx.get("monsters"),
+        ctx.get("items"),
+    )
+    ctx["peek_vm"] = vm
+    ctx["render_next"] = True
 
 
 def register(dispatch, ctx) -> None:

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -52,6 +52,8 @@ def move(dir_code: str, ctx: Dict[str, Any]) -> None:
     dx, dy = DELTA[dir_code]
     p["pos"][1] = x + dx
     p["pos"][2] = y + dy
+    # Successful movement requests a render of the new room.
+    ctx["render_next"] = True
     # Do not echo success movement like "You head north." Original shows next room immediately.
 
 

--- a/src/mutants/repl/loop.py
+++ b/src/mutants/repl/loop.py
@@ -28,9 +28,10 @@ def main() -> None:
             break
 
         token, _, arg = raw.strip().partition(" ")
-        handled = dispatch.call(token, arg)
+        dispatch.call(token, arg)
 
-        if handled in {"north", "south", "east", "west", "look"}:
+        if ctx.get("render_next"):
             render_frame(ctx)
+            ctx["render_next"] = False
         else:
             flush_feedback(ctx)

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -45,3 +45,25 @@ def test_boundary_blocks_movement():
     assert p["pos"] == [2000, 14, 0]
     events = ctx["feedback_bus"].drain()
     assert any(ev["kind"] == "MOVE/BLOCKED" and ev["text"] == "You're blocked!" for ev in events)
+
+
+def test_peek_direction_renders_adjacent_room(capsys):
+    ctx = make_ctx()
+    p = active(ctx["player_state"])
+    p["pos"] = [2000, 0, 0]
+    look_cmd("north", ctx)
+    assert ctx["render_next"]
+    render_frame(ctx)
+    out = capsys.readouterr().out
+    assert "You're in an abandoned building." in out
+    assert p["pos"] == [2000, 0, 0]
+
+
+def test_peek_blocked_does_not_render():
+    ctx = make_ctx()
+    p = active(ctx["player_state"])
+    p["pos"] = [2000, 14, 0]
+    look_cmd("east", ctx)
+    assert not ctx["render_next"]
+    events = ctx["feedback_bus"].drain()
+    assert any(ev["kind"] == "LOOK/BLOCKED" for ev in events)


### PR DESCRIPTION
## Summary
- Switch REPL to outcome-driven rendering keyed by `ctx['render_next']`
- Add directional `look` command that peeks adjacent rooms and skips render when blocked
- Render helpers now support peek VMs and non-rendering commands flush feedback
- Movement commands request render only on successful moves
- Tests cover peeking success and blocked cases

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c55d5bbf94832b8a1fbaa998b00a23