### PR TITLE
Implement throw command to drop items in adjacent rooms

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -142,8 +142,9 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 
 ### Systems
 
-#### Item Transfers (Get/Drop)
+#### Item Transfers (Get/Drop/Throw)
 * **Service**: `services/item_transfer.py` centralizes rules and persistence for moving items **ground ↔ inventory**. It enforces **first-match only** (prefix by display name), **INV_CAP=10**, **GROUND_CAP=6**, and the overflow behavior (random item swap) for player commands. **Worn armor is excluded from inventory operations** and is only affected by the `remove` command.
+* **Throw**: `throw_to_neighbor(ctx, dir, prefix)` performs a drop at the adjacent tile, sharing `drop`’s armor exclusion and overflow semantics. If the neighbor ground is full, a random ground item will enter the player’s inventory (same as `drop`).
 * **Ordering**: Ground display and “first-match” selection use a **stable insertion order** grouped by first-seen display name so duplicates appear adjacent. Inventory order is pickup order (FIFO).
 * **Persistence**: Inventory is stored in `state/playerlivestate.json` as `inventory: [iid,...]`. Ground is represented by setting/clearing `pos` on instances in `state/items/instances.json`. All writes use atomic saves.
 
@@ -180,7 +181,7 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
   - `run_argcmd_positional(ctx, spec, arg, do_action)`: tokenizes (quotes allowed); validates each arg by kind (`direction`, `item_in_inventory`, `literal('ions')`, `integer_range(min,max)`); missing args → usage; parse errors → reason-coded warn; else call `do_action(**values)`.
 * **Adoption**:
   - `get` and `drop` use `run_argcmd`.
-  - Future two-arg commands (POINT, THROW, `BUY ions [amount]` at maintenance shops) will use `run_argcmd_positional` with the minimal arg kinds above.
+  - Two-arg commands (e.g., **THROW**) use `run_argcmd_positional` with `direction` + `item_in_inventory`; THROW never requests a render (feedback only).
 * **Armor rule**: any **inventory** arg-kind excludes worn armor; armor is not targetable by `get/drop/look/throw/point/buy`. Only `remove` operates on the armor slot.
 
 ## Router Prefix Rule (new)

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -90,6 +90,7 @@ At startup (once per calendar day), the game performs a **litter reset**:
 - Inventory is an **ordered list of instance IDs** in `state/playerlivestate.json`; worn armor lives separately and isn't counted.
 - `get <prefix>` picks the **first matching** ground item (by display-name prefix). If this pushes inventory over **10**, a random inventory item falls to the ground (overflow, swapping with a random ground item if the tile already has six).
 - `drop <prefix>` drops the first matching inventory item (pickup order, excluding worn armor). If ground exceeds **6**, a random ground item pops into inventory and may drop another if inventory would exceed 10.
+- `throw <dir> <prefix>` acts like **drop to the adjacent tile** in `dir` (north/south/east/west). It uses the same caps/overflow rules as `drop` and **never renders** the tile; it only pushes feedback (e.g., “You throw the Skull north.”).
 - `inv` prints inventory with the same naming rules as the ground list.
 
 ## Argument-Command Framework (updated)

--- a/docs/ui_invariants.md
+++ b/docs/ui_invariants.md
@@ -23,3 +23,9 @@
 - Two-argument commands declare ordered arg kinds; missing args result in a **usage** message; parse errors map to stable **reason codes** (e.g., `invalid_direction`, `invalid_amount_range`, `wrong_item_literal`).
 - Inventory arg kinds **exclude worn armor**; only `remove` may act on armor.
 
+## Throw UX (new)
+- `throw [direction] [item]` behaves like dropping that item onto the adjacent tile. It never renders a tile; it pushes feedback:
+  - Success: “You throw the {item} {dir}.”
+  - Invalid direction / no neighbor: “You can’t throw that way.”
+  - Not carrying / armor: same messages as `drop`.
+

--- a/src/mutants/commands/throw.py
+++ b/src/mutants/commands/throw.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from typing import Dict, Any
+from .argcmd import PosArg, PosArgSpec, run_argcmd_positional
+from ..services import item_transfer as itx
+
+
+def _do_throw(ctx: Dict[str, Any], dir: str, item: str) -> Dict[str, Any]:
+    return itx.throw_to_neighbor(ctx, dir, item)
+
+
+def throw_cmd(arg: str, ctx: Dict[str, Any]) -> None:
+    spec = PosArgSpec(
+        verb="THROW",
+        args=[PosArg("dir", "direction"), PosArg("item", "item_in_inventory")],
+        messages={
+            "usage": "Type THROW [direction] [item].",
+            "invalid": "You can't throw that way.",
+            "success": "You throw the {item} {dir}.",
+        },
+        reason_messages={
+            "invalid_direction": "That isn't a valid direction.",
+            "not_carrying": "You're not carrying a {item}.",
+            "not_found": "You're not carrying a {item}.",
+            "inventory_empty": "You have nothing to throw.",
+            "armor_cannot_drop": "You can't throw what you're wearing.",
+            "no_target_tile": "You can't throw that way.",
+        },
+        success_kind="COMBAT/THROW",
+        warn_kind="SYSTEM/WARN",
+    )
+
+    run_argcmd_positional(ctx, spec, arg, lambda **kw: _do_throw(ctx, **kw))
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("throw", lambda arg: throw_cmd(arg, ctx))
+

--- a/tests/test_throw_cmd.py
+++ b/tests/test_throw_cmd.py
@@ -1,0 +1,57 @@
+import types
+from src.mutants.commands import throw as throw_cmd
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, kind, text, **_):
+        self.events.append((kind, text))
+
+    def drain(self):
+        ev, self.events = self.events, []
+        return ev
+
+
+def _ctx():
+    return {"feedback_bus": FakeBus(), "player_state": {"pos": (2000, 5, 5)}}
+
+
+def test_throw_usage_when_missing_args():
+    ctx = _ctx()
+    throw_cmd.throw_cmd("north", ctx)
+    assert ctx["feedback_bus"].events == [("SYSTEM/WARN", "Type THROW [direction] [item].")]
+
+
+def test_throw_invalid_direction_warns():
+    ctx = _ctx()
+    orig = throw_cmd.itx.throw_to_neighbor
+    try:
+        throw_cmd.itx.throw_to_neighbor = lambda *a, **k: {"ok": False, "reason": "invalid_direction"}
+        throw_cmd.throw_cmd("up skull", ctx)
+        assert ("SYSTEM/WARN", "That isn't a valid direction.") in ctx["feedback_bus"].events
+    finally:
+        throw_cmd.itx.throw_to_neighbor = orig
+
+
+def test_throw_not_carrying_warns(monkeypatch):
+    ctx = _ctx()
+    monkeypatch.setattr(
+        throw_cmd.itx,
+        "throw_to_neighbor",
+        lambda ctx, dir, prefix: {"ok": False, "reason": "not_found"},
+    )
+    throw_cmd.throw_cmd("n skull", ctx)
+    assert ("SYSTEM/WARN", "You're not carrying a skull.") in ctx["feedback_bus"].events
+
+
+def test_throw_success_feedback(monkeypatch):
+    ctx = _ctx()
+    monkeypatch.setattr(
+        throw_cmd.itx, "throw_to_neighbor", lambda ctx, dir, prefix: {"ok": True}
+    )
+    throw_cmd.throw_cmd("north skull", ctx)
+    assert ("COMBAT/THROW", "You throw the skull north.") in ctx["feedback_bus"].events
+    assert ctx.get("render_next") is not True
+


### PR DESCRIPTION
## Summary
- add `throw` command using positional argument runner
- support dropping inventory items onto adjacent tiles with overflow rules
- document throw semantics and update UI invariants

## Testing
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=./src python -m mutants <<'EOF'
logs trace ui on
debug add item skull 1
get skull
inv
throw north skull
look
EOF`
- `PYTHONPATH=./src python -m mutants <<'EOF'
debug add item skull 1
get skull
throw north zz
EOF`
- `PYTHONPATH=./src python -m mutants <<'EOF'
logs trace ui on
debug add item skull 1
inv
throw
throw up skull
throw north zz
throw north skull
look
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68c57526e5c0832bbd4a334abef4845d