### PR TITLE
Make daily litter import-safe and harden theme loading

### DIFF
--- a/src/mutants/ui/themes.py
+++ b/src/mutants/ui/themes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 
 DEFAULT_WIDTH = 80
@@ -22,14 +22,30 @@ class Theme:
 
 def load_theme(path: str) -> Theme:
     p = Path(path)
-    data: Dict[str, str] = {}
+    data: Dict[str, Any] = {}
     if p.exists():
-        data = json.loads(p.read_text(encoding="utf-8"))
-    width = int(data.get("width", data.get("WIDTH", DEFAULT_WIDTH)))
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+
+    width_raw = data.get("width", data.get("WIDTH", DEFAULT_WIDTH))
+    try:
+        width = int(width_raw)
+    except (TypeError, ValueError):
+        width = DEFAULT_WIDTH
+
     name = data.get("name", p.stem if p.exists() else "default")
-    colors_path = data.get("colors_path")
-    ansi_enabled = bool(data.get("ansi_enabled", True))
-    palette: Dict[str, str] = {}  # legacy palettes no longer used
+    colors_path = data.get("colors_path") if isinstance(data.get("colors_path"), str) else None
+
+    ansi_raw = data.get("ansi_enabled", True)
+    if isinstance(ansi_raw, str):
+        ansi_enabled = ansi_raw.lower() == "true"
+    else:
+        ansi_enabled = bool(ansi_raw)
+
+    palette = data.get("palette") if isinstance(data.get("palette"), dict) else {}
+
     return Theme(
         name=name,
         width=width,


### PR DESCRIPTION
## Summary
- compute daily-litter paths at runtime and allow root override
- require boolean `spawnable` flags and fix daily-litter logging
- harden theme loader against missing/invalid JSON

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a38e2a68832ba14b29ca8035a33b