### PR TITLE
feat: add throw command

### DIFF
--- a/src/mutants/commands/argcmd.py
+++ b/src/mutants/commands/argcmd.py
@@ -198,6 +198,15 @@ def run_argcmd_positional(
         bus.push(spec.warn_kind, msg or "Nothing happens.")
         return
 
-    success = _fmt((spec.messages or {}).get("success"), **values) or f"{spec.verb.title()} OK."
+    fmt_vals = dict(values)
+    name = (
+        decision.get("display_name")
+        or decision.get("name")
+        or decision.get("item_name")
+    )
+    if name:
+        fmt_vals.setdefault("name", name)
+
+    success = _fmt((spec.messages or {}).get("success"), **fmt_vals) or f"{spec.verb.title()} OK."
     bus.push(spec.success_kind, success)
 

--- a/src/mutants/commands/throw.py
+++ b/src/mutants/commands/throw.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+from ..services import item_transfer as itx
+from ..ui import item_display as idisp
+from .argcmd import PosArg, PosArgSpec, run_argcmd_positional
+
+def throw_cmd(arg: str, ctx):
+    spec = PosArgSpec(
+        verb="THROW",
+        args=[PosArg("dir", "direction"), PosArg("item", "item_in_inventory")],
+        messages={
+            "usage": "Type THROW [direction] [item].",
+            "invalid": "You're not carrying a {item}.",
+            "success": "You throw the {name} {dir}.",
+        },
+        reason_messages={
+            "inventory_empty": "You have nothing to throw.",
+            "armor_cannot_drop": "You can't throw what you're wearing.",
+            "not_found": "You're not carrying a {item}.",
+        },
+        success_kind="COMBAT/THROW",
+        warn_kind="SYSTEM/WARN",
+    )
+
+    def action(dir: str, item: str):
+        dec = itx.throw_to_direction(ctx, dir, item)
+        if dec.get("ok") and dec.get("iid"):
+            dec["display_name"] = idisp.canonical_name_from_iid(dec["iid"])
+        return dec
+
+    run_argcmd_positional(ctx, spec, arg, action)
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("throw", lambda arg: throw_cmd(arg, ctx))

--- a/tests/test_argcmd_positional_core.py
+++ b/tests/test_argcmd_positional_core.py
@@ -51,6 +51,25 @@ def test_throw_success_message_uses_values():
     assert ctx["feedback_bus"].events == [("COMBAT/THROW", "You throw the skull north.")]
 
 
+def test_success_message_can_use_display_name():
+    ctx = _ctx()
+    spec = PosArgSpec(
+        verb="THROW",
+        args=[PosArg("dir", "direction"), PosArg("item", "item_in_inventory")],
+        messages={"success": "You throw the {name} {dir}."},
+        success_kind="COMBAT/THROW",
+    )
+    run_argcmd_positional(
+        ctx,
+        spec,
+        "n sk",
+        lambda **kw: {"ok": True, "display_name": "Skull"},
+    )
+    assert ctx["feedback_bus"].events == [
+        ("COMBAT/THROW", "You throw the Skull north."),
+    ]
+
+
 def test_buy_ions_amount_range_and_gate_messages():
     ctx = _ctx()
     spec = PosArgSpec(

--- a/tests/test_throw_command.py
+++ b/tests/test_throw_command.py
@@ -1,0 +1,61 @@
+import json, shutil
+from pathlib import Path
+
+from src.mutants.commands.throw import throw_cmd
+from src.mutants.registries import items_instances as itemsreg
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, kind, text, **_):
+        self.events.append((kind, text))
+
+
+def _ctx():
+    return {"feedback_bus": FakeBus()}
+
+
+def _copy_state(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+
+
+def test_throw_moves_item_to_adjacent_tile(monkeypatch, tmp_path):
+    src_state = Path(__file__).resolve().parents[1] / "state"
+    dst_state = tmp_path / "state"
+    _copy_state(src_state, dst_state)
+    monkeypatch.chdir(tmp_path)
+
+    iid = itemsreg.create_and_save_instance("nuclear_decay", 2000, 0, 0)
+    itemsreg.clear_position(iid)
+
+    pfile = Path("state/playerlivestate.json")
+    with pfile.open("r", encoding="utf-8") as f:
+        pdata = json.load(f)
+    pdata["inventory"] = [iid]
+    with pfile.open("w", encoding="utf-8") as f:
+        json.dump(pdata, f)
+
+    ctx = _ctx()
+    ctx["player_state"] = {
+        "active_id": pdata["players"][0]["id"],
+        "players": [
+            {"id": pdata["players"][0]["id"], "pos": [2000, 0, 0]}
+        ],
+    }
+
+    throw_cmd("north nuclear", ctx)
+
+    bus_events = ctx["feedback_bus"].events
+    assert bus_events == [
+        ("COMBAT/THROW", "You throw the Nuclear-Decay north."),
+    ]
+
+    inst = itemsreg.get_instance(iid)
+    assert inst.get("pos", {}).get("x") == 0
+    assert inst.get("pos", {}).get("y") == -1
+
+    with pfile.open("r", encoding="utf-8") as f:
+        pdata_after = json.load(f)
+    assert pdata_after.get("inventory") == []


### PR DESCRIPTION
## Summary
- allow positional commands to format success messages with resolved item names
- support throwing items to adjacent tiles with drop-style overflow
- wire up THROW command and tests

## Testing
- `PYTHONPATH=src:. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5ae3930fc832b8b16af5670044738