### PR TITLE
Add gate-closing command

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -22,6 +22,7 @@ This repeats each turn.
 ## Where things live
 - **REPL**: `repl/loop.py` (the metronome), `repl/dispatch.py` (command router).
 - **Commands**: `commands/*.py` (movement, theme, logs, etc.).
+  - New: `close <dir>` closes an adjacent **gate** on the current tile (mirrors the state to the neighbor tile’s opposite edge). Feedback shows “You’ve just closed the north gate.”
 - **App context**: `app/context.py` (wires player state, world loader, renderer, theme, feedback bus).
 - **UI**: `ui/renderer.py` (layout), `ui/formatters.py` (phrasing), `ui/themes.py` (loads colors), `ui/styles.py` (token names), `ui/wrap.py` (80-col lists).
 - **Color Groups** (new): text fragments are tagged with semantic groups like `compass.line`, `dir.open`, `dir.blocked`, `room.title`, `room.desc`. A single JSON file (`state/ui/colors.json`) maps each group to a color name so palette tweaks require no code edits. `styles.resolve_color_for_group(group)` handles dotted fallback (`compass.line` → `compass.*` → default).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 - Fix: Ground item list no longer breaks hyphenated names across lines.
 - Hardening: Item display names render hyphens as U+2011 (no-break hyphen) to
   resist misconfigured wrappers.
+- Feature: `close <dir>` command to close an adjacent gate; mirrors neighbor edge and logs `GATE/CLOSE`.
 - Change: `get`/`drop` now require a subject argument; typing them alone shows usage instead of acting implicitly.
 - UX: `get`/`drop` emit explicit success feedback with item names, and clearer invalid messages (“There isn’t a {subject} here.” / “You’re not carrying a {subject}. ”). Worn armor remains excluded from inventory operations (only `remove` can affect armor).
 - Router: All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** keep one-letter forms (`n/s/e/w`). Ambiguous prefixes now warn and do nothing.

--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -120,6 +120,19 @@ Disable tracing when done:
 logs trace ui off
 ```
 
+## Gate operations
+
+- **Close a gate** in a given direction from your current tile:
+  ```
+  close n
+  ```
+  Feedback: `You've just closed the north gate.`  
+  A log line is written:
+  ```
+  GATE/CLOSE {"pos":"(xE : yN)","dir":"N"}
+  ```
+  After closing, `look` will show `north - closed gate.` and trying to move that way will be blocked.
+
 ## Debug helpers
 - **Add items to current tile** (for quick setup while testing):
   ```

--- a/src/mutants/commands/close.py
+++ b/src/mutants/commands/close.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mutants.registries.world import BASE_GATE
+
+DIRS = {
+    "n": "N",
+    "north": "N",
+    "s": "S",
+    "south": "S",
+    "e": "E",
+    "east": "E",
+    "w": "W",
+    "west": "W",
+}
+
+DIR_WORD = {"N": "north", "S": "south", "E": "east", "W": "west"}
+
+
+def _active(state: Dict[str, Any]) -> Dict[str, Any]:
+    aid = state.get("active_id")
+    for p in state.get("players", []):
+        if p.get("id") == aid:
+            return p
+    return state["players"][0]
+
+
+def register(dispatch, ctx) -> None:
+    bus = ctx["feedback_bus"]
+    logsink = ctx.get("logsink")
+
+    def cmd(arg: str) -> None:
+        token = (arg or "").strip().split()
+        if not token:
+            bus.push("SYSTEM/INFO", "Type CLOSE [direction] to close a gate.")
+            return
+        d0 = token[0].lower()
+        if d0 not in DIRS:
+            bus.push("SYSTEM/WARN", f"Unknown direction: {token[0]}")
+            return
+        D = DIRS[d0]
+
+        p = _active(ctx["player_state"])
+        year, x, y = p.get("pos", [0, 0, 0])
+        world = ctx["world_loader"](year)
+        tile = world.get_tile(x, y)
+        if not tile:
+            bus.push("SYSTEM/WARN", "Current tile not found.")
+            return
+        edge = tile["edges"].get(D, {})
+        gs = edge.get("gate_state")
+        if edge.get("base") != BASE_GATE or gs not in (1, 2):
+            bus.push("SYSTEM/WARN", "There is no gate to close that way.")
+            return
+        if gs == 2:
+            bus.push("SYSTEM/INFO", f"The {d0} gate is already closed.")
+            return
+
+        world.set_edge(x, y, D, gate_state=2, force_gate_base=True)
+        world.save()
+
+        bus.push("SYSTEM/OK", f"You've just closed the {DIR_WORD[D]} gate.")
+        if logsink:
+            logsink.handle({
+                "ts": "",
+                "kind": "GATE/CLOSE",
+                "text": f"{{\"pos\":\"({x}E : {y}N)\",\"dir\":\"{D}\"}}",
+            })
+
+    dispatch.register("close", cmd)


### PR DESCRIPTION
## Summary
- add `close` command to shut a neighboring gate and mirror the opposite edge
- document gate-closing command and log output

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=src python -m mutants <<'EOF'
help
EOF`
- `PYTHONPATH=src python -m mutants <<'EOF'
close
EOF`
- `PYTHONPATH=src python -m mutants <<'EOF'
look
close n
look
n
logs tail 50
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68c5b2e866dc832baee1efc9b887c407