### PR TITLE
Handle closing open gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,6 @@
   - README troubleshooting section.
   - ARCHITECTURE notes on cwd dependence and fallback.
   - New `docs/LOGGING.md`.
+
+### Fixed
+- CLOSE [direction] now detects gates by type and closes open gates.

--- a/src/mutants/commands/close.py
+++ b/src/mutants/commands/close.py
@@ -48,16 +48,19 @@ def register(dispatch, ctx) -> None:
         if not tile:
             bus.push("SYSTEM/WARN", "Current tile not found.")
             return
-        edge = tile["edges"].get(D, {})
-        gs = edge.get("gate_state")
-        if edge.get("base") != BASE_GATE or gs not in (1, 2):
+        edge = (tile.get("edges") or {}).get(D, {}) or {}
+        base = edge.get("base", 0)
+        gs = edge.get("gate_state", 0)
+
+        if base != BASE_GATE:
             bus.push("SYSTEM/WARN", "There is no gate to close that way.")
             return
-        if gs == 2:
+
+        if gs in (1, 2):
             bus.push("SYSTEM/INFO", f"The {d0} gate is already closed.")
             return
 
-        world.set_edge(x, y, D, gate_state=2, force_gate_base=True)
+        world.set_edge(x, y, D, gate_state=1, force_gate_base=True)
         world.save()
 
         bus.push("SYSTEM/OK", f"You've just closed the {DIR_WORD[D]} gate.")

--- a/tests/commands/test_close_gate.py
+++ b/tests/commands/test_close_gate.py
@@ -1,0 +1,75 @@
+import types
+
+from mutants.commands import close as close_cmd
+from mutants.repl.dispatch import Dispatch
+from mutants.registries.world import BASE_GATE
+
+
+class DummyWorld:
+    def __init__(self, edge):
+        self._edge = edge
+        self.saved = False
+
+    def get_tile(self, x, y):
+        return {"edges": {"W": self._edge}}
+
+    def set_edge(self, x, y, D, *, gate_state=None, force_gate_base=False):
+        if force_gate_base:
+            self._edge["base"] = BASE_GATE
+        if gate_state is not None:
+            self._edge["gate_state"] = gate_state
+
+    def save(self):
+        self.saved = True
+
+
+def mk_ctx(edge):
+    bus = types.SimpleNamespace(msgs=[])
+
+    def push(chan, msg):
+        bus.msgs.append((chan, msg))
+
+    bus.push = push
+    world = DummyWorld(edge)
+    ctx = {
+        "feedback_bus": bus,
+        "player_state": {
+            "active_id": 1,
+            "players": [{"id": 1, "pos": [2000, 0, 0]}],
+        },
+        "world_loader": lambda year: world,
+    }
+    return world, ctx, bus
+
+
+def run_close(ctx, arg):
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+    close_cmd.register(dispatch, ctx)
+    dispatch.call("close", arg)
+
+
+def test_close_on_open_gate_sets_closed():
+    edge = {"base": BASE_GATE, "gate_state": 0}
+    world, ctx, bus = mk_ctx(edge)
+    run_close(ctx, "west")
+    assert edge["gate_state"] == 1
+    assert world.saved is True
+    assert ("SYSTEM/OK", "You've just closed the west gate.") in bus.msgs
+
+
+def test_close_on_already_closed_gate_informs():
+    edge = {"base": BASE_GATE, "gate_state": 1}
+    world, ctx, bus = mk_ctx(edge)
+    run_close(ctx, "west")
+    assert edge["gate_state"] == 1
+    assert world.saved is False
+    assert ("SYSTEM/INFO", "The west gate is already closed.") in bus.msgs
+
+
+def test_close_when_no_gate_warns():
+    edge = {"base": 0, "gate_state": 0}
+    world, ctx, bus = mk_ctx(edge)
+    run_close(ctx, "west")
+    assert world.saved is False
+    assert ("SYSTEM/WARN", "There is no gate to close that way.") in bus.msgs


### PR DESCRIPTION
## Summary
- allow CLOSE command to operate on open gates by checking edge type rather than state
- add tests covering closing open, closed, and missing gates
- document fix in changelog

## Testing
- `PYTHONPATH=src:. pytest`
- `PYTHONPATH=src:. pytest tests/commands/test_close_gate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5d73279b0832b907f7d8ab85243fa