### PR TITLE
Add OPEN command to reopen gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - `WORLD_DEBUG` env flag for detailed logs.
   - `WORLD_STRICT` env flag to fail on missing world JSONs.
 - Logs for discovery, world loading, nearest-year fallback, and minimal world creation.
+- Command: `open <dir>` reopens a closed gate.
 - Documentation:
   - README troubleshooting section.
   - ARCHITECTURE notes on cwd dependence and fallback.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -23,6 +23,7 @@ This repeats each turn.
 - **REPL**: `repl/loop.py` (the metronome), `repl/dispatch.py` (command router).
 - **Commands**: `commands/*.py` (movement, theme, logs, etc.).
   - New: `close <dir>` closes an adjacent **gate** on the current tile (mirrors the state to the neighbor tile’s opposite edge). Feedback shows “You’ve just closed the north gate.”
+  - New: `open <dir>` reopens a closed gate. Feedback shows “You've just opened the north gate.” Locked gates remain locked.
 - **App context**: `app/context.py` (wires player state, world loader, renderer, theme, feedback bus).
 - **UI**: `ui/renderer.py` (layout), `ui/formatters.py` (phrasing), `ui/themes.py` (loads colors), `ui/styles.py` (token names), `ui/wrap.py` (80-col lists).
 - **Color Groups** (new): text fragments are tagged with semantic groups like `compass.line`, `dir.open`, `dir.blocked`, `room.title`, `room.desc`. A single JSON file (`state/ui/colors.json`) maps each group to a color name so palette tweaks require no code edits. `styles.resolve_color_for_group(group)` handles dotted fallback (`compass.line` → `compass.*` → default).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 - Hardening: Item display names render hyphens as U+2011 (no-break hyphen) to
   resist misconfigured wrappers.
 - Feature: `close <dir>` command to close an adjacent gate; mirrors neighbor edge and logs `GATE/CLOSE`.
+- Feature: `open <dir>` command to open a closed gate; mirrors neighbor edge and logs `GATE/OPEN`.
 - Change: `get`/`drop` now require a subject argument; typing them alone shows usage instead of acting implicitly.
 - UX: `get`/`drop` emit explicit success feedback with item names, and clearer invalid messages (“There isn’t a {subject} here.” / “You’re not carrying a {subject}. ”). Worn armor remains excluded from inventory operations (only `remove` can affect armor).
 - Router: All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** keep one-letter forms (`n/s/e/w`). Ambiguous prefixes now warn and do nothing.

--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -126,12 +126,18 @@ logs trace ui off
   ```
   close n
   ```
-  Feedback: `You've just closed the north gate.`  
+  Feedback: `You've just closed the north gate.`
   A log line is written:
   ```
   GATE/CLOSE {"pos":"(xE : yN)","dir":"N"}
   ```
   After closing, `look` will show `north - closed gate.` and trying to move that way will be blocked.
+
+- **Open a gate** in a given direction (if it's closed):
+  ```
+  open n
+  ```
+  Feedback: `You've just opened the north gate.`
 
 ## Debug helpers
 - **Add items to current tile** (for quick setup while testing):

--- a/src/mutants/commands/open.py
+++ b/src/mutants/commands/open.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mutants.registries.world import BASE_GATE
+
+DIRS = {
+    "n": "N",
+    "north": "N",
+    "s": "S",
+    "south": "S",
+    "e": "E",
+    "east": "E",
+    "w": "W",
+    "west": "W",
+}
+
+DIR_WORD = {"N": "north", "S": "south", "E": "east", "W": "west"}
+
+
+def _active(state: Dict[str, Any]) -> Dict[str, Any]:
+    aid = state.get("active_id")
+    for p in state.get("players", []):
+        if p.get("id") == aid:
+            return p
+    return state["players"][0]
+
+
+def register(dispatch, ctx) -> None:
+    bus = ctx["feedback_bus"]
+    logsink = ctx.get("logsink")
+
+    def cmd(arg: str) -> None:
+        token = (arg or "").strip().split()
+        if not token:
+            bus.push("SYSTEM/INFO", "Type OPEN [direction] to open a gate.")
+            return
+        d0 = token[0].lower()
+        if d0 not in DIRS:
+            bus.push("SYSTEM/WARN", f"Unknown direction: {token[0]}")
+            return
+        D = DIRS[d0]
+
+        p = _active(ctx["player_state"])
+        year, x, y = p.get("pos", [0, 0, 0])
+        world = ctx["world_loader"](year)
+        tile = world.get_tile(x, y)
+        if not tile:
+            bus.push("SYSTEM/WARN", "Current tile not found.")
+            return
+        edge = (tile.get("edges") or {}).get(D, {}) or {}
+        base = edge.get("base", 0)
+        gs = edge.get("gate_state", 0)
+
+        if base != BASE_GATE:
+            bus.push("SYSTEM/WARN", "There is no gate to open that way.")
+            return
+
+        if gs == 2:
+            bus.push("SYSTEM/WARN", "The gate is locked.")
+            return
+
+        if gs == 0:
+            bus.push("SYSTEM/INFO", f"The {d0} gate is already open.")
+            return
+
+        world.set_edge(x, y, D, gate_state=0, force_gate_base=True)
+        world.save()
+
+        bus.push("SYSTEM/OK", f"You've just opened the {DIR_WORD[D]} gate.")
+        if logsink:
+            logsink.handle({
+                "ts": "",
+                "kind": "GATE/OPEN",
+                "text": f"{{\"pos\":\"({x}E : {y}N)\",\"dir\":\"{D}\"}}",
+            })
+
+    dispatch.register("open", cmd)

--- a/tests/commands/test_open_gate.py
+++ b/tests/commands/test_open_gate.py
@@ -1,0 +1,84 @@
+import types
+
+from mutants.commands import open as open_cmd
+from mutants.repl.dispatch import Dispatch
+from mutants.registries.world import BASE_GATE
+
+
+class DummyWorld:
+    def __init__(self, edge):
+        self._edge = edge
+        self.saved = False
+
+    def get_tile(self, x, y):
+        return {"edges": {"W": self._edge}}
+
+    def set_edge(self, x, y, D, *, gate_state=None, force_gate_base=False):
+        if force_gate_base:
+            self._edge["base"] = BASE_GATE
+        if gate_state is not None:
+            self._edge["gate_state"] = gate_state
+
+    def save(self):
+        self.saved = True
+
+
+def mk_ctx(edge):
+    bus = types.SimpleNamespace(msgs=[])
+
+    def push(chan, msg):
+        bus.msgs.append((chan, msg))
+
+    bus.push = push
+    world = DummyWorld(edge)
+    ctx = {
+        "feedback_bus": bus,
+        "player_state": {
+            "active_id": 1,
+            "players": [{"id": 1, "pos": [2000, 0, 0]}],
+        },
+        "world_loader": lambda year: world,
+    }
+    return world, ctx, bus
+
+
+def run_open(ctx, arg):
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+    open_cmd.register(dispatch, ctx)
+    dispatch.call("open", arg)
+
+
+def test_open_on_closed_gate_sets_open():
+    edge = {"base": BASE_GATE, "gate_state": 1}
+    world, ctx, bus = mk_ctx(edge)
+    run_open(ctx, "west")
+    assert edge["gate_state"] == 0
+    assert world.saved is True
+    assert ("SYSTEM/OK", "You've just opened the west gate.") in bus.msgs
+
+
+def test_open_on_locked_gate_warns():
+    edge = {"base": BASE_GATE, "gate_state": 2}
+    world, ctx, bus = mk_ctx(edge)
+    run_open(ctx, "west")
+    assert edge["gate_state"] == 2
+    assert world.saved is False
+    assert ("SYSTEM/WARN", "The gate is locked.") in bus.msgs
+
+
+def test_open_when_already_open_informs():
+    edge = {"base": BASE_GATE, "gate_state": 0}
+    world, ctx, bus = mk_ctx(edge)
+    run_open(ctx, "west")
+    assert edge["gate_state"] == 0
+    assert world.saved is False
+    assert ("SYSTEM/INFO", "The west gate is already open.") in bus.msgs
+
+
+def test_open_when_no_gate_warns():
+    edge = {"base": 0, "gate_state": 0}
+    world, ctx, bus = mk_ctx(edge)
+    run_open(ctx, "west")
+    assert world.saved is False
+    assert ("SYSTEM/WARN", "There is no gate to open that way.") in bus.msgs


### PR DESCRIPTION
## Summary
- add `open` command to reopen nearby gates
- document new `open <dir>` command and log behavior
- cover gate opening scenarios with tests

## Testing
- `PYTHONPATH=.:src pytest` *(fails: test_move_commands.py::test_look_renders_room, test_move_commands.py::test_peek_direction_renders_adjacent_room)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e2a6f554832b9ada386fbd47eeee