### PR TITLE
Fix movement through closed gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,5 @@
 
 ### Fixed
 - CLOSE [direction] now detects gates by type and closes open gates.
+- Closed or locked gates now block movement; attempting to walk into one shows
+  "The {dir} gate is closed."

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -46,7 +46,12 @@ def move(dir_code: str, ctx: Dict[str, Any]) -> None:
             sink.handle({"ts": "", "kind": "MOVE/DECISION", "text": json.dumps(payload)})
 
     if not dec.passable:
-        ctx["feedback_bus"].push("MOVE/BLOCKED", "You're blocked!")
+        if dec.reason == "closed_gate":
+            ctx["feedback_bus"].push(
+                "MOVE/BLOCKED", f"The {DIR_WORD[dir_code]} gate is closed."
+            )
+        else:
+            ctx["feedback_bus"].push("MOVE/BLOCKED", "You're blocked!")
         return
 
     dx, dy = DELTA[dir_code]

--- a/tests/commands/test_move_blocked_by_closed_gate.py
+++ b/tests/commands/test_move_blocked_by_closed_gate.py
@@ -1,0 +1,48 @@
+import types
+
+from mutants.commands.move import move
+from mutants.registries.world import BASE_GATE, GATE_CLOSED, GATE_OPEN
+
+
+class DummyWorld:
+    def __init__(self, cur_edge, nbr_edge):
+        self.cur_edge = cur_edge
+        self.nbr_edge = nbr_edge
+
+    def get_tile(self, year, x, y):
+        if (x, y) == (0, 0):
+            return {"edges": {"W": self.cur_edge}}
+        if (x, y) == (-1, 0):
+            return {"edges": {"E": self.nbr_edge}}
+        return {"edges": {}}
+
+
+def mk_ctx(cur_edge, nbr_edge):
+    bus = types.SimpleNamespace(msgs=[])
+
+    def push(chan, msg):
+        bus.msgs.append((chan, msg))
+
+    bus.push = push
+    world = DummyWorld(cur_edge, nbr_edge)
+    ctx = {
+        "feedback_bus": bus,
+        "player_state": {
+            "active_id": 1,
+            "players": [{"id": 1, "pos": [2000, 0, 0]}],
+        },
+        "world_loader": lambda year: world,
+        "render_next": False,
+    }
+    return ctx, bus
+
+
+def test_move_blocked_message():
+    cur = {"base": BASE_GATE, "gate_state": GATE_CLOSED}
+    nbr = {"base": BASE_GATE, "gate_state": GATE_CLOSED}
+    ctx, bus = mk_ctx(cur, nbr)
+    move("W", ctx)
+    assert ("MOVE/BLOCKED", "The west gate is closed.") in bus.msgs
+    # ensure player did not move
+    p = ctx["player_state"]["players"][0]
+    assert p["pos"] == [2000, 0, 0]

--- a/tests/engine/test_edge_resolver_gates.py
+++ b/tests/engine/test_edge_resolver_gates.py
@@ -1,0 +1,23 @@
+from mutants.engine import edge_resolver as er
+from mutants.registries.world import BASE_GATE, BASE_OPEN, GATE_OPEN, GATE_CLOSED
+
+
+def mk_edge(base, gs=GATE_OPEN):
+    return {"base": base, "gate_state": gs}
+
+
+def test_open_gate_is_passable_both_sides():
+    a, b = mk_edge(BASE_GATE, GATE_OPEN), mk_edge(BASE_GATE, GATE_OPEN)
+    assert er._passable_pair(a, b) is True
+
+
+def test_closed_gate_blocks():
+    a, b = mk_edge(BASE_GATE, GATE_CLOSED), mk_edge(BASE_GATE, GATE_CLOSED)
+    assert er._passable_pair(a, b) is False
+    assert er._block_reason(a, b) == "closed_gate"
+
+
+def test_one_sided_closed_gate_blocks_conservatively():
+    a, b = mk_edge(BASE_GATE, GATE_CLOSED), mk_edge(BASE_OPEN, GATE_OPEN)
+    assert er._passable_pair(a, b) is False
+    assert er._block_reason(a, b) == "closed_gate"


### PR DESCRIPTION
## Summary
- ensure edge resolution blocks closed or locked gates and records block reason
- show "The {dir} gate is closed." when movement is blocked by a gate
- test gate passability and movement feedback for closed gates

## Testing
- `PYTHONPATH=src:. pytest tests/engine/test_edge_resolver_gates.py tests/commands/test_move_blocked_by_closed_gate.py`
- `PYTHONPATH=src:. pytest` *(fails: tests/test_move_commands.py::test_look_renders_room, tests/test_move_commands.py::test_peek_direction_renders_adjacent_room)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e52efde0832b859b77b0afff305f