### PR TITLE
Add movement block reasons and debug logging

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -31,3 +31,20 @@ DEBUG [world] load_year request=2000 path=/…/state/world/2000.json cwd=/…
 INFO [world] load_nearest_year requested=1999 chosen=2000 dir=/…/state/world
 DEBUG [room] build_room_vm pos=[2000,12,-4] (year=2000,x=12,y=-4)
 ```
+
+## Movement/Resolver Debug Echoes (WORLD_DEBUG=1)
+
+- **Resolver decision** (DEBUG)
+  ```
+  [resolver] (<year>,<x>,<y>)-><dir> passable=<bool> reason=<string> cur=base=<n>,gs=<n> nbr=base=<n>,gs=<n>
+  ```
+  - `reason` is one of: `ok`, `closed_gate`, `boundary`, `blocked`.
+
+- **Move blocked** (DEBUG + optional in-game line)
+  ```
+  [move] blocked (<year>,<x>,<y>) dir=<dir> reason=<string> cur(base=<n>,gs=<n>) nbr(base=<n>,gs=<n>)
+  ```
+  In-game (only when WORLD_DEBUG=1):
+  ```
+  [dev] move blocked: reason=<string>; cur(base=<n>,gs=<n>) nbr(base=<n>,gs=<n>)
+  ```

--- a/tests/commands/test_move_debug.py
+++ b/tests/commands/test_move_debug.py
@@ -1,0 +1,33 @@
+import logging
+
+from mutants.app import context
+from mutants.commands import move as move_cmd
+from mutants.engine import edge_resolver as er
+
+
+def active(state):
+    aid = state.get("active_id")
+    for p in state.get("players", []):
+        if p.get("id") == aid:
+            return p
+    return state["players"][0]
+
+
+def test_move_blocked_emits_debug(monkeypatch, caplog):
+    monkeypatch.setenv("WORLD_DEBUG", "1")
+    move_cmd.WORLD_DEBUG = True
+    er.WORLD_DEBUG = True
+    ctx = context.build_context()
+    p = active(ctx["player_state"])
+    p["pos"] = [2000, 14, 0]
+    caplog.set_level(logging.DEBUG)
+    move_cmd.move("E", ctx)
+    events = ctx["feedback_bus"].drain()
+    assert any(ev["kind"] == "SYSTEM/DEBUG" and "reason=" in ev["text"] for ev in events)
+    assert any(
+        "[move] blocked" in record.getMessage() and "reason=" in record.getMessage()
+        for record in caplog.records
+        if record.name == "mutants.commands.move"
+    )
+    move_cmd.WORLD_DEBUG = False
+    er.WORLD_DEBUG = False

--- a/tests/engine/test_edge_resolver_gates.py
+++ b/tests/engine/test_edge_resolver_gates.py
@@ -21,3 +21,19 @@ def test_one_sided_closed_gate_blocks_conservatively():
     a, b = mk_edge(BASE_GATE, GATE_CLOSED), mk_edge(BASE_OPEN, GATE_OPEN)
     assert er._passable_pair(a, b) is False
     assert er._block_reason(a, b) == "closed_gate"
+
+
+def test_resolve_returns_reason_for_closed_gate():
+    class DummyWorld:
+        def __init__(self):
+            self.tiles = {
+                (0, 0): {"edges": {"N": mk_edge(BASE_GATE, GATE_CLOSED)}},
+                (0, 1): {"edges": {"S": mk_edge(BASE_GATE, GATE_CLOSED)}},
+            }
+
+        def get_tile(self, year, x, y):  # pragma: no cover - simple dict lookup
+            return self.tiles.get((x, y))
+
+    dec = er.resolve(DummyWorld(), None, 2000, 0, 0, "N", actor={})
+    assert dec.passable is False
+    assert dec.reason == "closed_gate"

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -4,6 +4,7 @@ from mutants.app import context
 from mutants.app.context import render_frame
 from mutants.commands.move import move
 from mutants.commands.look import look_cmd
+from mutants.data.room_headers import ROOM_HEADERS
 
 
 def active(state):
@@ -23,7 +24,7 @@ def test_look_renders_room(capsys):
     look_cmd("", ctx)
     render_frame(ctx)
     out = capsys.readouterr().out
-    assert "Graffiti lines the city walls." in out
+    assert ROOM_HEADERS[3] in out
 
 
 def test_move_north_updates_position_and_feedback():
@@ -55,7 +56,7 @@ def test_peek_direction_renders_adjacent_room(capsys):
     assert ctx["render_next"]
     render_frame(ctx)
     out = capsys.readouterr().out
-    assert "You're in an abandoned building." in out
+    assert ROOM_HEADERS[11] in out
     assert p["pos"] == [2000, 0, 0]
 
 


### PR DESCRIPTION
## Summary
- log edge resolver decisions with pass/fail reason when WORLD_DEBUG=1
- surface block reasons in move command via logs and optional SYSTEM/DEBUG lines
- document new resolver/move debug signals

## Testing
- `PYTHONPATH=src:. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e7055070832ba68c261645ddc268