### PR TITLE
Validate debug add-item against catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@
 - CLOSE [direction] now detects gates by type and closes open gates.
 - Closed or locked gates now block movement; attempting to walk into one shows
   "The {dir} gate is closed."
+- Debug add-item now validates against state/items/catalog.json; unknown or
+  ambiguous names are rejected with suggestions.

--- a/src/mutants/commands/additem.py
+++ b/src/mutants/commands/additem.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+from mutants.app import context as appctx
+from mutants.registries import items_instances as itemsreg
+from mutants.registries import items as items_registry
+import os, logging
+
+LOG = logging.getLogger(__name__)
+WORLD_DEBUG = os.getenv("WORLD_DEBUG") == "1"
+
+
+def _pos_from_ctx() -> tuple[int, int, int]:
+    ctx = appctx.current_context() if hasattr(appctx, "current_context") else None
+    if not ctx:
+        return 0, 0, 0
+    state = ctx.get("player_state", {})
+    aid = state.get("active_id")
+    for pl in state.get("players", []):
+        if pl.get("id") == aid:
+            pos = pl.get("pos") or [0, 0, 0]
+            return int(pos[0]), int(pos[1]), int(pos[2])
+    pos = state.get("players", [{}])[0].get("pos") or [0, 0, 0]
+    return int(pos[0]), int(pos[1]), int(pos[2])
+
+
+def handle(tokens, bus):
+    # Expected usage: ADD <item_name_or_id> [count]
+    if len(tokens) < 2:
+        bus.push("SYSTEM/INFO", "Usage: ADD <item> [count]")
+        return
+    item_token = tokens[1]
+    count = 1
+    if len(tokens) >= 3:
+        try:
+            count = max(1, min(99, int(tokens[2])))
+        except ValueError:
+            pass
+
+    # New: resolve token against catalog; reject unknowns/gibberish.
+    resolved, suggestions = items_registry.resolve_item(item_token)
+    if not resolved:
+        hint = ""
+        if suggestions:
+            hint = " Try: " + ", ".join(suggestions[:5])
+        bus.push("SYSTEM/WARN", f"Unknown item '{item_token}'.{hint}")
+        if WORLD_DEBUG:
+            LOG.debug("[additem] reject token=%r suggestions=%r", item_token, suggestions)
+        return
+
+    # Choose canonical id to spawn (prefer catalog 'id')
+    item_id = resolved.get("id") or resolved.get("name")
+
+    # proceed with existing placement logic using item_id and count...
+    year, x, y = _pos_from_ctx()
+    for _ in range(count):
+        itemsreg.create_and_save_instance(item_id, year, x, y, origin="debug_add")
+    bus.push("DEBUG", f"added {count} x {item_id} at ({x},{y}).")
+
+
+def add_cmd(arg: str, ctx) -> None:
+    tokens = ["add"] + arg.strip().split()
+    bus = ctx.get("feedback_bus") if isinstance(ctx, dict) else None
+    if bus is None:
+        bus = type("Bus", (), {"push": lambda *a, **k: None})()
+    handle(tokens, bus)
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("add", lambda arg: add_cmd(arg, ctx))

--- a/src/mutants/registries/items.py
+++ b/src/mutants/registries/items.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+from pathlib import Path
+import json, time, difflib
+from typing import Dict, Any, Tuple, Optional
+
+# Reuse STATE from runtime so paths are consistent with the rest of the app.
+try:
+    from mutants.bootstrap.runtime import STATE
+except Exception:
+    STATE = Path("state")
+
+_ITEMS_PATH = STATE / "items" / "catalog.json"
+_CACHE: Dict[str, Any] = {}
+_CACHE_MTIME: Optional[float] = None
+
+def _load_raw() -> Dict[str, Any]:
+    with _ITEMS_PATH.open() as f:
+        return json.load(f)
+
+def _normalize(s: str) -> str:
+    return "".join(s.lower().split())
+
+def _rebuild_index(data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Expected catalog format examples:
+      {"items": [{"id":"nuclear-waste","name":"Nuclear-Waste", ...}, ...]}
+      or a dict keyed by id. We index both id and name.
+    """
+    items = []
+    if isinstance(data, dict) and "items" in data and isinstance(data["items"], list):
+        items = data["items"]
+    elif isinstance(data, dict):
+        # fallback: dict keyed by id
+        items = [{"id": k, **(v or {})} for k, v in data.items()]
+    else:
+        raise ValueError("Unrecognized items catalog format")
+
+    index: Dict[str, Dict[str, Any]] = {}
+    names: Dict[str, str] = {}
+    for it in items:
+        iid = str(it.get("id") or "").strip()
+        name = str(it.get("name") or iid).strip()
+        if not iid:
+            continue
+        for key in {iid, name}:
+            if key:
+                index[_normalize(key)] = it
+        names[name] = iid
+    return {"items": items, "index": index, "names": names}
+
+def _ensure_cache() -> Dict[str, Any]:
+    global _CACHE, _CACHE_MTIME
+    mtime = _ITEMS_PATH.stat().st_mtime
+    if _CACHE and _CACHE_MTIME == mtime:
+        return _CACHE
+    data = _load_raw()
+    _CACHE = _rebuild_index(data)
+    _CACHE_MTIME = mtime
+    return _CACHE
+
+def resolve_item(token: str) -> Tuple[Optional[Dict[str, Any]], list[str]]:
+    """
+    Resolve a user token to a catalog item. Returns (item_or_None, suggestions).
+    - Exact match on id or name (case/space-insensitive) wins.
+    - Else, unique prefix match on normalized keys.
+    - Else, return suggestions using difflib on visible names.
+    """
+    token_norm = _normalize(token)
+    cache = _ensure_cache()
+    idx = cache["index"]
+    if token_norm in idx:
+        return idx[token_norm], []
+
+    # Unique prefix over normalized keys
+    candidates = [v for k, v in idx.items() if k.startswith(token_norm)]
+    # Deduplicate same object references (id and name both index the same dict)
+    uniq = []
+    seen_ids = set()
+    for c in candidates:
+        cid = c.get("id")
+        if cid not in seen_ids:
+            seen_ids.add(cid)
+            uniq.append(c)
+    if len(uniq) == 1:
+        return uniq[0], []
+
+    # Suggestions: use pretty names (fallback to ids)
+    names = list(cache["names"].keys())
+    sug = difflib.get_close_matches(token, names, n=5, cutoff=0.6)
+    if not sug:
+        # also try IDs
+        ids = [it.get("id", "") for it in cache["items"]]
+        sug = difflib.get_close_matches(token, ids, n=5, cutoff=0.6)
+    return None, sug

--- a/tests/commands/test_additem_validation.py
+++ b/tests/commands/test_additem_validation.py
@@ -1,0 +1,47 @@
+import types
+
+
+def _fake_catalog(monkeypatch, items):
+    from mutants.registries import items as reg
+
+    def _fake_load_raw():
+        return {"items": items}
+
+    monkeypatch.setattr(reg, "_load_raw", _fake_load_raw)
+    # Force cache rebuild each test
+    monkeypatch.setattr(reg, "_CACHE", {}, raising=False)
+    monkeypatch.setattr(reg, "_CACHE_MTIME", None, raising=False)
+
+
+def test_reject_unknown_item(monkeypatch):
+    _fake_catalog(monkeypatch, [{"id": "nuclear-waste", "name": "Nuclear-Waste"}])
+
+    # Build a minimal bus and command context
+    bus = types.SimpleNamespace(msgs=[])
+    bus.push = lambda ch, m: bus.msgs.append((ch, m))
+
+    from mutants.commands import additem as cmd
+    cmd.handle(["add", "zzzzz"], bus)
+
+    assert any("Unknown item" in m for _, m in bus.msgs)
+
+
+def test_accept_exact_id(monkeypatch):
+    _fake_catalog(monkeypatch, [{"id": "nuclear-waste", "name": "Nuclear-Waste"}])
+    bus = types.SimpleNamespace(msgs=[])
+    bus.push = lambda ch, m: bus.msgs.append((ch, m))
+    from mutants.commands import additem as cmd
+
+    # You may need to patch the spawn side-effect; here we assert no rejection message.
+    cmd.handle(["add", "nuclear-waste", "2"], bus)
+    assert not any("Unknown item" in m for _, m in bus.msgs)
+
+
+def test_accept_unique_prefix(monkeypatch):
+    _fake_catalog(monkeypatch, [{"id": "nuclear-waste", "name": "Nuclear-Waste"}])
+    bus = types.SimpleNamespace(msgs=[])
+    bus.push = lambda ch, m: bus.msgs.append((ch, m))
+    from mutants.commands import additem as cmd
+
+    cmd.handle(["add", "nuclear"], bus)
+    assert not any("Unknown item" in m for _, m in bus.msgs)


### PR DESCRIPTION
## Summary
- add cached item catalog registry with normalized lookup and suggestions
- validate ADD command tokens against catalog with clear warnings
- test and document item validation in changelog

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ec51f2cc832b9f9933c674c7459b