### PR TITLE
Improve debug add item fuzzy matching

### DIFF
--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -142,9 +142,9 @@ logs trace ui off
 ## Debug helpers
 - **Add items to current tile** (for quick setup while testing):
   ```
-  debug add item <item_id> [count]
+  debug add item <id|prefix|"Display Name"> [count]
   ```
-  Places one or more instances of `<item_id>` at your current coordinates. Useful to check wrapping of hyphenated names and inventory/ground overflow behavior quickly.
+  Accepts catalog IDs (preferred), unique prefixes, or display names with or without quotes. Matching is case-insensitive and ignores leading articles (`a`, `an`, `the`). Hyphens and underscores are interchangeable for catalog IDs. Places one or more instances at your current coordinates. Useful to check wrapping of hyphenated names and inventory/ground overflow behavior quickly.
 
 ## What Tracing Logs
 

--- a/tests/commands/test_debug_add_item.py
+++ b/tests/commands/test_debug_add_item.py
@@ -1,0 +1,60 @@
+import pytest
+
+from mutants.app import context
+from mutants.commands import debug as debug_cmd
+
+
+def _setup(monkeypatch):
+    ctx = context.build_context()
+    calls = []
+
+    def fake_create(item_id, year, x, y, origin="debug_add"):
+        calls.append(item_id)
+
+    monkeypatch.setattr(debug_cmd.itemsreg, "create_and_save_instance", fake_create)
+    return ctx, calls
+
+
+def _run(cmd, ctx):
+    debug_cmd.debug_cmd(cmd, ctx)
+    return ctx["feedback_bus"].drain()
+
+
+def test_exact_catalog_id(monkeypatch):
+    ctx, calls = _setup(monkeypatch)
+    events = _run("add item nuclear_waste", ctx)
+    assert calls == ["nuclear_waste"]
+    assert any("added" in ev["text"] for ev in events)
+
+
+def test_prefix_match(monkeypatch):
+    ctx, calls = _setup(monkeypatch)
+    _run("add item nuclear-w", ctx)
+    assert calls == ["nuclear_waste"]
+
+
+def test_display_name_match(monkeypatch):
+    ctx, calls = _setup(monkeypatch)
+    _run("add item Nuclear-Thong", ctx)
+    assert calls == ["nuclear_thong"]
+
+
+def test_quoted_name_with_article(monkeypatch):
+    ctx, calls = _setup(monkeypatch)
+    _run('add item "A Nuclear-Thong"', ctx)
+    assert calls == ["nuclear_thong"]
+
+
+def test_ambiguous_input_warns(monkeypatch):
+    ctx, calls = _setup(monkeypatch)
+    events = _run("add item nuclear", ctx)
+    assert calls == []
+    assert any("Ambiguous item ID" in ev["text"] for ev in events)
+
+
+def test_unknown_input_warns(monkeypatch):
+    ctx, calls = _setup(monkeypatch)
+    events = _run("add item junkfoo", ctx)
+    assert calls == []
+    assert any("Unknown item" in ev["text"] for ev in events)
+


### PR DESCRIPTION
## Summary
- allow `debug add item` to match catalog IDs, prefixes, or display names
- document flexible debug item lookup
- cover fuzzy item matches with tests

## Testing
- `PYTHONPATH=src pytest tests/commands/test_debug_add_item.py -q`
- `PYTHONPATH=src:. pytest -q` *(fails: fixture 'ctx' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6051e4d74832b91c8d5a91e1c8d95