### PR TITLE
feat: normalize item names

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,3 +7,8 @@ support unique prefixes, so `throw n nuc` will throw the Nuclear-Decay north if
 it's the only match. Thrown items always leave your inventory. If the throw is
 blocked (no exit, closed gate, or map boundary) the item lands at your feet.
 Throw uses the same passability rules as movement for consistency.
+
+### Input normalization
+All item-token parsing should use `normalize_item_query()` from `mutants.util.textnorm`.
+This guarantees consistent behavior across commands (debug/use/equip/throw) and lets us evolve
+the normalization rules in one place.

--- a/docs/logging_and_tracing.md
+++ b/docs/logging_and_tracing.md
@@ -142,9 +142,12 @@ logs trace ui off
 ## Debug helpers
 - **Add items to current tile** (for quick setup while testing):
   ```
-  debug add item <id|prefix|"Display Name"> [count]
+  debug add item <item_id_or_name> [count]
   ```
-  Accepts catalog IDs (preferred), unique prefixes, or display names with or without quotes. Matching is case-insensitive and ignores leading articles (`a`, `an`, `the`). Hyphens and underscores are interchangeable for catalog IDs. Places one or more instances at your current coordinates. Useful to check wrapping of hyphenated names and inventory/ground overflow behavior quickly.
+  Notes:
+  - The command is case-insensitive and accepts quotes and leading articles (A/An/The).
+  - Unicode punctuation and multiple spaces are normalized automatically.
+  - Prefer catalog IDs (e.g., `nuclear-waste`), but display names like `"A Nuclear-Thong"` also work if fuzzy matching is enabled.
 
 ## What Tracing Logs
 

--- a/src/mutants/util/textnorm.py
+++ b/src/mutants/util/textnorm.py
@@ -1,0 +1,31 @@
+import re
+import unicodedata
+
+_ARTICLES = {"a", "an", "the"}
+
+def normalize_item_query(s: str | None) -> str:
+    """
+    Normalize a user-entered item query into a canonical, hyphenated token.
+    Examples:
+      '  "A  Nuclear–Thong"  ' -> 'nuclear-thong'
+      "the Nuclear Thong"      -> 'nuclear-thong'
+      "NUCLEAR-TH"             -> 'nuclear-th'
+    """
+    if not s:
+        return ""
+    # Unicode normalize (turn “smart” punctuation into consistent forms)
+    s = unicodedata.normalize("NFKC", s)
+    # Trim whitespace and outer quotes (including Unicode quotes)
+    s = s.strip()
+    s = s.strip("'\"“”‘’")
+    s = s.strip()
+    # Lowercase
+    s = s.lower()
+    # Drop leading articles
+    parts = s.split()
+    if parts and parts[0] in _ARTICLES:
+        parts = parts[1:]
+    s = " ".join(parts)
+    # Replace any non-alnum run with a single hyphen; trim edge hyphens
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s

--- a/tests/util/test_textnorm.py
+++ b/tests/util/test_textnorm.py
@@ -1,0 +1,20 @@
+from mutants.util.textnorm import normalize_item_query
+
+
+def test_normalize_basic():
+    assert normalize_item_query("Nuclear-Thong") == "nuclear-thong"
+    assert normalize_item_query("  the Nuclear Thong  ") == "nuclear-thong"
+
+
+def test_normalize_quotes_unicode():
+    assert normalize_item_query('"A  Nuclear–Thong"') == "nuclear-thong"
+    assert normalize_item_query("‘An  Ion—Decay’") == "ion-decay"
+
+
+def test_normalize_prefix_preserved():
+    assert normalize_item_query("NUCLEAR-TH") == "nuclear-th"
+
+
+def test_normalize_empty_safe():
+    assert normalize_item_query("") == ""
+    assert normalize_item_query(None) == ""


### PR DESCRIPTION
## Summary
- add `normalize_item_query` helper for canonical item-name tokens
- use common normalizer in `debug add item`
- document and test item input normalization

## Testing
- `PYTHONPATH=src python -m pytest tests/util/test_textnorm.py tests/commands/test_debug_add_item.py`
- `PYTHONPATH=src python -m pytest` *(fails: fixture 'ctx' not found in tests/test_throw_command.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b85715c8832b987c18f07d27d533