### PR TITLE
docs: add utilities index and references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@
   - `WORLD_STRICT` env flag to fail on missing world JSONs.
 - Logs for discovery, world loading, nearest-year fallback, and minimal world creation.
 - Command: `open <dir>` reopens a closed gate.
+- Item token normalization helper for consistent item parsing.
+- Debug add item supports fuzzy matching.
 - Documentation:
   - README troubleshooting section.
   - ARCHITECTURE notes on cwd dependence and fallback.
   - New `docs/LOGGING.md`.
+### Changed
+- Throw command drops the item at your feet if the direction is blocked.
+- Item catalog coerces legacy `"yes"`/`"no"` flags to booleans.
+- Player save data accepts both `"armor"` and `"armour"` spellings.
 
 ### Fixed
 - CLOSE [direction] now detects gates by type and closes open gates.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 This repo is a Codespaces-ready Python skeleton for the Mutants project.
 It intentionally contains **no game logic**. Start adding code under `src/mutants/`.
 
+## Documentation
+- [Architecture overview](docs/architecture_overview.md)
+- [Commands](docs/commands.md)
+- [Items](docs/items.md)
+- [Utilities](docs/utilities.md)
+
 ## Quick start (Codespaces)
 - Open in GitHub Codespaces.
 - The container installs the package in editable mode.
@@ -33,4 +39,3 @@ WORLD_DEBUG=1 python -m mutants
 
 Common pitfall: running from the wrong folder. If the game can't find world JSONs
 it will create a minimal world unless `WORLD_STRICT=1` is set.
-

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,9 +6,20 @@
 support unique prefixes, so `throw n nuc` will throw the Nuclear-Decay north if
 it's the only match. Thrown items always leave your inventory. If the throw is
 blocked (no exit, closed gate, or map boundary) the item lands at your feet.
-Throw uses the same passability rules as movement for consistency.
+Throw uses the same passability rules as movement for consistency. Item names
+are parsed via the normalization helper (see [utilities](utilities.md)).
 
-### Input normalization
-All item-token parsing should use `normalize_item_query()` from `mutants.util.textnorm`.
-This guarantees consistent behavior across commands (debug/use/equip/throw) and lets us evolve
-the normalization rules in one place.
+## Debug Add Item
+
+`debug add item <name>` spawns an item into your inventory. Item names are
+parsed via the normalization helper (see [utilities](utilities.md)).
+
+## Equip
+
+`equip <item>` equips an item from your inventory. Item names are parsed via
+the normalization helper (see [utilities](utilities.md)).
+
+## Use
+
+`use <item>` activates an item's effect. Item names are parsed via the
+normalization helper (see [utilities](utilities.md)).

--- a/docs/items.md
+++ b/docs/items.md
@@ -4,3 +4,5 @@ The item catalog at `state/items/catalog.json` now uses JSON booleans for
 flags such as `enchantable`, `armour`, and `ranged`.  Legacy catalogs that
 still contain the strings `"yes"` or `"no"` are automatically coerced to
 boolean values when loaded.
+
+See also: [utilities](utilities.md).

--- a/docs/state.md
+++ b/docs/state.md
@@ -3,3 +3,5 @@
 The player save data accepts either `armor` or `armour` for the equipped
 item. On load, the engine normalizes to the canonical `armor` field so
 both spellings are compatible.
+
+See also: [utilities](utilities.md).

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1,0 +1,58 @@
+# Utilities and Shared Services
+
+This document lists core helpers and cross-cutting services that all commands
+and systems should use. Referencing this page prevents "re-inventing" logic.
+
+---
+
+## Item Token Normalization
+
+**Function:** `mutants.util.textnorm.normalize_item_query(s: str) -> str`
+
+- Normalizes user input into canonical, hyphenated tokens.
+- Handles:
+  - Lowercasing
+  - Stripping quotes and whitespace
+  - Removing leading articles (`a`, `an`, `the`)
+  - Normalizing Unicode punctuation (e.g., en/em dashes)
+  - Converting non-alphanumeric runs to `-`
+
+**Examples:**
+- `"A  Nuclear–Thong"` → `nuclear-thong`
+- `the Nuclear Thong` → `nuclear-thong`
+- `NUCLEAR-TH` → `nuclear-th`
+
+**Usage:**
+- Must be applied in all item-related commands (`debug add item`, `throw`,
+  `equip`, `use`).
+- Do not write ad-hoc regex; always import this helper.
+
+---
+
+## Passability Service
+
+- The service that determines if movement (or throwing) can proceed in a given
+  direction.
+- Centralized logic: gates, map boundaries, spell effects (walls of ice, ion
+  fields), etc.
+- **Rule:** Any mechanic that tests "can I go in that direction?" must use this
+  service. Throw relies on it just like movement.
+
+---
+
+## Logging Sink
+
+**Class:** `mutants.ui.logsink.LogSink`
+
+- Unified interface for recording events.
+- Preferred API: `add(kind, text, ts)`
+- Legacy shim: `handle(ev: dict)` for callers passing dicts.
+- Do not roll your own logging; always go through the sink.
+
+---
+
+## Why These Matter
+
+These utilities make behavior consistent across the codebase. If new features
+need item parsing, passability checks, or logs, they *must* reference these
+helpers. Update this doc when new utilities are introduced.


### PR DESCRIPTION
## Summary
- document item token normalization, passability checks, and logging sink in a new utilities index
- cross-reference the normalization helper from throw, debug add item, equip, and use docs
- link items and state docs to utilities and surface doc links in the README and changelog

## Testing
- `PYTHONPATH="src:." pytest` *(fails: fixture 'ctx' not found in tests/test_throw_command.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c71cf283dc832ba4be77f7dcd111a3