### PR TITLE
Allow direction prefixes

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -100,6 +100,7 @@ Commands that take a **subject argument** use a small runner to keep UX consiste
 - `commands/argcmd.py` exposes `ArgSpec` + `run_argcmd(ctx, spec, arg, do_action)` for single-arg commands (e.g., GET/DROP) and `PosArgSpec` + `run_argcmd_positional(...)` for two-arg commands (e.g., POINT, THROW, and the limited `BUY ions [amount]` form).
 - `ArgSpec`/`PosArgSpec` declare the **arg policy** (`required|optional|forbidden`), **argument kinds** (e.g., `direction`, `item_in_inventory`, `integer_range`, `literal('ions')`), **message templates** (usage/invalid/success), optional **reason→message** mapping, and the **feedback kinds** for success/warn.
 - Runners handle: trim/tokenize → usage on empty/missing → parse & validate each argument → call `do_action(...)` → map failure `reason` to a message → push explicit success feedback using parsed values (e.g., `{dir}`, `{item}`, `{amt}`) or resolved item names.
+- Item tokens are normalized via `mutants.util.textnorm.normalize_item_query`; direction tokens go through `mutants.util.directions.resolve_dir`.
 
 ### Command Prefix Rule (router)
 - All commands accept **≥3-letter unique prefixes** (case-insensitive). Only **north/south/east/west** allow single-letter forms (`n/s/e/w`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,4 +13,5 @@
 - Framework: Added positional-args runner for two-argument commands (POINT/THROW and the restricted `BUY ions [100000-999999]` at maintenance shops); docs and minimal tests included.
 - Change: Item `spawnable` flags now use JSON booleans; migration script included.
 - Logging: Daily litter reset logs when no eligible spawnables remain for a year.
+- Change: Direction tokens now accept any prefix of the full word in movement and command arguments.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,11 @@
 # Commands
 
+## Movement
+
+Typing a direction moves you to an adjacent tile. Any prefix of the full word
+is accepted, case-insensitively: `w`/`we`/`wes`/`west`,
+`n`/`no`/`nor`/`nort`/`north`, and similarly for `east` and `south`.
+
 ## Get
 
 `get <item>` picks up an item from the ground. Item names are parsed via the
@@ -8,12 +14,24 @@ match the prefix, the first one in the ground list is picked up.
 
 ## Throw
 
-`throw <direction> <item>` throws an item into an adjacent tile. Item names
-support unique prefixes, so `throw n nuc` will throw the Nuclear-Decay north if
-it's the only match. Thrown items always leave your inventory. If the throw is
-blocked (no exit, closed gate, or map boundary) the item lands at your feet.
-Throw uses the same passability rules as movement for consistency. Item names
-are parsed via the normalization helper (see [utilities](utilities.md)).
+`throw <direction> <item>` throws an item into an adjacent tile. Direction
+arguments accept any prefix of the full word, e.g. `throw we ion-p` throws the
+Ion-Pistol west. Item names support unique prefixes, so `throw n nuc` will throw
+the Nuclear-Decay north if it's the only match. Thrown items always leave your
+inventory. If the throw is blocked (no exit, closed gate, or map boundary) the
+item lands at your feet. Throw uses the same passability rules as movement for
+consistency. Item names are parsed via the normalization helper (see
+[utilities](utilities.md)).
+
+## Open
+
+`open <direction>` reopens a closed gate. Direction arguments accept any prefix
+of the full word (e.g. `open no` opens the north gate).
+
+## Close
+
+`close <direction>` closes an adjacent gate. Direction arguments accept any
+prefix of the full word (e.g. `close so` closes the south gate).
 
 ## Debug Add Item
 

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -29,6 +29,26 @@ and systems should use. Referencing this page prevents "re-inventing" logic.
 
 ---
 
+## Direction Token Resolver
+
+**Function:** `mutants.util.directions.resolve_dir(token: str) -> str | None`
+
+- Resolves a user-entered direction token to `"north"`, `"south"`,
+  `"east"`, or `"west"`.
+- Accepts any prefix of the full word, case-insensitively (`we` → `west`,
+  `nor` → `north`).
+
+**Examples:**
+- `resolve_dir("w")` → `"west"`
+- `resolve_dir("sou")` → `"south"`
+- `resolve_dir("")` → `None`
+
+**Usage:**
+- All direction parsing—standalone movement and command arguments—must use this
+  resolver. Do not implement per-command direction logic.
+
+---
+
 ## Passability Service
 
 - The service that determines if movement (or throwing) can proceed in a given

--- a/src/mutants/commands/argcmd.py
+++ b/src/mutants/commands/argcmd.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import shlex
 
+from mutants.util.directions import resolve_dir
+
 
 # ---------- Single-argument runner ----------
 
@@ -90,19 +92,8 @@ def _tokenize(s: str) -> List[str]:
     return shlex.split(s or "")
 
 
-def _parse_direction(tok: str) -> Optional[str]:
-    if not tok:
-        return None
-    t = tok.lower()
-    if t in ("n", "north"):
-        return "north"
-    if t in ("s", "south"):
-        return "south"
-    if t in ("e", "east"):
-        return "east"
-    if t in ("w", "west"):
-        return "west"
-    return None
+def coerce_direction(tok: str) -> Optional[str]:
+    return resolve_dir(tok)
 
 
 def _parse_int_range(tok: str, lo: int, hi: int) -> Optional[int]:
@@ -125,7 +116,7 @@ def _parse_by_kind(tok: str, kind: str) -> Tuple[Optional[Any], Optional[str]]:
     Only kinds needed for POINT/THROW/BUY-ions are implemented.
     """
     if kind == "direction":
-        v = _parse_direction(tok)
+        v = coerce_direction(tok)
         return (v, None if v else "invalid_direction")
     if kind == "item_in_inventory":
         # Parsing is pass-through; actual resolution happens in the action/service.

--- a/src/mutants/commands/close.py
+++ b/src/mutants/commands/close.py
@@ -4,18 +4,7 @@ from typing import Any, Dict
 
 from mutants.registries.world import BASE_GATE
 
-DIRS = {
-    "n": "N",
-    "north": "N",
-    "s": "S",
-    "south": "S",
-    "e": "E",
-    "east": "E",
-    "w": "W",
-    "west": "W",
-}
-
-DIR_WORD = {"N": "north", "S": "south", "E": "east", "W": "west"}
+from .argcmd import coerce_direction
 
 
 def _active(state: Dict[str, Any]) -> Dict[str, Any]:
@@ -35,11 +24,11 @@ def register(dispatch, ctx) -> None:
         if not token:
             bus.push("SYSTEM/INFO", "Type CLOSE [direction] to close a gate.")
             return
-        d0 = token[0].lower()
-        if d0 not in DIRS:
+        dir_full = coerce_direction(token[0])
+        if not dir_full:
             bus.push("SYSTEM/WARN", f"Unknown direction: {token[0]}")
             return
-        D = DIRS[d0]
+        D = dir_full[0].upper()
 
         p = _active(ctx["player_state"])
         year, x, y = p.get("pos", [0, 0, 0])
@@ -57,13 +46,13 @@ def register(dispatch, ctx) -> None:
             return
 
         if gs in (1, 2):
-            bus.push("SYSTEM/INFO", f"The {d0} gate is already closed.")
+            bus.push("SYSTEM/INFO", f"The {dir_full} gate is already closed.")
             return
 
         world.set_edge(x, y, D, gate_state=1, force_gate_base=True)
         world.save()
 
-        bus.push("SYSTEM/OK", f"You've just closed the {DIR_WORD[D]} gate.")
+        bus.push("SYSTEM/OK", f"You've just closed the {dir_full} gate.")
         if logsink:
             logsink.handle({
                 "ts": "",

--- a/src/mutants/commands/open.py
+++ b/src/mutants/commands/open.py
@@ -4,18 +4,7 @@ from typing import Any, Dict
 
 from mutants.registries.world import BASE_GATE
 
-DIRS = {
-    "n": "N",
-    "north": "N",
-    "s": "S",
-    "south": "S",
-    "e": "E",
-    "east": "E",
-    "w": "W",
-    "west": "W",
-}
-
-DIR_WORD = {"N": "north", "S": "south", "E": "east", "W": "west"}
+from .argcmd import coerce_direction
 
 
 def _active(state: Dict[str, Any]) -> Dict[str, Any]:
@@ -35,11 +24,11 @@ def register(dispatch, ctx) -> None:
         if not token:
             bus.push("SYSTEM/INFO", "Type OPEN [direction] to open a gate.")
             return
-        d0 = token[0].lower()
-        if d0 not in DIRS:
+        dir_full = coerce_direction(token[0])
+        if not dir_full:
             bus.push("SYSTEM/WARN", f"Unknown direction: {token[0]}")
             return
-        D = DIRS[d0]
+        D = dir_full[0].upper()
 
         p = _active(ctx["player_state"])
         year, x, y = p.get("pos", [0, 0, 0])
@@ -61,13 +50,13 @@ def register(dispatch, ctx) -> None:
             return
 
         if gs == 0:
-            bus.push("SYSTEM/INFO", f"The {d0} gate is already open.")
+            bus.push("SYSTEM/INFO", f"The {dir_full} gate is already open.")
             return
 
         world.set_edge(x, y, D, gate_state=0, force_gate_base=True)
         world.save()
 
-        bus.push("SYSTEM/OK", f"You've just opened the {DIR_WORD[D]} gate.")
+        bus.push("SYSTEM/OK", f"You've just opened the {dir_full} gate.")
         if logsink:
             logsink.handle({
                 "ts": "",

--- a/src/mutants/repl/dispatch.py
+++ b/src/mutants/repl/dispatch.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 import sys
 from typing import Callable, Dict, List, Optional
 
+from mutants.util.directions import resolve_dir
+
 
 class Dispatch:
     """
@@ -60,6 +62,12 @@ class Dispatch:
         return None
 
     def call(self, token: str, arg: str) -> Optional[str]:
+        dir_name = resolve_dir(token)
+        if dir_name and dir_name in self._cmds:
+            fn = self._cmds.get(dir_name)
+            if fn:
+                fn(arg)
+            return dir_name
         name = self._resolve_prefix(token)
         if not name:
             return None

--- a/src/mutants/util/directions.py
+++ b/src/mutants/util/directions.py
@@ -1,0 +1,15 @@
+CANONICAL_DIRS = ("north", "south", "east", "west")
+
+def resolve_dir(token: str) -> str | None:
+    """Resolve a direction *token* to its canonical full word.
+
+    The match is case-insensitive and accepts any unique prefix of the
+    canonical directions.
+    Returns the full canonical direction on a unique match or ``None`` if the
+    token is empty, ambiguous or invalid.
+    """
+    t = (token or "").strip().lower()
+    if not t:
+        return None
+    matches = [d for d in CANONICAL_DIRS if d.startswith(t)]
+    return matches[0] if len(matches) == 1 else None

--- a/tests/commands/test_close_gate.py
+++ b/tests/commands/test_close_gate.py
@@ -73,3 +73,11 @@ def test_close_when_no_gate_warns():
     run_close(ctx, "west")
     assert world.saved is False
     assert ("SYSTEM/WARN", "There is no gate to close that way.") in bus.msgs
+
+
+def test_close_accepts_prefix():
+    edge = {"base": BASE_GATE, "gate_state": 0}
+    world, ctx, bus = mk_ctx(edge)
+    run_close(ctx, "we")
+    assert edge["gate_state"] == 1
+    assert ("SYSTEM/OK", "You've just closed the west gate.") in bus.msgs

--- a/tests/commands/test_open_gate.py
+++ b/tests/commands/test_open_gate.py
@@ -82,3 +82,11 @@ def test_open_when_no_gate_warns():
     run_open(ctx, "west")
     assert world.saved is False
     assert ("SYSTEM/WARN", "There is no gate to open that way.") in bus.msgs
+
+
+def test_open_accepts_prefix():
+    edge = {"base": BASE_GATE, "gate_state": 1}
+    world, ctx, bus = mk_ctx(edge)
+    run_open(ctx, "we")
+    assert edge["gate_state"] == 0
+    assert ("SYSTEM/OK", "You've just opened the west gate.") in bus.msgs

--- a/tests/test_router_prefix.py
+++ b/tests/test_router_prefix.py
@@ -60,3 +60,16 @@ def test_ambiguous_prefix_warns():
         ('SYSTEM/WARN', 'Ambiguous command "dri" (did you mean: drink, drive)')
     ]
 
+
+def test_direction_prefix_without_alias():
+    d = _dispatch()
+    called = {}
+
+    def west(arg):
+        called['dir'] = 'west'
+
+    d.register('west', west)
+    d.call('we', '')
+    assert called.get('dir') == 'west'
+    assert d._bus.events == []
+

--- a/tests/test_throw_command.py
+++ b/tests/test_throw_command.py
@@ -109,6 +109,18 @@ def test_throw_abbreviation(monkeypatch, tmp_path):
     inst = itemsreg.get_instance(iid)
     assert inst.get("pos", {}).get("y") == -1
 
+
+def test_throw_direction_prefix(monkeypatch, tmp_path):
+    ctx, pfile, inv = _setup(monkeypatch, tmp_path, ["nuclear_decay"])
+    iid = inv[0]
+    throw_cmd("we nuclear", ctx)
+    bus_events = ctx["feedback_bus"].events
+    assert bus_events == [
+        ("COMBAT/THROW", "You throw the Nuclear-Decay west."),
+    ]
+    inst = itemsreg.get_instance(iid)
+    assert inst.get("pos", {}).get("x") == -1
+
 def test_throw_open_exit_goes_to_destination(ctx):
     item = ctx.items_instances.create_and_save_instance("nuclear-rock")
     ctx.player["inventory"] = [item["iid"]]

--- a/tests/util/test_directions.py
+++ b/tests/util/test_directions.py
@@ -1,0 +1,28 @@
+from mutants.util.directions import resolve_dir
+
+
+def test_all_prefixes_resolve():
+    assert resolve_dir("n") == "north"
+    assert resolve_dir("no") == "north"
+    assert resolve_dir("nor") == "north"
+    assert resolve_dir("nort") == "north"
+    assert resolve_dir("north") == "north"
+    assert resolve_dir("s") == "south"
+    assert resolve_dir("so") == "south"
+    assert resolve_dir("sou") == "south"
+    assert resolve_dir("sout") == "south"
+    assert resolve_dir("south") == "south"
+    assert resolve_dir("e") == "east"
+    assert resolve_dir("ea") == "east"
+    assert resolve_dir("eas") == "east"
+    assert resolve_dir("east") == "east"
+    assert resolve_dir("w") == "west"
+    assert resolve_dir("we") == "west"
+    assert resolve_dir("wes") == "west"
+    assert resolve_dir("west") == "west"
+
+
+def test_invalid_returns_none():
+    assert resolve_dir("") is None
+    assert resolve_dir("northwest") is None
+    assert resolve_dir("x") is None


### PR DESCRIPTION
## Summary
- Add shared direction resolver and integrate with movement and commands
- Update open/close/throw to accept direction prefixes
- Document direction prefix support

## Testing
- `PYTHONPATH=".:src" pytest tests/util/test_directions.py tests/test_router_prefix.py::test_direction_prefix_without_alias tests/commands/test_open_gate.py::test_open_accepts_prefix tests/commands/test_close_gate.py::test_close_accepts_prefix tests/test_throw_command.py::test_throw_direction_prefix -q`
- `PYTHONPATH=".:src" pytest` *(fails: fixture 'ctx' not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c72342c94c832bb8718b3483de0c5d