### PR TITLE
Use shared direction resolver in look command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,6 +6,12 @@ Typing a direction moves you to an adjacent tile. Any prefix of the full word
 is accepted, case-insensitively: `w`/`we`/`wes`/`west`,
 `n`/`no`/`nor`/`nort`/`north`, and similarly for `east` and `south`.
 
+## Look
+
+`look` shows the current room. `look <direction>` peeks into an adjacent tile
+without moving. Direction arguments accept any prefix of the full word (e.g.
+`look we` peeks west).
+
 ## Get
 
 `get <item>` picks up an item from the ground. Item names are parsed via the

--- a/src/mutants/commands/look.py
+++ b/src/mutants/commands/look.py
@@ -7,17 +7,9 @@ from mutants.engine import edge_resolver as ER
 from mutants.registries import dynamics as dyn
 from mutants.registries.world import DELTA
 from mutants.app.context import build_room_vm
+from .argcmd import coerce_direction
 
-DIR_MAP = {
-    "north": "N",
-    "n": "N",
-    "south": "S",
-    "s": "S",
-    "east": "E",
-    "e": "E",
-    "west": "W",
-    "w": "W",
-}
+DIR_CODE = {"north": "N", "south": "S", "east": "E", "west": "W"}
 
 
 def _active(state: Dict[str, Any]) -> Dict[str, Any]:
@@ -29,15 +21,17 @@ def _active(state: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def look_cmd(arg: str, ctx: Dict[str, Any]) -> None:
-    arg = (arg or "").strip().lower()
-    if not arg:
+    token = (arg or "").strip()
+    if not token:
         ctx["render_next"] = True
         return
 
-    dir_code = DIR_MAP.get(arg)
-    if not dir_code:
+    dir_full = coerce_direction(token)
+    if not dir_full:
         ctx["feedback_bus"].push("LOOK/BAD_DIR", "Try north, south, east, or west.")
         return
+
+    dir_code = DIR_CODE[dir_full]
 
     p = _active(ctx["player_state"])
     year, x, y = p.get("pos", [0, 0, 0])

--- a/src/mutants/util/directions.py
+++ b/src/mutants/util/directions.py
@@ -1,15 +1,20 @@
+from typing import Optional
+
 CANONICAL_DIRS = ("north", "south", "east", "west")
 
-def resolve_dir(token: str) -> str | None:
-    """Resolve a direction *token* to its canonical full word.
 
-    The match is case-insensitive and accepts any unique prefix of the
-    canonical directions.
-    Returns the full canonical direction on a unique match or ``None`` if the
-    token is empty, ambiguous or invalid.
+def resolve_dir(token: Optional[str]) -> Optional[str]:
+    """Resolve *token* to a canonical direction or ``None``.
+
+    Any unique prefix of the cardinal directions is accepted, case-insensitively.
+    ``None`` is returned for empty, invalid, or ambiguous tokens.
     """
-    t = (token or "").strip().lower()
+    if not token:
+        return None
+    t = token.strip().lower()
     if not t:
         return None
     matches = [d for d in CANONICAL_DIRS if d.startswith(t)]
-    return matches[0] if len(matches) == 1 else None
+    if len(matches) == 1:
+        return matches[0]
+    return None

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -60,6 +60,18 @@ def test_peek_direction_renders_adjacent_room(capsys):
     assert p["pos"] == [2000, 0, 0]
 
 
+def test_peek_direction_prefix_renders_adjacent_room(capsys):
+    ctx = make_ctx()
+    p = active(ctx["player_state"])
+    p["pos"] = [2000, 0, 0]
+    look_cmd("we", ctx)
+    assert ctx["render_next"]
+    render_frame(ctx)
+    out = capsys.readouterr().out
+    assert ROOM_HEADERS[7] in out
+    assert p["pos"] == [2000, 0, 0]
+
+
 def test_peek_blocked_does_not_render():
     ctx = make_ctx()
     p = active(ctx["player_state"])


### PR DESCRIPTION
## Summary
- route direction tokens through `resolve_dir` in `look`
- document `look` direction prefixes
- add test for prefix-based look peeking

## Testing
- `PYTHONPATH=src pytest tests/test_move_commands.py`
- `PYTHONPATH=src pytest tests/commands/test_open_gate.py tests/commands/test_close_gate.py`
- `PYTHONPATH=src:. pytest tests/test_throw_command.py::test_throw_direction_prefix`
- `PYTHONPATH=src:. pytest` *(fails: fixture 'ctx' not found for some tests)*


------
https://chatgpt.com/codex/tasks/task_e_68c727c5f328832b884cb2e7eef4f2b7