### PR TITLE
Select first matching item for throw

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,11 +23,12 @@ match the prefix, the first one in the ground list is picked up.
 `throw <direction> <item>` throws an item into an adjacent tile. Direction
 arguments accept any prefix of the full word, e.g. `throw we ion-p` throws the
 Ion-Pistol west. Item names support unique prefixes, so `throw n nuc` will throw
-the Nuclear-Decay north if it's the only match. Thrown items always leave your
-inventory. If the throw is blocked (no exit, closed gate, or map boundary) the
-item lands at your feet. Throw uses the same passability rules as movement for
-consistency. Item names are parsed via the normalization helper (see
-[utilities](utilities.md)).
+the Nuclear-Decay north if it's the only match. If the item token matches
+multiple items in your inventory, throw picks the first match in inventory
+order. Thrown items always leave your inventory. If the throw is blocked (no
+exit, closed gate, or map boundary) the item lands at your feet. Throw uses the
+same passability rules as movement for consistency. Item names are parsed via
+the normalization helper (see [utilities](utilities.md)).
 
 ## Open
 

--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -219,9 +219,22 @@ def throw_to_direction(ctx, direction: str, prefix: str, *, seed: Optional[int] 
         return {"ok": False, "reason": "inventory_empty"}
     iid: Optional[str] = None
     if prefix:
-        iid, amb = _pick_first_match_by_prefix(inv, prefix)
-        if amb:
-            return {"ok": False, "reason": "ambiguous", "candidates": amb}
+        q = normalize_item_query(prefix)
+        if q:
+            for cand in inv:  # preserve inventory order
+                inst = itemsreg.get_instance(cand) or {}
+                item_id = (
+                    inst.get("item_id")
+                    or inst.get("catalog_id")
+                    or inst.get("id")
+                    or cand
+                )
+                name = idisp.canonical_name(str(item_id))
+                norm_name = normalize_item_query(name)
+                norm_id = normalize_item_query(str(item_id))
+                if norm_name.startswith(q) or norm_id.startswith(q):
+                    iid = cand
+                    break
     else:
         iid = inv[0]
     if not iid:


### PR DESCRIPTION
## Summary
- make `throw` resolve item prefixes to the first inventory match without prompting
- document that `throw` uses inventory order when multiple items share the token
- test that `throw` picks the first matching item

## Testing
- `PYTHONPATH=src:. pytest` *(4 errors: fixture 'ctx' not found in tests/test_throw_command.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c72b14203c832b84ebd6330d8b5e89