### PR TITLE
Unify direction constants and fix THROW north/south landing

### DIFF
--- a/src/mutants/engine/edge_resolver.py
+++ b/src/mutants/engine/edge_resolver.py
@@ -11,6 +11,7 @@ from mutants.registries.world import (
     BASE_GATE,
     GATE_OPEN,
 )
+from mutants.util.directions import DELTA as _DELTA, OPP as _OPP
 
 DESC_AREA = "area continues."
 DESC_ICE = "wall of ice."
@@ -107,10 +108,6 @@ def _gate_state_norm(v) -> int:
             return 2
         return 2
     return 2
-
-
-_DELTA = {"n": (0, 1), "s": (0, -1), "e": (1, 0), "w": (-1, 0)}
-_OPP = {"n": "s", "s": "n", "e": "w", "w": "e"}
 
 
 def resolve(world, dynamics, year: int, x: int, y: int, dir_key: str, actor: Optional[Dict] = None) -> EdgeDecision:

--- a/src/mutants/registries/world.py
+++ b/src/mutants/registries/world.py
@@ -35,9 +35,11 @@ WORLD_DEBUG = os.getenv("WORLD_DEBUG") == "1"
 WORLD_DIR = Path("state/world")
 
 # Direction helpers
+from mutants.util.directions import DELTA as _DELTA, OPP as _OPP
+
 DIRS = ("N", "S", "E", "W")
-OPPOSITE = {"N": "S", "S": "N", "E": "W", "W": "E"}
-DELTA = {"N": (0, 1), "S": (0, -1), "E": (1, 0), "W": (-1, 0)}
+OPPOSITE = {k.upper(): v.upper() for k, v in _OPP.items() if len(k) == 1}
+DELTA = {k.upper(): _DELTA[k] for k in ("n", "s", "e", "w")}
 
 BASE_OPEN = 0
 BASE_TERRAIN = 1

--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -7,18 +7,13 @@ from ..registries import items_instances as itemsreg
 from ..util.textnorm import normalize_item_query
 from mutants.engine import edge_resolver as ER
 from mutants.registries import dynamics as dyn
+from mutants.util.directions import vec as dir_vec
 
 LOG = logging.getLogger(__name__)
 WORLD_DEBUG = os.getenv("WORLD_DEBUG") == "1"
 
 GROUND_CAP = 6
 INV_CAP = 10  # worn armor excluded elsewhere
-DIR_DELTAS = {
-    "north": (0, -1),
-    "south": (0, 1),
-    "east": (1, 0),
-    "west": (-1, 0),
-}
 
 
 def _player_file() -> str:
@@ -245,7 +240,7 @@ def throw_to_direction(ctx, direction: str, prefix: str, *, seed: Optional[int] 
     world = ctx["world_loader"](year)
     dir_code = direction[:1].upper()
     dec = ER.resolve(world, dyn, year, x, y, dir_code, actor={})
-    dx, dy = DIR_DELTAS.get(direction.lower(), (0, 0))
+    dx, dy = dir_vec(direction)
     tx, ty = x + dx, y + dy
     if dec.passable:
         drop_x, drop_y = tx, ty

--- a/src/mutants/util/directions.py
+++ b/src/mutants/util/directions.py
@@ -1,6 +1,44 @@
+from __future__ import annotations
+
 from typing import Optional
 
+# Canonical direction vectors (right-handed grid):
+# x increases to the east; y increases to the north.
+DELTA = {
+    "n": (0, 1),
+    "s": (0, -1),
+    "e": (1, 0),
+    "w": (-1, 0),
+    "north": (0, 1),
+    "south": (0, -1),
+    "east": (1, 0),
+    "west": (-1, 0),
+}
+
+# Opposite direction lookup
+OPP = {
+    "n": "s",
+    "s": "n",
+    "e": "w",
+    "w": "e",
+    "north": "south",
+    "south": "north",
+    "east": "west",
+    "west": "east",
+}
+
 CANONICAL_DIRS = ("north", "south", "east", "west")
+
+
+def vec(direction: str) -> tuple[int, int]:
+    """Return (dx, dy) for any short/long direction key."""
+    return DELTA.get(direction.lower(), (0, 0))
+
+
+def opposite(direction: str) -> str:
+    """Return the opposite direction, preserving short/long form if given."""
+    d = direction.lower()
+    return OPP.get(d, d)
 
 
 def resolve_dir(token: Optional[str]) -> Optional[str]:

--- a/tests/test_directions_contract.py
+++ b/tests/test_directions_contract.py
@@ -1,0 +1,13 @@
+from mutants.util import directions as D
+
+
+def test_delta_and_opposites():
+    assert D.vec("north") == (0, 1)
+    assert D.vec("south") == (0, -1)
+    assert D.vec("east") == (1, 0)
+    assert D.vec("west") == (-1, 0)
+
+    assert D.vec("n") == (0, 1)
+    assert D.vec("s") == (0, -1)
+    assert D.opposite("n") == "s"
+    assert D.opposite("south") == "north"

--- a/tests/test_resolver_throw_consistency.py
+++ b/tests/test_resolver_throw_consistency.py
@@ -1,0 +1,83 @@
+import json, shutil
+from pathlib import Path
+
+from mutants.engine import edge_resolver as ER
+from mutants.registries import dynamics as dyn
+from mutants.registries import items_instances as itemsreg
+from mutants.services.item_transfer import throw_to_direction as do_throw
+from mutants.util.directions import vec
+
+
+class DummyWorld:
+    def get_tile(self, year, x, y):
+        return {
+            "edges": {
+                "N": {"base": 0},
+                "S": {"base": 0},
+                "E": {"base": 0},
+                "W": {"base": 0},
+            }
+        }
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, kind, text, **_):
+        self.events.append((kind, text))
+
+
+def _ctx():
+    world = DummyWorld()
+    return {"feedback_bus": FakeBus(), "world_loader": lambda year: world}
+
+
+def _copy_state(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+
+
+def _setup(monkeypatch, tmp_path):
+    src_state = Path(__file__).resolve().parents[1] / "state"
+    dst_state = tmp_path / "state"
+    _copy_state(src_state, dst_state)
+    monkeypatch.chdir(tmp_path)
+    itemsreg._CACHE = None
+    pfile = Path("state/playerlivestate.json")
+    with pfile.open("r", encoding="utf-8") as f:
+        pdata = json.load(f)
+    iid = itemsreg.create_and_save_instance("skull", 2000, 10, 10)
+    itemsreg.clear_position(iid)
+    pdata["inventory"] = [iid]
+    pdata["players"][0]["pos"] = [2000, 10, 10]
+    with pfile.open("w", encoding="utf-8") as f:
+        json.dump(pdata, f)
+    ctx = _ctx()
+    ctx["player_state"] = {
+        "active_id": pdata["players"][0]["id"],
+        "players": [{"id": pdata["players"][0]["id"], "pos": [2000, 10, 10]}],
+    }
+    return ctx, iid
+
+
+def test_resolver_and_throw_consistent(monkeypatch, tmp_path):
+    ctx, iid = _setup(monkeypatch, tmp_path)
+    year, x, y = 2000, 10, 10
+    world = ctx["world_loader"](year)
+    for direction in ["north", "south", "east", "west"]:
+        dx, dy = vec(direction)
+        dec = ER.resolve(world, dyn, year, x, y, direction[:1].upper(), actor={})
+        assert dec.passable
+        res = do_throw(ctx, direction, None)
+        assert res["ok"]
+        inst = itemsreg.get_instance(iid)
+        pos = inst.get("pos", {})
+        assert (pos.get("year"), pos.get("x"), pos.get("y")) == (year, x + dx, y + dy)
+        # reset item back to inventory for next direction
+        itemsreg.clear_position(iid)
+        pfile = Path("state/playerlivestate.json")
+        with pfile.open("r", encoding="utf-8") as f:
+            pdata = json.load(f)
+        pdata["inventory"].append(iid)
+        with pfile.open("w", encoding="utf-8") as f:
+            json.dump(pdata, f)

--- a/tests/test_throw_command.py
+++ b/tests/test_throw_command.py
@@ -75,7 +75,7 @@ def test_throw_moves_item_to_adjacent_tile(monkeypatch, tmp_path):
 
     inst = itemsreg.get_instance(iid)
     assert inst.get("pos", {}).get("x") == 0
-    assert inst.get("pos", {}).get("y") == -1
+    assert inst.get("pos", {}).get("y") == 1
 
     with pfile.open("r", encoding="utf-8") as f:
         pdata_after = json.load(f)
@@ -86,8 +86,8 @@ def test_thrown_item_can_be_picked_up(monkeypatch, tmp_path):
     ctx, pfile, inv = _setup(monkeypatch, tmp_path, ["nuclear_decay"])
     iid = inv[0]
     throw_cmd("north nuclear", ctx)
-    assert "nuclear_decay" in itemsreg.list_ids_at(2000, 0, -1)
-    ctx["player_state"]["players"][0]["pos"] = [2000, 0, -1]
+    assert "nuclear_decay" in itemsreg.list_ids_at(2000, 0, 1)
+    ctx["player_state"]["players"][0]["pos"] = [2000, 0, 1]
     dec = itx.pick_from_ground(ctx, "nuclear")
     assert dec.get("ok")
     with pfile.open("r", encoding="utf-8") as f:
@@ -107,7 +107,7 @@ def test_throw_abbreviation(monkeypatch, tmp_path):
     iid = inv[0]
     throw_cmd("north n", ctx)
     inst = itemsreg.get_instance(iid)
-    assert inst.get("pos", {}).get("y") == -1
+    assert inst.get("pos", {}).get("y") == 1
 
 
 def test_throw_direction_prefix(monkeypatch, tmp_path):

--- a/tests/test_throw_lands_correct_tile.py
+++ b/tests/test_throw_lands_correct_tile.py
@@ -1,0 +1,77 @@
+import json, shutil
+from pathlib import Path
+import pytest
+
+from mutants.services.item_transfer import throw_to_direction as do_throw
+from mutants.registries import items_instances as itemsreg
+
+
+class DummyWorld:
+    def get_tile(self, year, x, y):
+        return {
+            "edges": {
+                "N": {"base": 0},
+                "S": {"base": 0},
+                "E": {"base": 0},
+                "W": {"base": 0},
+            }
+        }
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, kind, text, **_):
+        self.events.append((kind, text))
+
+
+def _ctx():
+    world = DummyWorld()
+    return {"feedback_bus": FakeBus(), "world_loader": lambda year: world}
+
+
+def _copy_state(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+
+
+def _setup(monkeypatch, tmp_path):
+    src_state = Path(__file__).resolve().parents[1] / "state"
+    dst_state = tmp_path / "state"
+    _copy_state(src_state, dst_state)
+    monkeypatch.chdir(tmp_path)
+    itemsreg._CACHE = None
+    pfile = Path("state/playerlivestate.json")
+    with pfile.open("r", encoding="utf-8") as f:
+        pdata = json.load(f)
+    iid = itemsreg.create_and_save_instance("skull", 2000, 0, 0)
+    itemsreg.clear_position(iid)
+    pdata["inventory"] = [iid]
+    pdata["players"][0]["pos"] = [2000, 10, 10]
+    with pfile.open("w", encoding="utf-8") as f:
+        json.dump(pdata, f)
+    ctx = _ctx()
+    ctx["player_state"] = {
+        "active_id": pdata["players"][0]["id"],
+        "players": [{"id": pdata["players"][0]["id"], "pos": [2000, 10, 10]}],
+    }
+    return ctx, iid
+
+
+@pytest.mark.parametrize(
+    "direction,dx,dy",
+    [
+        ("north", 0, 1),
+        ("south", 0, -1),
+        ("east", 1, 0),
+        ("west", -1, 0),
+    ],
+)
+def test_throw_lands_correct_tile(monkeypatch, tmp_path, direction, dx, dy):
+    ctx, iid = _setup(monkeypatch, tmp_path)
+    res = do_throw(ctx, direction, None)
+    assert res["ok"]
+    inst = itemsreg.get_instance(iid)
+    pos = inst.get("pos", {})
+    year, x, y = pos.get("year"), pos.get("x"), pos.get("y")
+    assert (year, x, y) == (2000, 10 + dx, 10 + dy)


### PR DESCRIPTION
## Summary
- centralize direction vectors/opposites in `mutants.util.directions`
- consume canonical direction math in edge resolver, world registry, and item transfer
- correct THROW so north/south land on the intended tiles
- add regression and contract tests for direction math and throw behavior

## Testing
- `PYTHONPATH=src:. pytest tests/test_directions_contract.py tests/test_throw_lands_correct_tile.py tests/test_resolver_throw_consistency.py tests/test_throw_command.py::test_throw_moves_item_to_adjacent_tile tests/test_throw_command.py::test_thrown_item_can_be_picked_up tests/test_throw_command.py::test_throw_invalid_item_warns tests/test_throw_command.py::test_throw_abbreviation tests/test_throw_command.py::test_throw_direction_prefix -q`


------
https://chatgpt.com/codex/tasks/task_e_68c732293910832baedd2d1ace6ca10b