### PR TITLE
Handle duplicate drops FIFO

### DIFF
--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -96,11 +96,10 @@ def _pick_first_match_by_prefix(
         return (matches[0], None)
     if len(matches) > 1:
         names = [_iid_to_name(i) for i in matches]
-        # If all matched items share the same canonical name, treat as non-ambiguous.
-        unique = {n.lower() for n in names}
-        if len(unique) == 1:
+        # If all matched items share the same canonical name, auto-select first (FIFO).
+        if len({n.lower() for n in names}) == 1:
             return (matches[0], None)
-        # Otherwise surface candidate names to disambiguate.
+        # True ambiguity (different names): return candidates for prompting.
         return (None, names)
     return (None, None)
 

--- a/tests/test_drop_duplicates_non_ambiguous.py
+++ b/tests/test_drop_duplicates_non_ambiguous.py
@@ -63,16 +63,17 @@ def _setup_inventory(monkeypatch, tmp_path, item_ids):
     return ctx, pfile, inv
 
 
-def test_drop_prefix_with_identical_name_duplicates(monkeypatch, tmp_path):
+def test_drop_picks_first_duplicate(monkeypatch, tmp_path):
     ctx, pfile, inv = _setup_inventory(monkeypatch, tmp_path, ["gold_chunk", "gold_chunk"])
     res = drop_to_ground(ctx, "g")
     assert res["ok"]
     with pfile.open("r", encoding="utf-8") as f:
         pdata = json.load(f)
     inv_after = pdata.get("inventory", [])
-    assert (inv[0] in inv_after) ^ (inv[1] in inv_after)
+    # FIFO: first item dropped, second remains
+    assert inv[0] not in inv_after and inv[1] in inv_after
     ground_iids = [
         inst.get("iid") or inst.get("instance_id")
         for inst in itemsreg.list_instances_at(2000, 0, 0)
     ]
-    assert (inv[0] in ground_iids) ^ (inv[1] in ground_iids)
+    assert inv[0] in ground_iids and inv[1] not in ground_iids


### PR DESCRIPTION
## Summary
- Auto-select the first matching item when dropping duplicates by prefix
- Ensure drop ambiguity clearly lists candidate names for user clarification
- Add FIFO drop test verifying first matching item is removed

## Testing
- `PYTHONPATH=src:. pytest tests/test_drop_duplicates_non_ambiguous.py tests/test_drop_ambiguous_prompt.py -q`
- `PYTHONPATH=src:. pytest -q` *(fails: fixture 'ctx' not found in test_throw_command)*

------
https://chatgpt.com/codex/tasks/task_e_68c739a1b8d4832bb66b7f78de264532