### PR TITLE
Ensure DROP picks first matching inventory item

### DIFF
--- a/src/mutants/commands/drop.py
+++ b/src/mutants/commands/drop.py
@@ -14,7 +14,6 @@ def drop_cmd(arg: str, ctx):
         reason_messages={
             "inventory_empty": "You have nothing to drop.",
             "armor_cannot_drop": "You can't drop what you're wearing.",
-            "ambiguous": "Be more specific. You could mean: {candidates}.",
         },
         success_kind="LOOT/DROP",
         warn_kind="SYSTEM/WARN",

--- a/tests/test_drop_duplicates_non_ambiguous.py
+++ b/tests/test_drop_duplicates_non_ambiguous.py
@@ -66,13 +66,13 @@ def _setup_inventory(monkeypatch, tmp_path, item_ids):
 def test_drop_prefix_with_identical_name_duplicates(monkeypatch, tmp_path):
     ctx, pfile, inv = _setup_inventory(monkeypatch, tmp_path, ["gold_chunk", "gold_chunk"])
     res = drop_to_ground(ctx, "g")
-    assert res["ok"]
+    assert res["ok"] and res["iid"] == inv[0]
     with pfile.open("r", encoding="utf-8") as f:
         pdata = json.load(f)
     inv_after = pdata.get("inventory", [])
-    assert (inv[0] in inv_after) ^ (inv[1] in inv_after)
+    assert inv[0] not in inv_after and inv[1] in inv_after
     ground_iids = [
         inst.get("iid") or inst.get("instance_id")
         for inst in itemsreg.list_instances_at(2000, 0, 0)
     ]
-    assert (inv[0] in ground_iids) ^ (inv[1] in ground_iids)
+    assert inv[0] in ground_iids and inv[1] not in ground_iids


### PR DESCRIPTION
## Summary
- Make DROP select the first inventory item matching the prefix, mirroring GET/THROW
- Remove obsolete ambiguous message from DROP command
- Add tests asserting DROP's FIFO behavior for differing and duplicate item names

## Testing
- `PYTHONPATH=src:. pytest tests/test_drop_duplicates_non_ambiguous.py tests/test_drop_picks_first_match.py -q`
- `PYTHONPATH=src:. pytest -q` *(fails: fixture 'ctx' not found in tests/test_throw_command.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c73bb08be4832badb36858698ee2c0