### PR TITLE
Add lock command with key-based gates

### DIFF
--- a/src/mutants/commands/lock.py
+++ b/src/mutants/commands/lock.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from mutants.registries.world import BASE_GATE
+from mutants.registries import dynamics as dyn
+from mutants.registries import items_instances as itemsreg, items_catalog
+
+from .argcmd import PosArg, PosArgSpec, run_argcmd_positional
+
+
+def _has_any_key(ctx: Dict[str, Any]) -> tuple[bool, Optional[str]]:
+    """Return (has_key, key_type) for first key in inventory."""
+    cat = items_catalog.load_catalog()
+    p = ctx["player_state"]
+    inv = (p.get("players") or [{}])[0].get("inventory") or []
+    for iid in inv:
+        inst = itemsreg.get_instance(iid) or {}
+        item_id = inst.get("item_id")
+        meta = cat.get(item_id) if cat else None
+        if isinstance(meta, dict) and meta.get("key") is True:
+            return True, meta.get("key_type") or ""
+    return False, None
+
+
+def lock_cmd(arg: str, ctx: Dict[str, Any]) -> None:
+    spec = PosArgSpec(
+        verb="LOCK",
+        args=[PosArg("dir", "direction")],
+        messages={
+            "usage": "Type LOCK [direction].",
+            "success": "You lock the gate {dir}.",
+        },
+        reason_messages={
+            "not_gate": "You can only lock a closed gate.",
+            "already_open": "You can only lock a closed gate.",
+            "no_key": "You need a key to lock a gate.",
+        },
+    )
+
+    def action(dir: str) -> Dict[str, Any]:
+        p = ctx["player_state"]["players"][0]
+        year, x, y = p.get("pos", [0, 0, 0])
+        D = dir[0].upper()
+        world = ctx["world_loader"](year)
+        tile = world.get_tile(x, y) or {}
+        edge = (tile.get("edges") or {}).get(D, {})
+        base = edge.get("base", 0)
+        gs = edge.get("gate_state", 0)
+        if base != BASE_GATE:
+            return {"ok": False, "reason": "not_gate"}
+        if gs == 0:
+            return {"ok": False, "reason": "already_open"}
+        has_key, key_type = _has_any_key(ctx)
+        if not has_key:
+            return {"ok": False, "reason": "no_key"}
+        dyn.set_lock(year, x, y, D, key_type or "")
+        return {"ok": True, "dir": dir}
+
+    run_argcmd_positional(ctx, spec, arg, action)
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("lock", lambda arg: lock_cmd(arg, ctx))
+    dispatch.alias("loc", "lock")
+

--- a/src/mutants/commands/open.py
+++ b/src/mutants/commands/open.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from mutants.registries.world import BASE_GATE
+from mutants.registries import dynamics as dyn
+from mutants.registries import items_instances as itemsreg, items_catalog
 
 from .argcmd import coerce_direction
 
@@ -18,6 +20,22 @@ def _active(state: Dict[str, Any]) -> Dict[str, Any]:
 def register(dispatch, ctx) -> None:
     bus = ctx["feedback_bus"]
     logsink = ctx.get("logsink")
+
+    def _has_key_type_in_inventory(key_type: str) -> bool:
+        cat = items_catalog.load_catalog()
+        p = _active(ctx["player_state"])
+        inv = p.get("inventory") or []
+        for iid in inv:
+            inst = itemsreg.get_instance(iid) or {}
+            item_id = inst.get("item_id")
+            meta = cat.get(item_id) if cat else None
+            if (
+                isinstance(meta, dict)
+                and meta.get("key") is True
+                and meta.get("key_type") == key_type
+            ):
+                return True
+        return False
 
     def cmd(arg: str) -> None:
         token = (arg or "").strip().split()
@@ -45,13 +63,27 @@ def register(dispatch, ctx) -> None:
             bus.push("SYSTEM/WARN", "There is no gate to open that way.")
             return
 
-        if gs == 2:
-            bus.push("SYSTEM/WARN", "The gate is locked.")
-            return
+        lock_meta = dyn.get_lock(year, x, y, D)
+        required_key = None
+        if lock_meta:
+            required_key = lock_meta.get("lock_type")
+        elif gs == 2:
+            required_key = edge.get("key_type")
+            if required_key is None:
+                required_key = ""
 
-        if gs == 0:
+        if gs == 0 and not lock_meta:
             bus.push("SYSTEM/INFO", f"The {dir_full} gate is already open.")
             return
+
+        if required_key is not None:
+            if not _has_key_type_in_inventory(str(required_key)):
+                bus.push("SYSTEM/WARN", "The gate is locked.")
+                return
+            if lock_meta:
+                dyn.clear_lock(year, x, y, D)
+            else:
+                world.set_edge(x, y, D, key_type=None)
 
         world.set_edge(x, y, D, gate_state=0, force_gate_base=True)
         world.save()

--- a/src/mutants/engine/edge_resolver.py
+++ b/src/mutants/engine/edge_resolver.py
@@ -170,6 +170,11 @@ def resolve(world, dynamics, year: int, x: int, y: int, dir_key: str, actor: Opt
                 elif kind == "blasted":
                     reasons.append(("overlay", "blasted"))
                     cur_kind = "open"
+        if dynamics is not None and hasattr(dynamics, "get_lock"):
+            cur_lock = dynamics.get_lock(year, x, y, du)
+            if cur_lock and cur_kind == "gate":
+                cur_gs = 2
+                reasons.append(("lock", f"locked:{cur_lock.get('lock_type','')}"))
     except Exception:
         pass
 

--- a/tests/commands/test_lock_gate.py
+++ b/tests/commands/test_lock_gate.py
@@ -1,0 +1,158 @@
+import types
+
+from mutants.commands import lock as lock_cmd
+from mutants.commands import open as open_cmd
+from mutants.repl.dispatch import Dispatch
+from mutants.registries.world import BASE_GATE
+from mutants.registries import dynamics as dyn
+from mutants.registries import items_instances as itemsreg, items_catalog
+
+
+class DummyWorld:
+    def __init__(self, edge):
+        self._edge = edge
+        self.saved = False
+
+    def get_tile(self, x, y):
+        return {"edges": {"S": self._edge}}
+
+    def set_edge(self, x, y, D, *, gate_state=None, force_gate_base=False, key_type=None):
+        if force_gate_base:
+            self._edge["base"] = BASE_GATE
+        if gate_state is not None:
+            self._edge["gate_state"] = gate_state
+        if key_type is not None:
+            self._edge["key_type"] = key_type
+
+    def save(self):
+        self.saved = True
+
+
+def mk_ctx(inv, edge):
+    bus = types.SimpleNamespace(msgs=[])
+
+    def push(chan, msg):
+        bus.msgs.append((chan, msg))
+
+    bus.push = push
+    world = DummyWorld(edge)
+    ctx = {
+        "feedback_bus": bus,
+        "player_state": {
+            "active_id": 1,
+            "players": [{"id": 1, "pos": [2000, 0, 0], "inventory": list(inv)}],
+        },
+        "world_loader": lambda year: world,
+    }
+    return world, ctx, bus
+
+
+CAT = {
+    "gate_key_a": {"key": True, "key_type": "gate_a"},
+    "gate_key_b": {"key": True, "key_type": "gate_b"},
+}
+INSTANCES = {
+    "KA1": {"item_id": "gate_key_a"},
+    "KB1": {"item_id": "gate_key_b"},
+}
+
+
+def patch_items_and_dyn(monkeypatch):
+    monkeypatch.setattr(items_catalog, "load_catalog", lambda: CAT)
+    monkeypatch.setattr(itemsreg, "get_instance", lambda iid: INSTANCES.get(iid))
+
+    locks = {}
+
+    def _key(year, x, y, d):
+        return (year, x, y, d)
+
+    def get_lock(year, x, y, d):
+        return locks.get(_key(year, x, y, d))
+
+    def set_lock(year, x, y, d, lt):
+        dx, dy = {"N": (0, 1), "S": (0, -1), "E": (1, 0), "W": (-1, 0)}[d]
+        opp = {"N": "S", "S": "N", "E": "W", "W": "E"}[d]
+        locks[_key(year, x, y, d)] = {"locked": True, "lock_type": lt}
+        locks[_key(year, x + dx, y + dy, opp)] = {"locked": True, "lock_type": lt}
+
+    def clear_lock(year, x, y, d):
+        dx, dy = {"N": (0, 1), "S": (0, -1), "E": (1, 0), "W": (-1, 0)}[d]
+        opp = {"N": "S", "S": "N", "E": "W", "W": "E"}[d]
+        locks.pop(_key(year, x, y, d), None)
+        locks.pop(_key(year, x + dx, y + dy, opp), None)
+
+    monkeypatch.setattr(dyn, "get_lock", get_lock)
+    monkeypatch.setattr(dyn, "set_lock", set_lock)
+    monkeypatch.setattr(dyn, "clear_lock", clear_lock)
+
+
+def build_dispatch(ctx):
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+    lock_cmd.register(dispatch, ctx)
+    open_cmd.register(dispatch, ctx)
+    return dispatch
+
+
+def run(dispatch, bus, cmd):
+    pre = len(bus.msgs)
+    token, *rest = cmd.split(" ", 1)
+    arg = rest[0] if rest else ""
+    dispatch.call(token, arg)
+    return bus.msgs[pre:]
+
+
+def test_lock_requires_key(monkeypatch):
+    patch_items_and_dyn(monkeypatch)
+    edge = {"base": BASE_GATE, "gate_state": 1}
+    world, ctx, bus = mk_ctx([], edge)
+    dispatch = build_dispatch(ctx)
+    events = run(dispatch, bus, "lock south")
+    assert ("SYSTEM/WARN", "You need a key to lock a gate.") in events
+    assert dyn.get_lock(2000, 0, 0, "S") is None
+
+
+def test_lock_open_or_non_gate_warns(monkeypatch):
+    patch_items_and_dyn(monkeypatch)
+    # Open gate
+    edge = {"base": BASE_GATE, "gate_state": 0}
+    world, ctx, bus = mk_ctx(["KA1"], edge)
+    dispatch = build_dispatch(ctx)
+    events = run(dispatch, bus, "lock south")
+    assert ("SYSTEM/WARN", "You can only lock a closed gate.") in events
+    # Non-gate
+    edge2 = {"base": 0, "gate_state": 0}
+    world2, ctx2, bus2 = mk_ctx(["KA1"], edge2)
+    dispatch2 = build_dispatch(ctx2)
+    events2 = run(dispatch2, bus2, "lock south")
+    assert ("SYSTEM/WARN", "You can only lock a closed gate.") in events2
+
+
+def test_lock_prefixes_and_open_requires_matching_key(monkeypatch):
+    patch_items_and_dyn(monkeypatch)
+    edge = {"base": BASE_GATE, "gate_state": 1}
+    world, ctx, bus = mk_ctx(["KA1"], edge)
+    dispatch = build_dispatch(ctx)
+
+    for tok in ["s", "so", "sou", "sout"]:
+        events = run(dispatch, bus, f"loc {tok}")
+        assert ("SYSTEM/OK", "You lock the gate south.") in events
+
+    # Remove key and try to open
+    ctx["player_state"]["players"][0]["inventory"] = []
+    events = run(dispatch, bus, "open south")
+    assert ("SYSTEM/WARN", "The gate is locked.") in events
+
+    # Wrong key type
+    ctx["player_state"]["players"][0]["inventory"] = ["KB1"]
+    events = run(dispatch, bus, "open south")
+    assert ("SYSTEM/WARN", "The gate is locked.") in events
+
+    # Correct key
+    ctx["player_state"]["players"][0]["inventory"] = ["KA1"]
+    events = run(dispatch, bus, "open south")
+    assert ("SYSTEM/OK", "You've just opened the south gate.") in events
+    assert world.saved is True
+    assert edge["gate_state"] == 0
+    assert dyn.get_lock(2000, 0, 0, "S") is None
+


### PR DESCRIPTION
## Summary
- implement key-based LOCK command with directional prefixes
- treat locked gates as closed and require matching key to open
- cover locking and unlocking behavior with new tests

## Testing
- `PYTHONPATH=src:. pytest -q` *(fails: fixture 'ctx' not found in tests/test_throw_command.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c74cd68054832b9b3d3b27c3dc1b66