### PR TITLE
Add ranged item framework with point/fix commands

### DIFF
--- a/src/mutants/commands/_helpers.py
+++ b/src/mutants/commands/_helpers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from typing import Optional
+
+from ..registries import items_catalog, items_instances as itemsreg
+from ..util.textnorm import normalize_item_query as normalize
+from ..services import item_transfer as itx
+
+
+def inventory_iids_for_active_player(ctx) -> list[str]:
+    p = itx._load_player()
+    inv = p.get("inventory") or []
+    return [str(i) for i in inv]
+
+
+def find_inventory_item_by_prefix(ctx, token: str) -> Optional[str]:
+    q = normalize(token)
+    if not q:
+        return None
+    inv = inventory_iids_for_active_player(ctx)
+    cat = items_catalog.load_catalog()
+    for iid in inv:
+        inst = itemsreg.get_instance(iid) or {}
+        tpl = cat.get(inst.get("item_id")) or {}
+        key = normalize(tpl.get("name") or tpl.get("item_id") or "")
+        if key.startswith(q):
+            return iid
+    return None

--- a/src/mutants/commands/fix.py
+++ b/src/mutants/commands/fix.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from ._helpers import find_inventory_item_by_prefix
+from ..registries import items_catalog, items_instances as itemsreg
+
+
+def fix_cmd(arg: str, ctx):
+    tok = (arg or "").strip()
+    bus = ctx["feedback_bus"]
+    if not tok:
+        bus.push("SYSTEM/WARN", "Usage: fix [item]")
+        return
+    iid = find_inventory_item_by_prefix(ctx, tok)
+    if not iid:
+        bus.push("SYSTEM/WARN", f"You're not carrying a {tok}.")
+        return
+    inst = itemsreg.get_instance(iid) or {}
+    cat = items_catalog.load_catalog()
+    tpl = cat.get(inst.get("item_id")) or {}
+    name = tpl.get("name") or inst.get("item_id") or tok
+    if not tpl.get("charges_max"):
+        bus.push("SYSTEM/WARN", "That doesn't need fixing.")
+        return
+    gain = itemsreg.recharge_full(iid)
+    if gain <= 0:
+        bus.push("SYSTEM/OK", "It's already at full charge.")
+    else:
+        bus.push("SYSTEM/OK", f"You restore the {name} to full charge.")
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("fix", lambda arg: fix_cmd(arg, ctx))

--- a/src/mutants/commands/point.py
+++ b/src/mutants/commands/point.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+from .argcmd import coerce_direction
+from ._helpers import find_inventory_item_by_prefix
+from ..registries import items_catalog, items_instances as itemsreg
+
+
+def point_cmd(arg: str, ctx):
+    bus = ctx["feedback_bus"]
+    parts = (arg or "").strip().split(maxsplit=1)
+    if len(parts) < 2:
+        bus.push("SYSTEM/WARN", "Usage: point [direction] [item]")
+        return
+    dir_token, item_token = parts[0], parts[1]
+    d = coerce_direction(dir_token)
+    if not d:
+        bus.push("SYSTEM/WARN", "Try north, south, east, or west.")
+        return
+    iid = find_inventory_item_by_prefix(ctx, item_token)
+    if not iid:
+        bus.push("SYSTEM/WARN", f"You're not carrying a {item_token}.")
+        return
+    inst = itemsreg.get_instance(iid) or {}
+    cat = items_catalog.load_catalog()
+    tpl = cat.get(inst.get("item_id")) or {}
+    name = tpl.get("name") or inst.get("item_id") or item_token
+    if not tpl.get("charges_max"):
+        bus.push("SYSTEM/WARN", "That item can't be fired.")
+        return
+    if not itemsreg.spend_charge(iid):
+        bus.push("SYSTEM/WARN", "It sputters—no charge left.")
+        return
+    bus.push("COMBAT/POINT", f"You fire the {name} to the {d.title()}.")
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("point", lambda arg: point_cmd(arg, ctx))

--- a/src/mutants/registries/items_catalog.py
+++ b/src/mutants/registries/items_catalog.py
@@ -44,6 +44,15 @@ def _coerce_legacy_bools(items: List[Dict[str, Any]]) -> None:
                 elif lv == "no":
                     it[k] = False
 
+
+def _normalize_charges(items: List[Dict[str, Any]]) -> None:
+    """Alias legacy charge fields and infer helper flags in-place."""
+    for it in items:
+        if "charges_max" not in it and "charges_start" in it:
+            it["charges_max"] = it.get("charges_start")
+        if "charges_max" in it:
+            it["uses_charges"] = True
+
 def load_catalog(path: str = DEFAULT_CATALOG_PATH) -> ItemsCatalog:
     primary = Path(path)
     fallback = Path(FALLBACK_CATALOG_PATH)
@@ -54,4 +63,5 @@ def load_catalog(path: str = DEFAULT_CATALOG_PATH) -> ItemsCatalog:
     else:
         raise FileNotFoundError(f"Missing catalog: tried {primary} then {fallback}")
     _coerce_legacy_bools(items)
+    _normalize_charges(items)
     return ItemsCatalog(items)

--- a/src/mutants/ui/item_display.py
+++ b/src/mutants/ui/item_display.py
@@ -96,7 +96,13 @@ def canonical_name_from_iid(iid: str) -> str:
         if not inst:
             return iid
         item_id = inst.get("item_id") or inst.get("catalog_id") or inst.get("id") or iid
-        return canonical_name(str(item_id))
+        name = canonical_name(str(item_id))
+        if "charges" in inst:
+            try:
+                name = f"{name} ({int(inst.get('charges', 0))})"
+            except Exception:
+                pass
+        return name
     except Exception:
         return iid
 

--- a/state/items/catalog.json
+++ b/state/items/catalog.json
@@ -313,5 +313,27 @@
     "potion": false,
     "skull": false,
     "charges_start": 0
+  },
+  {
+    "item_id": "lightning-rod",
+    "name": "Lightning Rod",
+    "weight": 1,
+    "ion_value": 0,
+    "riblet_value": 0,
+    "spawnable": true,
+    "enchantable": false,
+    "nondegradable": true,
+    "base_power": 0,
+    "armour": false,
+    "armour_class": 0,
+    "ranged": true,
+    "poisonous": false,
+    "poison_type": 0,
+    "key": false,
+    "key_type": null,
+    "potion": false,
+    "skull": false,
+    "charges_max": 25,
+    "description": "A crackling rod that stores lightning."
   }
 ]

--- a/tests/test_ranged_items.py
+++ b/tests/test_ranged_items.py
@@ -1,0 +1,83 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from mutants.app import context
+from mutants.repl.dispatch import Dispatch
+from mutants.commands import debug, inv, look, point, fix
+from mutants.registries import items_instances as itemsreg
+from mutants.commands._helpers import inventory_iids_for_active_player
+
+
+@pytest.fixture
+def ctx(monkeypatch, tmp_path):
+    src_state = Path(__file__).resolve().parents[1] / "state"
+    dst_state = tmp_path / "state"
+    shutil.copytree(src_state, dst_state)
+    monkeypatch.chdir(tmp_path)
+    itemsreg._CACHE = None
+    # Clear positions to simplify
+    for inst in itemsreg.list_instances_at(2000, 0, 0):
+        iid = inst.get("iid") or inst.get("instance_id")
+        if iid:
+            itemsreg.clear_position(iid)
+    itemsreg.save_instances()
+    return context.build_context()
+
+
+@pytest.fixture
+def run(ctx):
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+    debug.register(dispatch, ctx)
+    inv.register(dispatch, ctx)
+    look.register(dispatch, ctx)
+    point.register(dispatch, ctx)
+    fix.register(dispatch, ctx)
+
+    def _run(cmd: str):
+        token, *rest = cmd.split(" ", 1)
+        arg = rest[0] if rest else ""
+        dispatch.call(token, arg)
+
+    return _run
+
+
+def _first_inventory_iid(ctx) -> str:
+    return inventory_iids_for_active_player(ctx)[0]
+
+
+def test_ranged_item_flow(ctx, run):
+    run("debug add lightning-rod")
+    ctx["feedback_bus"].drain()
+    run("inv")
+    events = ctx["feedback_bus"].drain()
+    assert any("Lightning" in ev["text"] and "(25)" in ev["text"] for ev in events)
+
+    run("look lightning")
+    events = ctx["feedback_bus"].drain()
+    assert any("Charges: 25" in ev["text"] for ev in events)
+
+    run("point west lightning")
+    events = ctx["feedback_bus"].drain()
+    assert any("fire the Lightning Rod to the West" in ev["text"] for ev in events)
+    iid = _first_inventory_iid(ctx)
+    assert itemsreg.get_instance(iid).get("charges") == 24
+
+    for _ in range(24):
+        itemsreg.spend_charge(iid)
+    run("point west lightning")
+    events = ctx["feedback_bus"].drain()
+    assert any("no charge left" in ev["text"] for ev in events)
+
+    run("fix lightning")
+    events = ctx["feedback_bus"].drain()
+    assert any("restore the Lightning Rod to full charge" in ev["text"] for ev in events)
+    run("inv")
+    events = ctx["feedback_bus"].drain()
+    assert any("Lightning" in ev["text"] and "(25)" in ev["text"] for ev in events)
+
+    run("fix lightning")
+    events = ctx["feedback_bus"].drain()
+    assert any("already at full charge" in ev["text"] for ev in events)


### PR DESCRIPTION
## Summary
- Support charged ranged items in catalog and instances
- Add `point` and `fix` commands plus inventory item lookup helper
- Show charges in inventory names and extend `look` for item inspection

## Testing
- `PYTHONPATH=src:. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c820f554b8832baa7c97636262e8d2