### PR TITLE
Catalog updates — ranged/charges schema, normalization, and migration

### DIFF
--- a/state/items/catalog.json
+++ b/state/items/catalog.json
@@ -17,8 +17,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "ion_decay",
@@ -38,8 +37,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "nuclear_rock",
@@ -59,8 +57,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "gold_chunk",
@@ -80,8 +77,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "cheese",
@@ -101,8 +97,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "light_spear",
@@ -122,8 +117,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "monster_bait",
@@ -143,8 +137,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "nuclear_thong",
@@ -164,8 +157,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "ion_pack",
@@ -185,8 +177,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "ion_booster",
@@ -206,8 +197,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "nuclear_waste",
@@ -227,8 +217,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "cigarette_butt",
@@ -248,8 +237,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "bottle_cap",
@@ -269,8 +257,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "gate_key_a",
@@ -290,8 +277,7 @@
     "key": true,
     "key_type": "gate_a",
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "gate_key_b",
@@ -311,8 +297,7 @@
     "key": true,
     "key_type": "gate_b",
     "potion": false,
-    "skull": false,
-    "charges_start": 0
+    "skull": false
   },
   {
     "item_id": "lightning-rod",
@@ -320,7 +305,7 @@
     "weight": 1,
     "ion_value": 0,
     "riblet_value": 0,
-    "spawnable": true,
+    "spawnable": false,
     "enchantable": false,
     "nondegradable": true,
     "base_power": 0,
@@ -334,6 +319,30 @@
     "potion": false,
     "skull": false,
     "charges_max": 25,
-    "description": "A crackling rod that stores lightning."
+    "description": "A crackling rod that stores lightning.",
+    "uses_charges": true
+  },
+  {
+    "item_id": "flare-wand",
+    "name": "Flare Wand",
+    "description": "A simple wand that fires a bright flare.",
+    "weight": 1,
+    "ion_value": 0,
+    "riblet_value": 0,
+    "spawnable": false,
+    "enchantable": false,
+    "nondegradable": true,
+    "base_power": 0,
+    "armour": false,
+    "armour_class": 0,
+    "ranged": true,
+    "uses_charges": true,
+    "charges_max": 7,
+    "poisonous": false,
+    "poison_type": 0,
+    "key": false,
+    "key_type": null,
+    "potion": false,
+    "skull": false
   }
 ]

--- a/tests/registries/test_items_catalog.py
+++ b/tests/registries/test_items_catalog.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+import pytest
 
 # Ensure src is on path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
@@ -47,3 +48,38 @@ def test_legacy_yes_no_coerced(tmp_path: Path) -> None:
     hat = cat.get("hat")
     assert hat["spawnable"] is True
     assert hat["armour"] is False
+
+
+def test_charges_alias_and_defaults(tmp_path: Path) -> None:
+    items = [
+        {
+            "item_id": "rod",
+            "name": "Rod",
+            "weight": 1,
+            "ranged": True,
+            "charges_start": 5,
+        }
+    ]
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text(json.dumps(items))
+    cat = load_catalog(str(catalog_path))
+    rod = cat.get("rod")
+    assert rod["charges_max"] == 5
+    assert rod["uses_charges"] is True
+    assert rod["spawnable"] is False
+
+
+def test_invalid_charges_error(tmp_path: Path) -> None:
+    items = [
+        {
+            "item_id": "bad",
+            "name": "Bad",
+            "weight": 1,
+            "uses_charges": True,
+            "charges_max": 0,
+        }
+    ]
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text(json.dumps(items))
+    with pytest.raises(ValueError):
+        load_catalog(str(catalog_path))

--- a/tools/migrate_catalog_charges.py
+++ b/tools/migrate_catalog_charges.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""One-shot codemod to migrate catalog charge fields.
+
+Usage:
+    python tools/migrate_catalog_charges.py [path ...]
+
+Paths default to ``state/items/catalog.json``. Files are rewritten in place
+with stable key ordering and pretty printing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _migrate_item(it: dict[str, Any]) -> None:
+    if "charges_start" in it:
+        it["charges_max"] = int(it["charges_start"])
+        it.pop("charges_start", None)
+
+    if it.get("ranged"):
+        it["spawnable"] = False
+        if it.get("charges_max", 0) > 0:
+            it["uses_charges"] = True
+    else:
+        if not it.get("uses_charges"):
+            it.pop("uses_charges", None)
+            if not it.get("charges_max"):
+                it.pop("charges_max", None)
+
+
+def _process(path: Path) -> None:
+    data = json.loads(path.read_text())
+    if isinstance(data, dict) and "items" in data:
+        items = data["items"]
+    else:
+        items = data
+    for it in items:
+        _migrate_item(it)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("paths", nargs="*", default=["state/items/catalog.json"])
+    args = ap.parse_args()
+    for p in args.paths:
+        _process(Path(p))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- normalize item catalog to support charges and ranged items with validation
- add one-shot migration script and migrate catalog with flare-wand debug item
- cover normalization with new tests

## Testing
- `pytest tests/registries/test_items_catalog.py`
- `pytest` *(fails: Interrupted: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c82b8938fc832bb2edd5d90505c021