### PR TITLE
Add item descriptions to catalog entries

### DIFF
--- a/state/items/catalog.json
+++ b/state/items/catalog.json
@@ -17,6 +17,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A fist-sized shard that hums with leftover atoms; it warms your palm and worries your genes.",
     "skull": false
   },
   {
@@ -37,6 +38,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A brittle cluster of ionized crystals that spit faint blue sparks when jostled.",
     "skull": false
   },
   {
@@ -57,6 +59,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A pitted stone veined with sickly glow—useful as a tool, regrettable as a pillow.",
     "skull": false
   },
   {
@@ -77,6 +80,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A jagged lump of prewar gold, tarnished but heavy enough to settle arguments.",
     "skull": false
   },
   {
@@ -97,6 +101,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A waxy wedge of survivor cheese—edible, technically, and disturbingly shelf-stable.",
     "skull": false
   },
   {
@@ -117,6 +122,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A scav-built spear of polished rebar; the tip catches stray light and bad intentions.",
     "skull": false
   },
   {
@@ -137,6 +143,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A reeking bundle of offal and chem-syrup; monsters smell it from a mile.",
     "skull": false
   },
   {
@@ -157,6 +164,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "Threadbare undergarment lined with rad-foil—fashion died, sarcasm didn’t.",
     "skull": false
   },
   {
@@ -177,6 +185,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A backpack battery slab with cracked hazard glyphs; enough juice to thrill or kill.",
     "skull": false
   },
   {
@@ -197,6 +206,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A jury-rigged capacitor clip that jolts old tech into overdrive—until it smokes.",
     "skull": false
   },
   {
@@ -217,6 +227,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A sealed drum of unkind green; it sloshes when you shouldn’t shake it.",
     "skull": false
   },
   {
@@ -237,6 +248,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A prewar filter stub that smells like endings; it still takes a spark.",
     "skull": false
   },
   {
@@ -257,6 +269,7 @@
     "key": false,
     "key_type": null,
     "potion": false,
+    "description": "A dented cap with a faded logo—currency in some ruins, noise-maker everywhere.",
     "skull": false
   },
   {
@@ -277,6 +290,7 @@
     "key": true,
     "key_type": "gate_a",
     "potion": false,
+    "description": "A stamped steel key tagged ‘A’; fits gates tuned to the gate-a channel.",
     "skull": false
   },
   {
@@ -297,6 +311,7 @@
     "key": true,
     "key_type": "gate_b",
     "potion": false,
+    "description": "A stamped steel key tagged ‘B’; fits gates tuned to the gate-b channel.",
     "skull": false
   },
   {


### PR DESCRIPTION
## Summary
- add descriptions to previously description-less catalog items with provided flavor text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c84e981750832bbfc0192dd9a4c2ce