### PR TITLE
Add class selection menu, state manager, and statistics command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ state/**
 !state/ui/themes/
 !state/ui/themes/bbs.json
 !state/ui/themes/mono.json
+state/savegame.json
+state/savegame.bak.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Command: `open <dir>` reopens a closed gate.
 - Item token normalization helper for consistent item parsing.
 - Debug add item supports fuzzy matching.
+- Class Selection startup screen, statistics command with prefix matching, and
+  save-game foundation (schema v1, Bury stubbed for now).
 - Documentation:
   - README troubleshooting section.
   - ARCHITECTURE notes on cwd dependence and fallback.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,20 @@ It intentionally contains **no game logic**. Start adding code under `src/mutant
 - [Commands](docs/commands.md)
 - [Items](docs/items.md)
 - [Utilities](docs/utilities.md)
+- [State layers](docs/STATE.md)
+- [Menus](docs/MENUS.md)
+- [Save system](docs/SAVES.md)
 
 ## Quick start (Codespaces)
 - Open in GitHub Codespaces.
 - The container installs the package in editable mode.
 - Run: `pip install -e .`
-- Run: `python -m mutants` (placeholder CLI).
+- Run: `python -m mutants`.
+- Pick a class on the Class Selection screen (1–5), use `stat` to view player details, and press `x` to return to the menu. `Bury` will arrive in a future update.
+
+## Features
+- Class Selection & Statistics foundation
+- Room rendering + feedback bus (legacy placeholder)
 
 ## Structure
 - `src/mutants/io/` — input/parse I/O (empty).

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -1,0 +1,31 @@
+# Menus
+
+## Class Selection
+
+The game boots into the class selection screen. Layout mirrors the classic BBS
+style:
+
+```
+1. Mutant Thief     Level: 1   Year: 2000   (0  0)
+2. Mutant Priest    Level: 1   Year: 2000   (0  0)
+3. Mutant Wizard    Level: 1   Year: 2000   (0  0)
+4. Mutant Warrior   Level: 1   Year: 2000   (0  0)
+5. Mutant Mage      Level: 1   Year: 2000   (0  0)
+Type BURY [class number] to reset a player.
+***
+Select (Bury, 1–5, ?)
+```
+
+- Press `1`–`5` to activate a class and enter the in-game view.
+- Type `?` for a reminder: “Enter 1–5 to choose a class; ‘Bury’ resets later.”
+- `BURY <n>` is accepted but currently responds with “Bury not implemented yet.”
+
+The menu always follows the template order regardless of the current active
+class.
+
+## In-Game
+
+- `statistics`/`sta` prints a summary for the active player.
+- Press `x` at any time to save and return to the class selection menu.
+- Other legacy commands (movement, look, etc.) continue to work while we migrate
+  the rest of the UI.

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -1,0 +1,25 @@
+# Save System
+
+## Paths
+- Template: `state/playerlivestate.json` (read-only, shipped with the repo)
+- Save file: `state/savegame.json`
+- Backups: `state/savegame.bak.<timestamp>` (created when a save is unreadable)
+
+## Atomic writes
+- Saves are written through a temp file in the same directory, flushed via
+  `fsync`, then renamed into place.
+- This keeps the save durable even if the process exits mid-write or the system
+  crashes.
+
+## Schema
+- `schema_version`: starts at `1`. Future migrations will branch on this value.
+- `meta.created_at`: ISO-8601 UTC timestamp for the initial save creation.
+- `meta.updated_at`: refreshed on every successful `persist()`.
+- `players`: map keyed by class id (`player_thief`, `player_priest`, etc.).
+- `active_id`: the class currently in control.
+
+## Autosave & triggers
+- Every class switch persists immediately.
+- `StateManager.save_on_exit()` flushes pending changes on clean exit.
+- Autosave by command-count is wired up but defaults to disabled (`0`).
+  Configure `autosave_interval` via runtime config in a later update.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,0 +1,89 @@
+# Player State Layers
+
+Mutants now separates player data into three layers so we can evolve the game
+without touching the golden templates shipped in the repo.
+
+## 1. Template (read-only)
+- Path: `state/playerlivestate.json`
+- Loaded at startup and never modified at runtime.
+- Provides baseline records for each supported class (`player_thief`,
+  `player_priest`, `player_wizard`, `player_warrior`, `player_mage`).
+
+## 2. Save (mutable, persistent)
+- Path: `state/savegame.json`
+- Schema: `{ "meta": {...}, "players": {<class_id>: {...}}, "active_id": "..." }`
+- `meta` currently contains `schema_version` (1), `created_at`, and `updated_at`.
+- Written atomically (temp → fsync → rename) whenever the active class changes
+  or when the process exits cleanly. Corrupt saves are backed up to
+  `savegame.bak.<timestamp>` and rebuilt from the template.
+
+## 3. Live (in-memory)
+- The `StateManager` owns `SaveData` (mutable), exposes a compatibility view via
+  `state_manager.legacy_state`, and drives autosave logic.
+- Screens and commands always read the active player via `state_manager`.
+- Commands that mutate player data should call `state_manager.mark_dirty()`;
+  autosave can be configured later.
+
+### Player record fields
+- `id`: stable identifier, e.g. `player_thief`.
+- `name`: player label (defaults to the class name).
+- `class`: textual class name ("Thief", "Priest", …).
+- `level`: integer ≥ 1.
+- `exp_points`: integer ≥ 0.
+- `hp`: `{ "current": int, "max": int }` with `0 ≤ current ≤ max`.
+- `stats`: `{ "str", "int", "wis", "dex", "con", "cha" }` integers.
+- `ions`, `riblets`: non-negative integers.
+- `conditions`: `{ "poisoned", "encumbered", "ion_starving" }` booleans.
+- `inventory`: list of item instance IDs (may be empty).
+- `pos`: `[year, x, y]` integers; year stays in sync with the loaded world.
+- Additional keys (notes, exhaustion, armour, etc.) are preserved.
+
+### Example
+
+Template fragment:
+
+```json
+{
+  "players": [
+    {
+      "id": "player_thief",
+      "name": "Thief",
+      "class": "Thief",
+      "level": 1,
+      "hp": {"current": 18, "max": 18},
+      "ions": 30000,
+      "riblets": 0,
+      "stats": {"str": 15, "dex": 14, "wis": 8, "int": 9, "con": 15, "cha": 16},
+      "conditions": {"poisoned": false, "encumbered": false, "ion_starving": false},
+      "pos": [2000, 0, 0]
+    }
+  ],
+  "active_id": "player_thief"
+}
+```
+
+Save fragment:
+
+```json
+{
+  "meta": {"schema_version": 1, "created_at": "2024-04-18T00:00:00Z", "updated_at": "2024-04-18T00:05:00Z"},
+  "players": {
+    "player_thief": {
+      "id": "player_thief",
+      "name": "Thief",
+      "class": "Thief",
+      "level": 1,
+      "hp": {"current": 18, "max": 18},
+      "ions": 29500,
+      "riblets": 5,
+      "stats": {...},
+      "conditions": {...},
+      "pos": [2000, 1, 0]
+    }
+  },
+  "active_id": "player_thief"
+}
+```
+
+The save keeps the template structure but holds live values (position, money,
+conditions, etc.).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,5 +1,12 @@
 # Commands
 
+## Prefix Matching
+
+Commands are case-insensitive and accept unique prefixes once you type at least
+three characters. If two commands share the same three-letter prefix you must
+type one more letter to disambiguate. Single-letter shortcuts remain available
+only when explicitly aliased (e.g. `x` to open the class selection menu).
+
 ## Movement
 
 Typing a direction moves you to an adjacent tile. Any prefix of the full word
@@ -44,6 +51,19 @@ prefix of the full word (e.g. `close so` closes the south gate).
 
 `debug add item <name>` spawns an item into your inventory. Item names are
 parsed via the normalization helper (see [utilities](utilities.md)).
+
+## Statistics
+
+`statistics` (or any prefix such as `sta`, `stat`, `stati`, …) shows the active
+player's level, HP, AC, experience, money, ability scores, active conditions,
+and current location. The command is read-only.
+
+## Class Selection
+
+Press `x` from in-game mode to save and return to the class selection menu.
+From the menu you can pick a new class by entering `1`–`5` or type `?` for a
+quick reminder. `BURY <n>` is accepted but currently replies with “Bury not
+implemented yet.”
 
 ## Equip
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,8 @@
+"""Namespace package shim so tests can import ``src.mutants``."""
+
+import importlib
+
+
+mutants = importlib.import_module("mutants")
+
+__all__ = ["mutants"]

--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Iterable, List
 
 import os, logging
 
-from mutants.bootstrap.lazyinit import ensure_player_state
 from mutants.bootstrap.runtime import ensure_runtime
 from mutants.data.room_headers import ROOM_HEADERS, STORE_FOR_SALE_IDX
 from mutants.registries.world import load_year
@@ -14,7 +13,9 @@ from mutants.ui.feedback import FeedbackBus
 from mutants.ui.logsink import LogSink
 from mutants.ui.themes import Theme, load_theme
 from mutants.ui import styles as st
+from mutants.ui.screens import ScreenManager
 from ..registries import items_instances as itemsreg
+from mutants.state.manager import StateManager
 
 LOG = logging.getLogger(__name__)
 WORLD_DEBUG = os.getenv("WORLD_DEBUG") == "1"
@@ -50,7 +51,6 @@ _CURRENT_CTX: Dict[str, Any] | None = None
 def build_context() -> Dict[str, Any]:
     """Build the application context."""
     info = ensure_runtime()
-    state = ensure_player_state()
     cfg = info.get("config", {})
     bus = FeedbackBus()
     theme_path = cfg.get("theme_path", str(DEFAULT_THEME_PATH))
@@ -67,8 +67,12 @@ def build_context() -> Dict[str, Any]:
     st.set_ansi_enabled(theme.ansi_enabled)
     sink = LogSink()
     bus.subscribe(sink.handle)
+    state_mgr = StateManager()
+
+    screen_mgr = ScreenManager(state_mgr, _render_room_lines)
+
     ctx: Dict[str, Any] = {
-        "player_state": state,
+        "player_state": state_mgr.legacy_state,
         "world_loader": load_year,
         "monsters": None,
         "items": itemsreg,
@@ -80,6 +84,8 @@ def build_context() -> Dict[str, Any]:
         "config": cfg,
         "render_next": False,
         "peek_vm": None,
+        "state_manager": state_mgr,
+        "screen_manager": screen_mgr,
     }
     global _CURRENT_CTX
     _CURRENT_CTX = ctx
@@ -159,7 +165,7 @@ def build_room_vm(
     return vm
 
 
-def render_frame(ctx: Dict[str, Any]) -> None:
+def _render_room_lines(ctx: Dict[str, Any]) -> List[str]:
     vm = ctx.pop("peek_vm", None)
     if vm is None:
         vm = build_room_vm(
@@ -170,13 +176,23 @@ def render_frame(ctx: Dict[str, Any]) -> None:
             ctx.get("items"),
         )
     events = ctx["feedback_bus"].drain()
-    lines = ctx["renderer"](
+    return ctx["renderer"](
         vm,
         feedback_events=events,
         palette=ctx["theme"].palette,
         width=ctx["theme"].width,
     )
-    for line in lines:
+
+
+def render_frame(ctx: Dict[str, Any]) -> None:
+    screen_mgr = ctx.get("screen_manager")
+    if screen_mgr is not None:
+        lines = screen_mgr.render(ctx)
+        for line in lines:
+            print(line)
+        flush_feedback(ctx)
+        return
+    for line in _render_room_lines(ctx):
         print(line)
 
 

--- a/src/mutants/commands/menu.py
+++ b/src/mutants/commands/menu.py
@@ -1,0 +1,19 @@
+"""Commands for switching between menus."""
+from __future__ import annotations
+
+
+def exit_to_selection(arg: str, ctx) -> None:
+    state_mgr = ctx.get("state_manager")
+    screen_mgr = ctx.get("screen_manager")
+    if screen_mgr is None:
+        ctx["feedback_bus"].push("SYSTEM/WARN", "Class selection unavailable.")
+        return
+    if state_mgr is not None:
+        state_mgr.persist()
+    screen_mgr.enter_selection(ctx)
+    ctx["feedback_bus"].push("SYSTEM/OK", "Returned to class selection.")
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("exitmenu", lambda arg: exit_to_selection(arg, ctx))
+    dispatch.alias("x", "exitmenu")

--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -1,0 +1,82 @@
+"""Statistics command for inspecting the active player."""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def _pos_tuple(pos: Iterable[int]) -> tuple[int, int, int]:
+    data = list(pos)
+    data += [0] * max(0, 3 - len(data))
+    try:
+        year = int(data[0])
+    except (TypeError, ValueError):
+        year = 0
+    try:
+        x = int(data[1])
+    except (TypeError, ValueError):
+        x = 0
+    try:
+        y = int(data[2])
+    except (TypeError, ValueError):
+        y = 0
+    return year, x, y
+
+
+def statistics_cmd(arg: str, ctx) -> None:
+    state_mgr = ctx.get("state_manager")
+    if state_mgr is None:
+        ctx["feedback_bus"].push("SYSTEM/WARN", "Statistics unavailable: state manager not initialized.")
+        return
+    player = state_mgr.get_active().to_dict()
+    bus = ctx["feedback_bus"]
+
+    name = player.get("name") or player.get("class") or "Unknown"
+    cls = player.get("class") or player.get("class_name") or ""
+    title = f"{name}"
+    if cls and cls.lower() not in name.lower():
+        title = f"{name} the {cls}"
+    bus.push("SYSTEM/OK", title)
+
+    level = player.get("level") or player.get("level_start") or 1
+    try:
+        level_val = int(level)
+    except (TypeError, ValueError):
+        level_val = 1
+    exp_val = player.get("exp_points", player.get("exp", 0))
+    bus.push("SYSTEM/OK", f"Level: {level_val}    EXP: {exp_val}")
+
+    hp = player.get("hp", {}) if isinstance(player.get("hp"), dict) else {}
+    hp_cur = hp.get("current", 0)
+    hp_max = hp.get("max", 0)
+    armour = player.get("armour", {}) if isinstance(player.get("armour"), dict) else {}
+    ac_val = armour.get("armour_class", player.get("ac", 0))
+    bus.push("SYSTEM/OK", f"HP: {hp_cur}/{hp_max}    AC: {ac_val}")
+
+    ions = player.get("ions", 0)
+    riblets = player.get("riblets", 0)
+    bus.push("SYSTEM/OK", f"Money: {ions} Ions, {riblets} Riblets")
+
+    stats = player.get("stats", {})
+    if isinstance(stats, dict):
+        order = ["str", "int", "wis", "dex", "con", "cha"]
+        parts = []
+        for key in order:
+            val = stats.get(key, "?")
+            parts.append(f"{key.upper()} {val}")
+        bus.push("SYSTEM/OK", "Stats: " + ", ".join(parts))
+
+    conds = player.get("conditions", {})
+    active = []
+    if isinstance(conds, dict):
+        for name, flag in conds.items():
+            if flag:
+                active.append(name.replace("_", " "))
+    cond_line = "none" if not active else ", ".join(active)
+    bus.push("SYSTEM/OK", f"Conditions: {cond_line}")
+
+    year, x, y = _pos_tuple(player.get("pos", [0, 0, 0]))
+    bus.push("SYSTEM/OK", f"Location: Year {year}, ({x}, {y})")
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("statistics", lambda arg: statistics_cmd(arg, ctx))

--- a/src/mutants/engine/game_state.py
+++ b/src/mutants/engine/game_state.py
@@ -1,0 +1,72 @@
+"""In-memory data structures for live player state and saves."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+import copy
+
+
+@dataclass(frozen=True)
+class PlayerTemplate:
+    """Immutable baseline for a class."""
+
+    class_id: str
+    data: Dict[str, Any]
+
+
+@dataclass
+class PlayerState:
+    """Mutable live state for a player."""
+
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def clamp(self) -> None:
+        """Clamp obviously invalid numeric values (hp, stats, money)."""
+
+        hp = self.data.get("hp")
+        if isinstance(hp, dict):
+            current = hp.get("current")
+            maximum = hp.get("max")
+            try:
+                maximum_int = max(0, int(maximum))
+            except (TypeError, ValueError):
+                maximum_int = 0
+            try:
+                current_int = max(0, int(current))
+            except (TypeError, ValueError):
+                current_int = 0
+            if maximum_int and current_int > maximum_int:
+                current_int = maximum_int
+            hp["max"] = maximum_int
+            hp["current"] = current_int
+
+        for field_name in ("level", "exp_points", "exp", "exhaustion"):
+            if field_name in self.data:
+                try:
+                    self.data[field_name] = int(self.data[field_name])
+                except (TypeError, ValueError):
+                    self.data[field_name] = 0
+
+        for money_key in ("ions", "riblets"):
+            if money_key in self.data:
+                try:
+                    self.data[money_key] = max(0, int(self.data[money_key]))
+                except (TypeError, ValueError):
+                    self.data[money_key] = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.data
+
+
+@dataclass
+class SaveData:
+    meta: Dict[str, Any]
+    players: Dict[str, PlayerState]
+    active_id: str
+
+
+def deep_copy_from_template(template: PlayerTemplate) -> PlayerState:
+    """Return a deep copy of *template* as a mutable ``PlayerState``."""
+
+    return PlayerState(copy.deepcopy(template.data))
+

--- a/src/mutants/persistence/paths.py
+++ b/src/mutants/persistence/paths.py
@@ -1,0 +1,17 @@
+"""Centralized filesystem paths for player template and save data."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+STATE_ROOT = Path("state")
+
+
+TEMPLATE_PATH = STATE_ROOT / "playerlivestate.json"
+SAVE_PATH = STATE_ROOT / "savegame.json"
+
+
+def ensure_state_root() -> None:
+    """Ensure the state root directory exists."""
+    STATE_ROOT.mkdir(parents=True, exist_ok=True)
+

--- a/src/mutants/state/manager.py
+++ b/src/mutants/state/manager.py
@@ -1,0 +1,340 @@
+"""State management for player templates, save files, and live runtime."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+from mutants.engine.game_state import (
+    PlayerTemplate,
+    PlayerState,
+    SaveData,
+    deep_copy_from_template,
+)
+from mutants.io.atomic import atomic_write_json
+from mutants.persistence.paths import TEMPLATE_PATH, SAVE_PATH, ensure_state_root
+
+
+LOG = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+
+KNOWN_CLASS_ORDER = [
+    "player_thief",
+    "player_priest",
+    "player_wizard",
+    "player_warrior",
+    "player_mage",
+]
+
+
+@dataclass
+class LoadResult:
+    save_data: SaveData
+    created: bool
+
+
+def _now_ts() -> str:
+    return datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+def _deep_merge(base: Mapping[str, Any], overrides: Mapping[str, Any] | None) -> Dict[str, Any]:
+    merged = deepcopy(base)
+    if not isinstance(overrides, Mapping):
+        return merged
+    for key, value in overrides.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def _normalize_pos(value: Any, fallback: Iterable[int]) -> List[int]:
+    fallback_list = list(fallback)
+    if isinstance(value, Mapping):
+        cand = [value.get("year"), value.get("x"), value.get("y")]
+    elif isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        cand = list(value)
+    else:
+        cand = list(fallback_list)
+
+    norm: List[int] = []
+    for idx in range(3):
+        try:
+            norm.append(int(cand[idx]))
+        except (TypeError, ValueError, IndexError):
+            norm.append(int(fallback_list[idx] if idx < len(fallback_list) else 0))
+    return norm
+
+
+def _sanitize_player_dict(raw: Mapping[str, Any], template: Mapping[str, Any]) -> Dict[str, Any]:
+    data = deepcopy(raw)
+
+    defaults = deepcopy(template)
+
+    # Nested dicts: merge defaults to ensure required keys exist.
+    for key in ("hp", "stats", "conditions"):
+        template_val = defaults.get(key) or {}
+        if key in data and isinstance(data[key], Mapping):
+            data[key] = _deep_merge(template_val, data[key])
+        else:
+            data[key] = deepcopy(template_val)
+
+    # Inventory must be a list.
+    inv = data.get("inventory")
+    if not isinstance(inv, list):
+        data["inventory"] = list(defaults.get("inventory", []))
+
+    # Position normalization.
+    data["pos"] = _normalize_pos(data.get("pos"), defaults.get("pos", [2000, 0, 0]))
+
+    # Conditions should be booleans.
+    conds = data.get("conditions", {})
+    if isinstance(conds, dict):
+        for name, value in list(conds.items()):
+            conds[name] = bool(value)
+
+    # Scalar ints.
+    for key in ("level", "exp_points", "exp", "exhaustion", "ions", "riblets"):
+        if key in data:
+            try:
+                data[key] = int(data[key])
+            except (TypeError, ValueError):
+                data[key] = int(defaults.get(key, 0))
+        else:
+            data[key] = int(defaults.get(key, 0))
+
+    state = PlayerState(data)
+    state.clamp()
+    return state.to_dict()
+
+
+def _backup_corrupt(path: Path) -> None:
+    try:
+        ts = time.strftime("%Y%m%d%H%M%S")
+        backup = path.with_suffix(path.suffix + f".bak.{ts}")
+        os.replace(path, backup)
+        LOG.warning("Backed up corrupt save to %s", backup)
+    except Exception:
+        LOG.exception("Failed to back up corrupt save %s", path)
+
+
+class StateManager:
+    """Manage templates, persistent save data, and live runtime state."""
+
+    def __init__(
+        self,
+        template_path: str | Path = TEMPLATE_PATH,
+        save_path: str | Path = SAVE_PATH,
+        autosave_interval: int | None = None,
+    ) -> None:
+        ensure_state_root()
+        self.template_path = Path(template_path)
+        self.save_path = Path(save_path)
+        self.autosave_interval = max(0, int(autosave_interval or 0))
+        self.command_counter = 0
+        self.dirty = False
+
+        LOG.info("Loading player templates from %s", self.template_path)
+        self.templates = self.load_template(self.template_path)
+        self.template_order = [cid for cid in KNOWN_CLASS_ORDER if cid in self.templates]
+
+        load_result = self.load_or_init_save(self.templates, self.save_path)
+        self.save_data = load_result.save_data
+        self.dirty = False
+
+        # Legacy dict exposed to the rest of the codebase.
+        self._legacy_state: Dict[str, Any] = {"players": [], "active_id": self.save_data.active_id}
+        self._legacy_players: List[Dict[str, Any]] = self._legacy_state["players"]
+        self._sync_legacy_views()
+
+        if load_result.created:
+            LOG.info("Created new save at %s", self.save_path)
+            self.persist()
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def load_template(path: str | Path) -> Dict[str, PlayerTemplate]:
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Template not found at {p}")
+        data = json.loads(p.read_text(encoding="utf-8"))
+        players = data.get("players")
+        if not isinstance(players, list):
+            raise ValueError("Template missing 'players' list")
+
+        templates: Dict[str, PlayerTemplate] = {}
+        missing: List[str] = []
+        for cid in KNOWN_CLASS_ORDER:
+            found = None
+            for entry in players:
+                if entry.get("id") == cid:
+                    found = entry
+                    break
+            if not found:
+                missing.append(cid)
+                continue
+            templates[cid] = PlayerTemplate(class_id=cid, data=_sanitize_player_dict(found, found))
+
+        if missing:
+            raise ValueError(f"Template missing classes: {', '.join(missing)}")
+
+        # Warn about extras.
+        for entry in players:
+            cid = entry.get("id")
+            if cid not in KNOWN_CLASS_ORDER:
+                LOG.warning("Ignoring unknown class '%s' in template", cid)
+        return templates
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def load_or_init_save(
+        templates: Mapping[str, PlayerTemplate], save_path: str | Path
+    ) -> LoadResult:
+        p = Path(save_path)
+        if not p.exists():
+            LOG.info("No save found at %s; generating from templates", p)
+            return LoadResult(
+                save_data=_build_save_from_templates(templates),
+                created=True,
+            )
+
+        try:
+            raw = json.loads(p.read_text(encoding="utf-8"))
+        except Exception as exc:
+            LOG.warning("Failed to read save %s (%s); rebuilding", p, exc)
+            _backup_corrupt(p)
+            return LoadResult(
+                save_data=_build_save_from_templates(templates),
+                created=True,
+            )
+
+        try:
+            meta = raw.get("meta") or {}
+            version = int(meta.get("schema_version", 0))
+            if version != SCHEMA_VERSION:
+                raise ValueError(f"Unsupported schema_version {version}")
+            players_raw = raw.get("players")
+            if not isinstance(players_raw, Mapping):
+                raise ValueError("Save missing 'players' mapping")
+        except Exception as exc:
+            LOG.warning("Invalid save structure; rebuilding (%s)", exc)
+            _backup_corrupt(p)
+            return LoadResult(
+                save_data=_build_save_from_templates(templates),
+                created=True,
+            )
+
+        players: Dict[str, PlayerState] = {}
+        for cid, template in templates.items():
+            raw_player = players_raw.get(cid)
+            if isinstance(raw_player, Mapping):
+                players[cid] = PlayerState(_sanitize_player_dict(raw_player, template.data))
+            else:
+                LOG.warning("Missing player '%s' in save; recreating from template", cid)
+                players[cid] = deep_copy_from_template(template)
+
+        active_id = raw.get("active_id")
+        if active_id not in players:
+            fallback = next(iter(players)) if players else None
+            if fallback:
+                LOG.warning("Active player '%s' invalid; defaulting to %s", active_id, fallback)
+                active_id = fallback
+            else:
+                active_id = ""
+        save_meta = {
+            "schema_version": SCHEMA_VERSION,
+            "created_at": meta.get("created_at") or _now_ts(),
+            "updated_at": meta.get("updated_at") or _now_ts(),
+        }
+        return LoadResult(save_data=SaveData(meta=save_meta, players=players, active_id=active_id), created=False)
+
+    # ------------------------------------------------------------------
+    def _sync_legacy_views(self) -> None:
+        self._legacy_players.clear()
+        for cid in self.template_order:
+            ps = self.save_data.players.get(cid)
+            if ps:
+                self._legacy_players.append(ps.to_dict())
+        self._legacy_state["active_id"] = self.save_data.active_id
+
+    @property
+    def legacy_state(self) -> Dict[str, Any]:
+        return self._legacy_state
+
+    @property
+    def active_id(self) -> str:
+        return self.save_data.active_id
+
+    def get_active(self) -> PlayerState:
+        return self.save_data.players[self.save_data.active_id]
+
+    def switch_active(self, class_id: str) -> None:
+        if class_id not in self.save_data.players:
+            raise KeyError(class_id)
+        if class_id == self.save_data.active_id:
+            LOG.info("Class '%s' already active", class_id)
+            return
+        LOG.info("Switching active class to %s", class_id)
+        self.save_data.active_id = class_id
+        self.dirty = True
+        self._sync_legacy_views()
+        self.persist()
+
+    def reset_player(self, class_id: str) -> str:
+        if class_id not in self.save_data.players:
+            raise KeyError(class_id)
+        return "Bury not implemented yet."
+
+    def persist(self) -> None:
+        payload = self._serialize()
+        updated = _now_ts()
+        payload["meta"]["updated_at"] = updated
+        self.save_data.meta.update(payload["meta"])
+        atomic_write_json(self.save_path, payload)
+        LOG.info("Saved game state to %s", self.save_path)
+        self.dirty = False
+        self.command_counter = 0
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
+
+    def on_command_executed(self, command_name: str | None = None) -> None:
+        if not command_name:
+            return
+        self.command_counter += 1
+        if self.autosave_interval and self.dirty and self.command_counter >= self.autosave_interval:
+            LOG.info("Autosave triggered after %s commands", self.command_counter)
+            self.persist()
+
+    def save_on_exit(self) -> None:
+        if self.dirty:
+            LOG.info("Saving on exit")
+            self.persist()
+
+    def _serialize(self) -> Dict[str, Any]:
+        players_out = {
+            cid: player.to_dict()
+            for cid, player in self.save_data.players.items()
+        }
+        meta = dict(self.save_data.meta)
+        meta.setdefault("schema_version", SCHEMA_VERSION)
+        meta.setdefault("created_at", _now_ts())
+        meta.setdefault("updated_at", _now_ts())
+        return {"meta": meta, "players": players_out, "active_id": self.save_data.active_id}
+
+
+def _build_save_from_templates(templates: Mapping[str, PlayerTemplate]) -> SaveData:
+    players = {cid: deep_copy_from_template(tpl) for cid, tpl in templates.items()}
+    active_id = next(iter(players)) if players else ""
+    meta = {"schema_version": SCHEMA_VERSION, "created_at": _now_ts(), "updated_at": _now_ts()}
+    return SaveData(meta=meta, players=players, active_id=active_id)
+

--- a/src/mutants/ui/screens.py
+++ b/src/mutants/ui/screens.py
@@ -1,0 +1,132 @@
+"""Screen primitives for class selection and in-game mode."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+from mutants.state.manager import StateManager
+
+
+@dataclass
+class ScreenResponse:
+    action: str
+    payload: Optional[Any] = None
+
+
+def _pos_tuple(pos: Iterable[int]) -> tuple[int, int, int]:
+    data = list(pos) if not isinstance(pos, list) else pos
+    if len(data) < 3:
+        data = list(data) + [0] * (3 - len(data))
+    try:
+        year = int(data[0])
+    except (TypeError, ValueError):
+        year = 0
+    try:
+        x = int(data[1])
+    except (TypeError, ValueError):
+        x = 0
+    try:
+        y = int(data[2])
+    except (TypeError, ValueError):
+        y = 0
+    return year, x, y
+
+
+class ClassSelectionScreen:
+    """Render and parse the class selection menu."""
+
+    def __init__(self, manager: StateManager) -> None:
+        self.manager = manager
+
+    def render(self) -> List[str]:
+        lines: List[str] = []
+        for idx, class_id in enumerate(self.manager.template_order, start=1):
+            player = self.manager.save_data.players[class_id].to_dict()
+            class_name = player.get("class") or player.get("class_name") or player.get("name") or class_id
+            display_name = f"Mutant {class_name}".strip()
+            display = f"{idx}. {display_name:<17}"
+            level = player.get("level") or player.get("level_start") or 1
+            try:
+                level_val = int(level)
+            except (TypeError, ValueError):
+                level_val = 1
+            year, x, y = _pos_tuple(player.get("pos", [2000, 0, 0]))
+            suffix = f"Level: {level_val:<2}   Year: {year:<4}   ({x:>2}  {y:>2})"
+            lines.append(f"{display}{suffix}")
+        lines.append("Type BURY [class number] to reset a player.")
+        lines.append("***")
+        lines.append("Select (Bury, 1–5, ?)")
+        return lines
+
+    def handle(self, input_str: str) -> ScreenResponse:
+        raw = (input_str or "").strip()
+        if not raw:
+            return ScreenResponse("noop")
+
+        token = raw.upper()
+        if token == "?":
+            return ScreenResponse("message", "Enter 1–5 to choose a class; 'Bury' resets later.")
+
+        if token.startswith("BURY"):
+            parts = raw.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                return ScreenResponse("message", "Bury not implemented yet.")
+            return ScreenResponse("message", "Usage: BURY <class number> (not implemented yet).")
+
+        if raw.isdigit():
+            choice = int(raw)
+            if 1 <= choice <= len(self.manager.template_order):
+                class_id = self.manager.template_order[choice - 1]
+                return ScreenResponse("enter_game", class_id)
+        return ScreenResponse("message", "Unknown selection. Enter 1–5, ?, or BURY <n>.")
+
+
+class InGameScreen:
+    """Thin wrapper around the legacy room renderer."""
+
+    def __init__(self, render_room_callable) -> None:
+        self._render_room = render_room_callable
+
+    def render(self, ctx: Dict[str, Any]) -> List[str]:
+        return self._render_room(ctx)
+
+
+class ScreenManager:
+    def __init__(self, manager: StateManager, render_room_callable) -> None:
+        self.manager = manager
+        self.selection = ClassSelectionScreen(manager)
+        self.ingame = InGameScreen(render_room_callable)
+        self.mode = "selection"
+
+    def in_selection(self) -> bool:
+        return self.mode == "selection"
+
+    def render(self, ctx: Dict[str, Any]) -> List[str]:
+        if self.in_selection():
+            return self.selection.render()
+        return self.ingame.render(ctx)
+
+    def handle_selection(self, raw: str, ctx: Dict[str, Any]) -> ScreenResponse:
+        response = self.selection.handle(raw)
+        if response.action == "enter_game" and isinstance(response.payload, str):
+            try:
+                self.manager.switch_active(response.payload)
+            except KeyError:
+                return ScreenResponse("message", "Unknown class.")
+            self.mode = "game"
+            ctx["render_next"] = True
+        elif response.action == "message" and response.payload:
+            print(response.payload)
+            ctx["render_next"] = True
+        elif response.action == "noop":
+            ctx["render_next"] = True
+        return response
+
+    def enter_selection(self, ctx: Dict[str, Any]) -> None:
+        self.mode = "selection"
+        ctx["render_next"] = True
+
+    def enter_game(self, ctx: Dict[str, Any]) -> None:
+        self.mode = "game"
+        ctx["render_next"] = True
+

--- a/tests/commands/test_statistics.py
+++ b/tests/commands/test_statistics.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from mutants.commands import statistics
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, kind, text):
+        self.events.append((kind, text))
+
+
+class FakePlayer:
+    def __init__(self):
+        self.data = {
+            "name": "Thief",
+            "class": "Thief",
+            "level": 1,
+            "exp_points": 0,
+            "hp": {"current": 10, "max": 12},
+            "armour": {"armour_class": 2},
+            "ions": 123,
+            "riblets": 4,
+            "stats": {"str": 10, "int": 9, "wis": 8, "dex": 11, "con": 12, "cha": 13},
+            "conditions": {"poisoned": False, "encumbered": True, "ion_starving": False},
+            "pos": [2000, 1, -2],
+        }
+
+    def to_dict(self):
+        return self.data
+
+
+class FakeStateManager:
+    def __init__(self):
+        self.player = FakePlayer()
+
+    def get_active(self):
+        return self.player
+
+
+def test_statistics_pushes_summary():
+    bus = FakeBus()
+    ctx = {"feedback_bus": bus, "state_manager": FakeStateManager()}
+    statistics.statistics_cmd("", ctx)
+    lines = [text for _kind, text in bus.events]
+    assert any("Thief" in line for line in lines)
+    assert any("HP" in line for line in lines)
+    assert any("Location" in line for line in lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = ROOT.parent
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/state/test_state_manager.py
+++ b/tests/state/test_state_manager.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mutants.state.manager import StateManager
+
+
+TEMPLATE_SRC = Path("state/playerlivestate.json")
+
+
+def _copy_template(tmp_path) -> Path:
+    data = json.loads(TEMPLATE_SRC.read_text(encoding="utf-8"))
+    tpl_path = tmp_path / "template.json"
+    tpl_path.write_text(json.dumps(data), encoding="utf-8")
+    return tpl_path
+
+
+def test_load_template_reads_known_classes(tmp_path):
+    tpl_path = _copy_template(tmp_path)
+    templates = StateManager.load_template(tpl_path)
+    assert set(templates.keys()) == {
+        "player_thief",
+        "player_priest",
+        "player_wizard",
+        "player_warrior",
+        "player_mage",
+    }
+
+
+def test_state_manager_initializes_save(tmp_path, monkeypatch):
+    tpl_path = _copy_template(tmp_path)
+    save_path = tmp_path / "save.json"
+
+    calls: list[Path] = []
+
+    def fake_atomic(path, payload):
+        calls.append(Path(path))
+
+    monkeypatch.setattr("mutants.state.manager.atomic_write_json", fake_atomic)
+
+    mgr = StateManager(template_path=tpl_path, save_path=save_path)
+    # First persist happens during initialization.
+    assert calls, "expected save to be written during initialization"
+    calls.clear()
+
+    assert mgr.active_id == "player_thief"
+    mgr.switch_active("player_priest")
+    assert mgr.active_id == "player_priest"
+    assert calls, "expected save on class switch"
+
+
+def test_switch_active_updates_legacy_view(tmp_path, monkeypatch):
+    tpl_path = _copy_template(tmp_path)
+    save_path = tmp_path / "save.json"
+
+    monkeypatch.setattr("mutants.state.manager.atomic_write_json", lambda p, d: None)
+
+    mgr = StateManager(template_path=tpl_path, save_path=save_path)
+    legacy = mgr.legacy_state
+    assert legacy["active_id"] == "player_thief"
+    mgr.switch_active("player_wizard")
+    assert legacy["active_id"] == "player_wizard"

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -16,7 +16,12 @@ def active(state):
 
 
 def make_ctx():
-    return context.build_context()
+    ctx = context.build_context()
+    screen = ctx.get("screen_manager")
+    if screen:
+        screen.enter_game(ctx)
+        ctx["render_next"] = False
+    return ctx
 
 
 def test_look_renders_room(capsys):

--- a/tests/test_router_prefix.py
+++ b/tests/test_router_prefix.py
@@ -73,3 +73,28 @@ def test_direction_prefix_without_alias():
     assert called.get('dir') == 'west'
     assert d._bus.events == []
 
+
+def test_statistics_prefix_matches():
+    d = _dispatch()
+    called = {}
+
+    def stats(arg):
+        called['ok'] = True
+
+    d.register('statistics', stats)
+    d.call('sta', '')
+    assert called.get('ok') is True
+
+
+def test_statistics_prefix_ambiguous_requires_more():
+    d = _dispatch()
+    d.register('statistics', lambda arg: None)
+    d.register('status', lambda arg: None)
+    d.call('stat', '')
+    assert d._bus.events == [
+        (
+            'SYSTEM/WARN',
+            'Ambiguous command "stat" (did you mean: statistics, status)',
+        )
+    ]
+

--- a/tests/ui/test_screens.py
+++ b/tests/ui/test_screens.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mutants.ui.screens import ScreenManager
+
+
+@dataclass
+class FakePlayer:
+    data: dict
+
+    def to_dict(self):
+        return self.data
+
+
+class FakeSaveData:
+    def __init__(self, players):
+        self.players = players
+        self.active_id = "player_thief"
+
+
+class FakeManager:
+    def __init__(self):
+        self.template_order = [
+            "player_thief",
+            "player_priest",
+            "player_wizard",
+            "player_warrior",
+            "player_mage",
+        ]
+        base = {
+            "pos": [2000, 0, 0],
+            "hp": {"current": 10, "max": 10},
+            "stats": {"str": 10, "int": 10, "wis": 10, "dex": 10, "con": 10, "cha": 10},
+            "conditions": {"poisoned": False, "encumbered": False, "ion_starving": False},
+            "level": 1,
+            "class": "Thief",
+            "name": "Thief",
+        }
+        players = {}
+        for cid in self.template_order:
+            entry = dict(base)
+            entry = {**base, "class": cid.split("_")[-1].capitalize(), "name": cid.split("_")[-1].capitalize()}
+            players[cid] = FakePlayer(entry)
+        self.save_data = FakeSaveData(players)
+        self.last_switch = None
+
+    def switch_active(self, class_id: str) -> None:
+        self.save_data.active_id = class_id
+        self.last_switch = class_id
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, kind, text):
+        self.events.append((kind, text))
+
+
+def fake_render_room(ctx):
+    return ["room"]
+
+
+def test_selection_numeric_switch(capsys):
+    mgr = FakeManager()
+    screens = ScreenManager(mgr, fake_render_room)
+    ctx = {"render_next": False, "feedback_bus": FakeBus()}
+    screens.handle_selection("2", ctx)
+    assert mgr.last_switch == "player_priest"
+    assert screens.mode == "game"
+    assert ctx["render_next"] is True
+
+
+def test_selection_help_message(capsys):
+    mgr = FakeManager()
+    screens = ScreenManager(mgr, fake_render_room)
+    ctx = {"render_next": False, "feedback_bus": FakeBus()}
+    screens.handle_selection("?", ctx)
+    out = capsys.readouterr().out
+    assert "Enter 1–5" in out
+
+
+def test_selection_bury_stub(capsys):
+    mgr = FakeManager()
+    screens = ScreenManager(mgr, fake_render_room)
+    ctx = {"render_next": False, "feedback_bus": FakeBus()}
+    screens.handle_selection("BURY 3", ctx)
+    out = capsys.readouterr().out
+    assert "Bury not implemented" in out


### PR DESCRIPTION
## Summary
- introduce a templated state manager with atomic save handling, a screen manager that boots into the class selection menu, and an `x` command to return there
- add a non-mutating statistics command with prefix matching along with new documentation covering menus, saves, and state layering
- expand the test suite for state management, screen parsing, and command routing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c86e866c6c832b95180044fa2a688b