### PR TITLE
Add quit command and selection exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It intentionally contains **no game logic**. Start adding code under `src/mutant
 - The container installs the package in editable mode.
 - Run: `pip install -e .`
 - Run: `python -m mutants`.
-- Pick a class on the Class Selection screen (1–5), use `stat` to view player details, and press `x` to return to the menu. `Bury` will arrive in a future update.
+- Pick a class on the Class Selection screen (1–5), use `stat` to view player details, press `x` to return to the menu, and use `quit` to save and exit. `Bury` will arrive in a future update.
 
 ## Features
 - Class Selection & Statistics foundation

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -19,6 +19,7 @@ Select (Bury, 1–5, ?)
 - Press `1`–`5` to activate a class and enter the in-game view.
 - Type `?` for a reminder: “Enter 1–5 to choose a class; ‘Bury’ resets later.”
 - `BURY <n>` is accepted but currently responds with “Bury not implemented yet.”
+- Type `quit`/`q` to save and exit immediately.
 
 The menu always follows the template order regardless of the current active
 class.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,6 +7,10 @@ three characters. If two commands share the same three-letter prefix you must
 type one more letter to disambiguate. Single-letter shortcuts remain available
 only when explicitly aliased (e.g. `x` to open the class selection menu).
 
+## Quit
+
+Type `quit` (or the prefix `qui`/`q`) to save and exit from anywhere.
+
 ## Movement
 
 Typing a direction moves you to an adjacent tile. Any prefix of the full word

--- a/src/mutants/commands/quit.py
+++ b/src/mutants/commands/quit.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def quit_cmd(arg: str, ctx: Dict[str, Any]) -> str:
+    state_mgr = ctx.get("state_manager")
+    if state_mgr is not None:
+        state_mgr.save_on_exit()
+    bus = ctx.get("feedback_bus")
+    if bus is not None:
+        bus.push("SYSTEM/OK", "Goodbye!")
+    return "__QUIT__"
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("quit", lambda arg: quit_cmd(arg, ctx))
+    dispatch.alias("q", "quit")

--- a/src/mutants/repl/loop.py
+++ b/src/mutants/repl/loop.py
@@ -31,10 +31,19 @@ def main() -> None:
 
         stripped = raw.strip()
         if screen_mgr and screen_mgr.in_selection():
-            screen_mgr.handle_selection(stripped, ctx)
+            resp = screen_mgr.handle_selection(stripped, ctx)
+            if getattr(resp, "action", "") == "quit":
+                if ctx.get("render_next"):
+                    render_frame(ctx)
+                    ctx["render_next"] = False
+                else:
+                    flush_feedback(ctx)
+                break
             if ctx.get("render_next"):
                 render_frame(ctx)
                 ctx["render_next"] = False
+            else:
+                flush_feedback(ctx)
             continue
 
         token, _, arg = stripped.partition(" ")
@@ -47,6 +56,9 @@ def main() -> None:
             ctx["render_next"] = False
         else:
             flush_feedback(ctx)
+
+        if executed == "quit" or executed == "__QUIT__":
+            break
 
     if state_mgr:
         state_mgr.save_on_exit()

--- a/src/mutants/ui/screens.py
+++ b/src/mutants/ui/screens.py
@@ -63,6 +63,10 @@ class ClassSelectionScreen:
         if not raw:
             return ScreenResponse("noop")
 
+        lowered = raw.lower()
+        if lowered in ("q",) or (len(lowered) >= 3 and lowered.startswith("qui")):
+            return ScreenResponse("quit")
+
         token = raw.upper()
         if token == "?":
             return ScreenResponse("message", "Enter 1–5 to choose a class; 'Bury' resets later.")
@@ -115,6 +119,11 @@ class ScreenManager:
                 return ScreenResponse("message", "Unknown class.")
             self.mode = "game"
             ctx["render_next"] = True
+        elif response.action == "quit":
+            ctx["render_next"] = False
+            bus = ctx.get("feedback_bus")
+            if bus is not None:
+                bus.push("SYSTEM/OK", "Goodbye!")
         elif response.action == "message" and response.payload:
             print(response.payload)
             ctx["render_next"] = True

--- a/tests/commands/test_quit.py
+++ b/tests/commands/test_quit.py
@@ -1,0 +1,57 @@
+from mutants.commands import quit as quit_cmd
+from mutants.repl.dispatch import Dispatch
+
+
+class DummyStateManager:
+    def __init__(self) -> None:
+        self.saved = 0
+
+    def save_on_exit(self) -> None:
+        self.saved += 1
+
+    def on_command_executed(self, executed):
+        pass
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.events = []
+
+    def push(self, kind, text):
+        self.events.append((kind, text))
+
+
+def make_ctx():
+    bus = DummyBus()
+    state_mgr = DummyStateManager()
+    ctx = {"feedback_bus": bus, "state_manager": state_mgr}
+    return ctx, bus, state_mgr
+
+
+def register_quit(ctx):
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+    quit_cmd.register(dispatch, ctx)
+    return dispatch
+
+
+def test_quit_prefix_saves_and_notifies():
+    ctx, bus, state_mgr = make_ctx()
+    dispatch = register_quit(ctx)
+
+    executed = dispatch.call("qui", "")
+
+    assert executed == "quit"
+    assert state_mgr.saved == 1
+    assert ("SYSTEM/OK", "Goodbye!") in bus.events
+
+
+def test_quit_alias_q():
+    ctx, bus, state_mgr = make_ctx()
+    dispatch = register_quit(ctx)
+
+    executed = dispatch.call("q", "")
+
+    assert executed == "quit"
+    assert state_mgr.saved == 1
+    assert ("SYSTEM/OK", "Goodbye!") in bus.events

--- a/tests/repl/test_loop_quit.py
+++ b/tests/repl/test_loop_quit.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from mutants.commands import quit as quit_cmd
+from mutants.repl import loop
+from mutants.ui.feedback import FeedbackBus
+
+
+class DummyStateManager:
+    def __init__(self) -> None:
+        self.saved = 0
+        self.executed = []
+
+    def save_on_exit(self) -> None:
+        self.saved += 1
+
+    def on_command_executed(self, executed) -> None:
+        self.executed.append(executed)
+
+
+class DummyScreenManager:
+    def in_selection(self) -> bool:
+        return False
+
+
+def test_loop_quit_triggers_save_and_exit(monkeypatch):
+    state_mgr = DummyStateManager()
+    bus = FeedbackBus()
+    screen_mgr = DummyScreenManager()
+
+    ctx = {
+        "feedback_bus": bus,
+        "state_manager": state_mgr,
+        "screen_manager": screen_mgr,
+        "render_next": False,
+    }
+
+    monkeypatch.setattr(loop, "build_context", lambda: ctx)
+    monkeypatch.setattr(
+        loop, "register_all", lambda dispatch, ctx: quit_cmd.register(dispatch, ctx)
+    )
+
+    monkeypatch.setattr(loop, "render_frame", lambda ctx: None)
+
+    drained_events = []
+
+    def fake_flush(local_ctx):
+        drained_events.append(local_ctx["feedback_bus"].drain())
+
+    monkeypatch.setattr(loop, "flush_feedback", fake_flush)
+
+    inputs = iter(["quit"])
+
+    def fake_input(prompt: str = "") -> str:
+        try:
+            return next(inputs)
+        except StopIteration as exc:  # pragma: no cover - defensive guard
+            raise AssertionError("input called after quit") from exc
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    loop.main()
+
+    assert state_mgr.saved == 2
+    assert state_mgr.executed[-1] == "quit"
+    assert any(ev for batch in drained_events for ev in batch if ev["text"] == "Goodbye!")

--- a/tests/ui/test_screens.py
+++ b/tests/ui/test_screens.py
@@ -88,3 +88,16 @@ def test_selection_bury_stub(capsys):
     screens.handle_selection("BURY 3", ctx)
     out = capsys.readouterr().out
     assert "Bury not implemented" in out
+
+
+def test_selection_quit_returns_quit_action():
+    mgr = FakeManager()
+    screens = ScreenManager(mgr, fake_render_room)
+    bus = FakeBus()
+    ctx = {"render_next": False, "feedback_bus": bus}
+
+    resp = screens.handle_selection("q", ctx)
+
+    assert resp.action == "quit"
+    assert ctx["render_next"] is False
+    assert ("SYSTEM/OK", "Goodbye!") in bus.events


### PR DESCRIPTION
## Summary
- add a global quit command that saves and sends a goodbye via the feedback bus
- wire the REPL and class selection screen to break out when quit/q is entered
- document the quit command in the README and command/menu references

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8872676e8832b870872e9df99dc12