### PR TITLE
Persist player compass position via state manager

### DIFF
--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -16,6 +16,8 @@
 - `meta.created_at`: ISO-8601 UTC timestamp for the initial save creation.
 - `meta.updated_at`: refreshed on every successful `persist()`.
 - `players`: map keyed by class id (`player_thief`, `player_priest`, etc.).
+  - Each player stores `pos = [year, x, y]`, the latest compass location tracked
+    by the `StateManager` and written on autosave/exit.
 - `active_id`: the class currently in control.
 
 ## Autosave & triggers

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -35,7 +35,9 @@ without touching the golden templates shipped in the repo.
 - `ions`, `riblets`: non-negative integers.
 - `conditions`: `{ "poisoned", "encumbered", "ion_starving" }` booleans.
 - `inventory`: list of item instance IDs (may be empty).
-- `pos`: `[year, x, y]` integers; year stays in sync with the loaded world.
+- `pos`: `[year, x, y]` integers; this compass location is updated through the
+  `StateManager` whenever you move or change year and is persisted on autosave
+  or clean exit.
 - Additional keys (notes, exhaustion, armour, etc.) are preserved.
 
 ### Example

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,9 @@ Type `quit` (or the prefix `qui`/`q`) to save and exit from anywhere.
 Typing a direction moves you to an adjacent tile. Any prefix of the full word
 is accepted, case-insensitively: `w`/`we`/`wes`/`west`,
 `n`/`no`/`nor`/`nort`/`north`, and similarly for `east` and `south`.
+Movement updates your compass location `[year, x, y]` through the
+`StateManager`, and the coordinates persist to `state/savegame.json` on
+autosave or clean exit.
 
 ## Look
 

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -80,8 +80,13 @@ def move(dir_code: str, ctx: Dict[str, Any]) -> None:
         return
 
     dx, dy = DELTA[dir_code]
-    p["pos"][1] = x + dx
-    p["pos"][2] = y + dy
+    new_x = x + dx
+    new_y = y + dy
+
+    state_mgr = ctx.get("state_manager")
+    if state_mgr is None:
+        raise RuntimeError("state manager unavailable; cannot update position")
+    state_mgr.set_position(year, new_x, new_y)
     # Successful movement requests a render of the new room.
     ctx["render_next"] = True
     # Do not echo success movement like "You head north." Original shows next room immediately.

--- a/src/mutants/state/manager.py
+++ b/src/mutants/state/manager.py
@@ -277,6 +277,20 @@ class StateManager:
     def get_active(self) -> PlayerState:
         return self.save_data.players[self.save_data.active_id]
 
+    def set_position(self, year: int, x: int, y: int) -> None:
+        """Update the active player's compass location."""
+
+        player = self.get_active().data
+        player["pos"] = [int(year), int(x), int(y)]
+        self.mark_dirty()
+
+    def set_year(self, year: int) -> None:
+        """Update only the active player's year, preserving x/y coordinates."""
+
+        player = self.get_active().data
+        current = _normalize_pos(player.get("pos"), [2000, 0, 0])
+        self.set_position(int(year), current[1], current[2])
+
     def switch_active(self, class_id: str) -> None:
         if class_id not in self.save_data.players:
             raise KeyError(class_id)

--- a/tests/state/test_state_manager.py
+++ b/tests/state/test_state_manager.py
@@ -61,3 +61,21 @@ def test_switch_active_updates_legacy_view(tmp_path, monkeypatch):
     assert legacy["active_id"] == "player_thief"
     mgr.switch_active("player_wizard")
     assert legacy["active_id"] == "player_wizard"
+
+
+def test_position_persists(tmp_path, monkeypatch):
+    tpl_path = _copy_template(tmp_path)
+    save_path = tmp_path / "save.json"
+
+    def fake_atomic(path, payload):
+        save_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    monkeypatch.setattr("mutants.state.manager.atomic_write_json", fake_atomic)
+
+    mgr = StateManager(template_path=tpl_path, save_path=save_path)
+
+    mgr.set_position(2001, 3, -1)
+    mgr.save_on_exit()
+
+    data = json.loads(save_path.read_text(encoding="utf-8"))
+    assert data["players"][mgr.active_id]["pos"] == [2001, 3, -1]

--- a/tests/test_move_commands.py
+++ b/tests/test_move_commands.py
@@ -34,10 +34,12 @@ def test_look_renders_room(capsys):
 
 def test_move_north_updates_position_and_feedback():
     ctx = make_ctx()
+    state_mgr = ctx["state_manager"]
+    state_mgr.set_position(2000, 0, 0)
     p = active(ctx["player_state"])
-    p["pos"] = [2000, 0, 0]
     move("N", ctx)
     assert p["pos"] == [2000, 0, 1]
+    assert state_mgr.get_active().data["pos"] == [2000, 0, 1]
     events = ctx["feedback_bus"].drain()
     # No movement echo; success should not emit MOVE/OK.
     assert not any(ev["kind"] == "MOVE/OK" for ev in events)
@@ -45,18 +47,20 @@ def test_move_north_updates_position_and_feedback():
 
 def test_boundary_blocks_movement():
     ctx = make_ctx()
+    state_mgr = ctx["state_manager"]
+    state_mgr.set_position(2000, 14, 0)
     p = active(ctx["player_state"])
-    p["pos"] = [2000, 14, 0]
     move("E", ctx)
     assert p["pos"] == [2000, 14, 0]
+    assert state_mgr.get_active().data["pos"] == [2000, 14, 0]
     events = ctx["feedback_bus"].drain()
     assert any(ev["kind"] == "MOVE/BLOCKED" and ev["text"] == "You're blocked!" for ev in events)
 
 
 def test_peek_direction_renders_adjacent_room(capsys):
     ctx = make_ctx()
+    ctx["state_manager"].set_position(2000, 0, 0)
     p = active(ctx["player_state"])
-    p["pos"] = [2000, 0, 0]
     look_cmd("north", ctx)
     assert ctx["render_next"]
     render_frame(ctx)
@@ -67,8 +71,8 @@ def test_peek_direction_renders_adjacent_room(capsys):
 
 def test_peek_direction_prefix_renders_adjacent_room(capsys):
     ctx = make_ctx()
+    ctx["state_manager"].set_position(2000, 0, 0)
     p = active(ctx["player_state"])
-    p["pos"] = [2000, 0, 0]
     look_cmd("we", ctx)
     assert ctx["render_next"]
     render_frame(ctx)
@@ -79,8 +83,8 @@ def test_peek_direction_prefix_renders_adjacent_room(capsys):
 
 def test_peek_blocked_does_not_render():
     ctx = make_ctx()
+    ctx["state_manager"].set_position(2000, 14, 0)
     p = active(ctx["player_state"])
-    p["pos"] = [2000, 14, 0]
     look_cmd("east", ctx)
     assert not ctx["render_next"]
     events = ctx["feedback_bus"].drain()


### PR DESCRIPTION
## Summary
- add helper APIs on `StateManager` for setting the active player's position/year
- route the move command and tests through the manager so compass coords stay in sync and persist
- document the saved `pos` field and cover persistence with unit tests

## Testing
- PYTHONPATH=src pytest tests/state/test_state_manager.py tests/test_move_commands.py

------
https://chatgpt.com/codex/tasks/task_e_68c88cb1ea10832b868d2bb7089521f0