### PR TITLE
Add travel command for year origin reposition

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,6 +20,14 @@ Movement updates your compass location `[year, x, y]` through the
 `StateManager`, and the coordinates persist to `state/savegame.json` on
 autosave or clean exit.
 
+## Travel
+
+`travel <year>` (prefixes `tra`/`trav`/`trave`/`travel`) moves you to the
+origin of the requested year. Your compass immediately updates to `[year, 0,
+0]` without triggering an automatic room render, so you can queue another
+action before the next paint. Traveling to the current year is allowed and
+currently free; a future update will charge 3,000 Ions per year of distance.
+
 ## Look
 
 `look` shows the current room. `look <direction>` peeks into an adjacent tile

--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Time travel command that repositions the active player."""
+
+from typing import Any, Callable, Dict
+
+
+def _parse_year(arg: str) -> int | None:
+    """Parse a year argument, returning ``None`` when invalid."""
+
+    s = (arg or "").strip()
+    try:
+        return int(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
+    """Handle the ``travel`` command."""
+
+    bus = ctx["feedback_bus"]
+    state_manager = ctx.get("state_manager")
+    if state_manager is None:
+        bus.push("SYSTEM/WARN", "Travel unavailable.")
+        return
+
+    year = _parse_year(arg)
+    if year is None:
+        bus.push("SYSTEM/WARN", "Usage: travel <year>")
+        return
+
+    loader: Callable[[int], Any] | None = ctx.get("world_loader")
+    if callable(loader):
+        try:
+            loader(int(year))
+        except Exception:
+            bus.push(
+                "SYSTEM/WARN",
+                f"World {year} unavailable; a fallback may be used.",
+            )
+
+    state_manager.set_position(int(year), 0, 0)
+    bus.push("SYSTEM/OK", f"Traveled to Year {year}; position set to (0, 0).")
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("travel", lambda arg: travel_cmd(arg, ctx))

--- a/tests/commands/test_travel.py
+++ b/tests/commands/test_travel.py
@@ -1,0 +1,32 @@
+from mutants.commands import travel as t
+
+
+class Bus:
+    def __init__(self) -> None:
+        self.events = []
+
+    def push(self, kind, msg):
+        self.events.append((kind, msg))
+
+
+class SM:
+    def __init__(self) -> None:
+        self.pos = [2000, 2, 2]
+
+    def get_active(self):
+        class P:
+            def __init__(self, pos):
+                self.data = {"pos": pos}
+
+        return P(self.pos)
+
+    def set_position(self, y, x, z):
+        self.pos[:] = [y, x, z]
+
+
+def test_travel_sets_origin_no_render():
+    bus, sm = Bus(), SM()
+    ctx = {"feedback_bus": bus, "state_manager": sm}
+    t.travel_cmd("2100", ctx)
+    assert sm.pos == [2100, 0, 0]
+    assert any("Traveled to Year 2100" in msg for _, msg in bus.events)


### PR DESCRIPTION
## Summary
- add a `travel` command that repositions the active player to the origin of the requested year without forcing a render
- attempt to preload the target world when a loader is available and surface user feedback
- document the travel command and cover the behaviour with a unit test

## Testing
- PYTHONPATH=src pytest tests/commands/test_travel.py

------
https://chatgpt.com/codex/tasks/task_e_68c89212fe38832b853870cd66a1aaf5