### PR TITLE
Implement BBS-style statistics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It intentionally contains **no game logic**. Start adding code under `src/mutant
 - The container installs the package in editable mode.
 - Run: `pip install -e .`
 - Run: `python -m mutants`.
-- Pick a class on the Class Selection screen (1–5), use `stat` to view player details, press `x` to return to the menu, and use `quit` to save and exit. `Bury` will arrive in a future update.
+- Pick a class on the Class Selection screen (1–5), use `sta`/`stat` to view the full statistics page, press `x` to return to the menu, and use `quit` to save and exit. `Bury` will arrive in a future update.
 
 ## Features
 - Class Selection & Statistics foundation

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -70,8 +70,29 @@ parsed via the normalization helper (see [utilities](utilities.md)).
 ## Statistics
 
 `statistics` (or any prefix such as `sta`, `stat`, `stati`, …) shows the active
-player's level, HP, AC, experience, money, ability scores, active conditions,
-and current location. The command is read-only.
+player's full BBS-style sheet without triggering a render. A typical output
+looks like:
+
+```
+Name: Gwydion / Mutant Thief
+Exhaustion      : 0
+Str: 15     Int: 9     Wis: 8
+Dex: 14     Con: 15    Cha: 16
+Hit Points      : 18 / 18      Level: 1
+Exp. Points     : 0
+Riblets         : 0
+Ions            : 30000
+Wearing Armor   : Nothing.   Armour Class: 1
+Ready to Combat : NO ONE
+Readied Spell   : No spell memorized.
+Year A.D.       : 2000
+
+You are carrying the following items:  (Total Weight: 0 LB's)
+Nothing.
+```
+
+Values are drawn from the active player and the items registry when available,
+and the command is read-only.
 
 ## Class Selection
 

--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -1,81 +1,208 @@
 """Statistics command for inspecting the active player."""
 from __future__ import annotations
 
-from typing import Iterable
+
+def _col(label: str, value: str, width: int = 16) -> str:
+    return f"{label:<{width}} : {value}"
 
 
-def _pos_tuple(pos: Iterable[int]) -> tuple[int, int, int]:
-    data = list(pos)
-    data += [0] * max(0, 3 - len(data))
+def _name_line(player: dict) -> str:
+    name_raw = player.get("name") or player.get("class") or "Unknown"
+    cls_raw = player.get("class") or player.get("class_name") or ""
+    name = str(name_raw).strip()
+    cls = str(cls_raw).strip()
+    if cls and cls.lower() not in name.lower():
+        disp = f"{name} / Mutant {cls}"
+    else:
+        disp = f"{name} / Mutant {cls or name}"
+    return f"Name: {disp}"
+
+
+def _num(value, default: int = 0) -> int:
     try:
-        year = int(data[0])
-    except (TypeError, ValueError):
-        year = 0
+        return int(value)
+    except Exception:
+        return default
+
+
+def _hp(player: dict) -> tuple[int, int]:
+    hp = player.get("hp") or {}
+    if isinstance(hp, dict):
+        current = _num(hp.get("current"))
+        maximum = _num(hp.get("max"))
+    else:
+        current = maximum = _num(hp)
+    return current, maximum
+
+
+def _ac(player: dict) -> int:
+    armour = player.get("armour") or {}
+    if isinstance(armour, dict):
+        value = armour.get("armour_class", player.get("ac", 1))
+    else:
+        value = armour or player.get("ac", 1)
+    return _num(value, 1)
+
+
+def _year(player: dict) -> int:
+    pos = player.get("pos") or [2000, 0, 0]
+    if isinstance(pos, (list, tuple)) and pos:
+        return _num(pos[0], 2000)
+    return 2000
+
+
+def _item_display(items, iid) -> str:
+    for attr in ("get_display_name", "display_name", "name_of", "describe"):
+        fn = getattr(items, attr, None)
+        if callable(fn):
+            try:
+                info = fn(iid)
+                if isinstance(info, dict):
+                    return str(info.get("name") or iid)
+                return str(info)
+            except Exception:
+                pass
+    return str(iid)
+
+
+def _item_weight_lb(items, iid) -> int:
+    for attr in ("weight_lb", "get_weight_lb", "describe"):
+        fn = getattr(items, attr, None)
+        if callable(fn):
+            try:
+                info = fn(iid)
+                if isinstance(info, dict):
+                    return _num(info.get("weight_lb"), 0)
+                return _num(info, 0)
+            except Exception:
+                pass
+    return 0
+
+
+def _armour_name(player: dict) -> str:
+    armour = player.get("armour") or {}
+    if isinstance(armour, dict):
+        for key in ("display_name", "name", "id"):
+            value = armour.get(key)
+            if value:
+                return str(value)
+    elif armour:
+        return str(armour)
+    return "Nothing."
+
+
+def _player_dict(ctx) -> dict:
+    state_mgr = ctx.get("state_manager")
+    if state_mgr is None:
+        return {}
     try:
-        x = int(data[1])
-    except (TypeError, ValueError):
-        x = 0
-    try:
-        y = int(data[2])
-    except (TypeError, ValueError):
-        y = 0
-    return year, x, y
+        active = state_mgr.get_active()
+    except Exception:
+        return {}
+    if active is None:
+        return {}
+    if hasattr(active, "to_dict"):
+        try:
+            data = active.to_dict() or {}
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            return {}
+    if isinstance(active, dict):
+        return active
+    return {}
 
 
 def statistics_cmd(arg: str, ctx) -> None:
-    state_mgr = ctx.get("state_manager")
-    if state_mgr is None:
-        ctx["feedback_bus"].push("SYSTEM/WARN", "Statistics unavailable: state manager not initialized.")
+    bus = ctx.get("feedback_bus")
+    if bus is None:
         return
-    player = state_mgr.get_active().to_dict()
-    bus = ctx["feedback_bus"]
 
-    name = player.get("name") or player.get("class") or "Unknown"
-    cls = player.get("class") or player.get("class_name") or ""
-    title = f"{name}"
-    if cls and cls.lower() not in name.lower():
-        title = f"{name} the {cls}"
-    bus.push("SYSTEM/OK", title)
+    player = _player_dict(ctx)
 
-    level = player.get("level") or player.get("level_start") or 1
-    try:
-        level_val = int(level)
-    except (TypeError, ValueError):
-        level_val = 1
-    exp_val = player.get("exp_points", player.get("exp", 0))
-    bus.push("SYSTEM/OK", f"Level: {level_val}    EXP: {exp_val}")
+    stats = player.get("stats") or {}
+    if not isinstance(stats, dict):
+        stats = {}
+    stats_values = {key: _num(stats.get(key)) for key in ("str", "int", "wis", "dex", "con", "cha")}
 
-    hp = player.get("hp", {}) if isinstance(player.get("hp"), dict) else {}
-    hp_cur = hp.get("current", 0)
-    hp_max = hp.get("max", 0)
-    armour = player.get("armour", {}) if isinstance(player.get("armour"), dict) else {}
-    ac_val = armour.get("armour_class", player.get("ac", 0))
-    bus.push("SYSTEM/OK", f"HP: {hp_cur}/{hp_max}    AC: {ac_val}")
+    hp_current, hp_max = _hp(player)
+    level = _num(player.get("level", player.get("level_start")), 1)
+    exhaustion = _num(player.get("exhaustion"))
+    exp_points = _num(player.get("exp_points", player.get("exp")))
+    riblets = _num(player.get("riblets"))
+    ions = _num(player.get("ions"))
+    armour_class = _ac(player)
+    armour_name = _armour_name(player)
+    year = _year(player)
 
-    ions = player.get("ions", 0)
-    riblets = player.get("riblets", 0)
-    bus.push("SYSTEM/OK", f"Money: {ions} Ions, {riblets} Riblets")
+    lines = [
+        _name_line(player),
+        _col("Exhaustion", str(exhaustion)),
+        f"Str: {stats_values['str']:<2}     Int: {stats_values['int']:<2}     Wis: {stats_values['wis']:<2}",
+        f"Dex: {stats_values['dex']:<2}     Con: {stats_values['con']:<2}    Cha: {stats_values['cha']:<2}",
+        f"{_col('Hit Points', f'{hp_current} / {hp_max}')}      Level: {level}",
+        _col("Exp. Points", str(exp_points)),
+        _col("Riblets", str(riblets)),
+        _col("Ions", str(ions)),
+        f"{_col('Wearing Armor', armour_name)}   Armour Class: {armour_class}",
+        _col("Ready to Combat", "NO ONE"),
+        _col("Readied Spell", "No spell memorized."),
+        _col("Year A.D.", str(year)),
+        "",
+    ]
 
-    stats = player.get("stats", {})
-    if isinstance(stats, dict):
-        order = ["str", "int", "wis", "dex", "con", "cha"]
-        parts = []
-        for key in order:
-            val = stats.get(key, "?")
-            parts.append(f"{key.upper()} {val}")
-        bus.push("SYSTEM/OK", "Stats: " + ", ".join(parts))
+    inventory = player.get("inventory") or []
+    if not isinstance(inventory, (list, tuple)):
+        inventory = [inventory] if inventory else []
 
-    conds = player.get("conditions", {})
-    active = []
-    if isinstance(conds, dict):
-        for name, flag in conds.items():
-            if flag:
-                active.append(name.replace("_", " "))
-    cond_line = "none" if not active else ", ".join(active)
-    bus.push("SYSTEM/OK", f"Conditions: {cond_line}")
+    items_registry = ctx.get("items")
+    inventory_lines = []
+    total_weight = 0
 
-    year, x, y = _pos_tuple(player.get("pos", [0, 0, 0]))
-    bus.push("SYSTEM/OK", f"Location: Year {year}, ({x}, {y})")
+    for entry in inventory:
+        item_dict = entry if isinstance(entry, dict) else None
+        iid = None
+        if isinstance(entry, dict):
+            iid = entry.get("id") or entry.get("name")
+        else:
+            iid = entry
+
+        display_name = None
+        if items_registry is not None and iid is not None:
+            try:
+                display_name = _item_display(items_registry, iid)
+            except Exception:
+                display_name = None
+        if display_name is None and item_dict:
+            display_name = item_dict.get("name") or item_dict.get("display_name")
+        if display_name is None:
+            display_name = str(iid)
+
+        weight = 0
+        if items_registry is not None and iid is not None:
+            try:
+                weight = _item_weight_lb(items_registry, iid)
+            except Exception:
+                weight = 0
+        if weight == 0 and item_dict:
+            candidate = item_dict.get("weight_lb") or item_dict.get("weight")
+            if candidate is not None:
+                weight = _num(candidate, 0)
+        try:
+            total_weight += int(weight)
+        except Exception:
+            pass
+
+        inventory_lines.append(str(display_name))
+
+    lines.append(f"You are carrying the following items:  (Total Weight: {total_weight} LB's)")
+    if inventory_lines:
+        lines.extend(inventory_lines)
+    else:
+        lines.append("Nothing.")
+
+    for line in lines:
+        bus.push("SYSTEM/OK", line)
 
 
 def register(dispatch, ctx) -> None:

--- a/tests/commands/test_statistics.py
+++ b/tests/commands/test_statistics.py
@@ -44,6 +44,6 @@ def test_statistics_pushes_summary():
     ctx = {"feedback_bus": bus, "state_manager": FakeStateManager()}
     statistics.statistics_cmd("", ctx)
     lines = [text for _kind, text in bus.events]
-    assert any("Thief" in line for line in lines)
-    assert any("HP" in line for line in lines)
-    assert any("Location" in line for line in lines)
+    assert any(line.startswith("Name:") for line in lines)
+    assert any("Hit Points" in line and "Level" in line for line in lines)
+    assert any("Year A.D." in line for line in lines)

--- a/tests/commands/test_statistics_format.py
+++ b/tests/commands/test_statistics_format.py
@@ -1,0 +1,56 @@
+from mutants.commands import statistics as stat
+
+
+class Bus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, key, string):
+        self.events.append((key, string))
+
+
+class FakeItems:
+    def describe(self, iid):
+        return {"name": f"Item {iid}", "weight_lb": 2}
+
+
+class SM:
+    def __init__(self):
+        self.p = {
+            "name": "Gwydion",
+            "class": "Thief",
+            "level": 1,
+            "exp_points": 0,
+            "hp": {"current": 18, "max": 18},
+            "ions": 30000,
+            "riblets": 0,
+            "stats": {"str": 15, "int": 9, "wis": 8, "dex": 14, "con": 15, "cha": 16},
+            "conditions": {"poisoned": False},
+            "armour": {"armour_class": 1},
+            "pos": [2000, 0, 0],
+            "inventory": ["i1", "i2"],
+        }
+
+    def get_active(self):
+        class P:
+            def __init__(self, data):
+                self._data = data
+
+            def to_dict(self):
+                return self._data
+
+        return P(self.p)
+
+
+def test_statistics_renders_core_lines():
+    bus = Bus()
+    sm = SM()
+    ctx = {"feedback_bus": bus, "state_manager": sm, "items": FakeItems()}
+    stat.statistics_cmd("", ctx)
+    out = [text for _, text in bus.events]
+    assert any(line.startswith("Name:") for line in out)
+    assert any("Exhaustion" in line for line in out)
+    assert any("Hit Points" in line and "Level" in line for line in out)
+    assert any("Year A.D." in line for line in out)
+    assert any("You are carrying the following items" in line for line in out)
+    assert any("Total Weight:" in line for line in out)


### PR DESCRIPTION
## Summary
- replace the statistics command output with the BBS-style statistics sheet including inventory weight handling
- document the new statistics view in the commands guide and README quickstart
- add regression tests that cover the statistics layout

## Testing
- PYTHONPATH=src pytest tests/commands/test_statistics.py tests/commands/test_statistics_format.py

------
https://chatgpt.com/codex/tasks/task_e_68c94c614014832b99df5e2e4a8fdc0b