### PR TITLE
Unify inventory formatting across commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,6 +40,18 @@ without moving. Direction arguments accept any prefix of the full word (e.g.
 normalization helper (see [utilities](utilities.md)). If multiple ground items
 match the prefix, the first one in the ground list is picked up.
 
+## Inventory
+
+`inventory` (prefix `inv`) prints your carried items in the final BBS format:
+
+```
+You are carrying the following items:  (Total Weight: <N> LB's)
+<item lines or Nothing.>
+```
+
+The list is identical to the Statistics page; both commands call the same
+renderer.
+
 ## Throw
 
 `throw <direction> <item>` throws an item into an adjacent tile. Direction
@@ -92,7 +104,8 @@ Nothing.
 ```
 
 Values are drawn from the active player and the items registry when available,
-and the command is read-only.
+and the command is read-only. The inventory section is shared with the
+`inventory` command so both screens stay in sync.
 
 ## Class Selection
 

--- a/src/mutants/commands/debug.py
+++ b/src/mutants/commands/debug.py
@@ -61,6 +61,7 @@ def _add_to_inventory(ctx, item_id: str, count: int) -> None:
     p["inventory"] = inv
     it._save_player(p)
     itemsreg.save_instances()
+    it._sync_state_manager(ctx, inv)
 
 
 def debug_add_cmd(arg: str, ctx):

--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -1,39 +1,50 @@
 from __future__ import annotations
-import json, os
-from mutants.registries import items_catalog, items_instances as itemsreg
-from ..ui.item_display import item_label, number_duplicates, with_article
-from ..ui import wrap as uwrap
-from ..ui.textutils import harden_final_display
+
+from typing import Any, Dict, Optional
+
+from mutants.ui.inventory_final import render_inventory_final
 
 
-def _player_file() -> str:
-    return os.path.join(os.getcwd(), "state", "playerlivestate.json")
-
-
-def _load_player():
+def _player_dict(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    state_mgr = ctx.get("state_manager")
+    if state_mgr is None:
+        return None
     try:
-        return json.load(open(_player_file(), "r", encoding="utf-8"))
-    except FileNotFoundError:
-        return {}
+        active = state_mgr.get_active()
+    except Exception:
+        return None
+    if active is None:
+        return None
+    if hasattr(active, "to_dict"):
+        try:
+            data = active.to_dict() or {}
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            return None
+    if isinstance(active, dict):
+        return active
+    return None
 
 
-def inv_cmd(arg: str, ctx):
-    p = _load_player()
-    inv = list(p.get("inventory") or [])
-    cat = items_catalog.load_catalog()
-    names = []
-    for iid in inv:
-        inst = itemsreg.get_instance(iid) or {}
-        tpl = cat.get(inst.get("item_id")) or {}
-        names.append(item_label(inst, tpl, show_charges=False))
-    numbered = number_duplicates(names)
-    display = [harden_final_display(with_article(n)) for n in numbered]
-    bus = ctx["feedback_bus"]
-    if not display:
-        bus.push("SYSTEM/OK", "You are carrying nothing.")
+def inv_cmd(arg: str, ctx: Dict[str, Any]) -> None:
+    bus = ctx.get("feedback_bus")
+    if bus is None:
         return
-    bus.push("SYSTEM/OK", "You are carrying:")
-    for ln in uwrap.wrap_list(display):
+
+    player = _player_dict(ctx)
+    if player is None:
+        bus.push("SYSTEM/WARN", "Inventory unavailable.")
+        return
+
+    items = ctx.get("items")
+    lines, total = render_inventory_final(player, items)
+
+    bus.push(
+        "SYSTEM/OK",
+        f"You are carrying the following items:  (Total Weight: {total} LB's)",
+    )
+    for ln in lines:
         bus.push("SYSTEM/OK", ln)
 
 

--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -1,6 +1,8 @@
 """Statistics command for inspecting the active player."""
 from __future__ import annotations
 
+from mutants.ui.inventory_final import render_inventory_final
+
 
 def _col(label: str, value: str, width: int = 16) -> str:
     return f"{label:<{width}} : {value}"
@@ -49,34 +51,6 @@ def _year(player: dict) -> int:
     if isinstance(pos, (list, tuple)) and pos:
         return _num(pos[0], 2000)
     return 2000
-
-
-def _item_display(items, iid) -> str:
-    for attr in ("get_display_name", "display_name", "name_of", "describe"):
-        fn = getattr(items, attr, None)
-        if callable(fn):
-            try:
-                info = fn(iid)
-                if isinstance(info, dict):
-                    return str(info.get("name") or iid)
-                return str(info)
-            except Exception:
-                pass
-    return str(iid)
-
-
-def _item_weight_lb(items, iid) -> int:
-    for attr in ("weight_lb", "get_weight_lb", "describe"):
-        fn = getattr(items, attr, None)
-        if callable(fn):
-            try:
-                info = fn(iid)
-                if isinstance(info, dict):
-                    return _num(info.get("weight_lb"), 0)
-                return _num(info, 0)
-            except Exception:
-                pass
-    return 0
 
 
 def _armour_name(player: dict) -> str:
@@ -151,55 +125,13 @@ def statistics_cmd(arg: str, ctx) -> None:
         "",
     ]
 
-    inventory = player.get("inventory") or []
-    if not isinstance(inventory, (list, tuple)):
-        inventory = [inventory] if inventory else []
-
     items_registry = ctx.get("items")
-    inventory_lines = []
-    total_weight = 0
+    inv_lines, total_weight = render_inventory_final(player, items_registry)
 
-    for entry in inventory:
-        item_dict = entry if isinstance(entry, dict) else None
-        iid = None
-        if isinstance(entry, dict):
-            iid = entry.get("id") or entry.get("name")
-        else:
-            iid = entry
-
-        display_name = None
-        if items_registry is not None and iid is not None:
-            try:
-                display_name = _item_display(items_registry, iid)
-            except Exception:
-                display_name = None
-        if display_name is None and item_dict:
-            display_name = item_dict.get("name") or item_dict.get("display_name")
-        if display_name is None:
-            display_name = str(iid)
-
-        weight = 0
-        if items_registry is not None and iid is not None:
-            try:
-                weight = _item_weight_lb(items_registry, iid)
-            except Exception:
-                weight = 0
-        if weight == 0 and item_dict:
-            candidate = item_dict.get("weight_lb") or item_dict.get("weight")
-            if candidate is not None:
-                weight = _num(candidate, 0)
-        try:
-            total_weight += int(weight)
-        except Exception:
-            pass
-
-        inventory_lines.append(str(display_name))
-
-    lines.append(f"You are carrying the following items:  (Total Weight: {total_weight} LB's)")
-    if inventory_lines:
-        lines.extend(inventory_lines)
-    else:
-        lines.append("Nothing.")
+    lines.append(
+        f"You are carrying the following items:  (Total Weight: {total_weight} LB's)"
+    )
+    lines.extend(inv_lines)
 
     for line in lines:
         bus.push("SYSTEM/OK", line)

--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -40,6 +40,29 @@ def _ensure_inventory(p: Dict) -> None:
         p["inventory"] = []
 
 
+def _sync_state_manager(ctx, inventory: List[str]) -> None:
+    if not isinstance(ctx, dict):
+        return
+    state_mgr = ctx.get("state_manager")
+    if state_mgr is None:
+        return
+    try:
+        active = state_mgr.get_active()
+    except Exception:
+        return
+    target = getattr(active, "data", None)
+    if isinstance(target, dict):
+        target["inventory"] = list(inventory)
+    elif isinstance(active, dict):
+        active["inventory"] = list(inventory)
+    sync = getattr(state_mgr, "_sync_legacy_views", None)
+    if callable(sync):
+        try:
+            sync()
+        except Exception:
+            pass
+
+
 def _armor_iid(p: Dict) -> Optional[str]:
     a = p.get("armor") or p.get("armour")
     if isinstance(a, dict):
@@ -165,6 +188,7 @@ def pick_from_ground(ctx, prefix: str, *, seed: Optional[int] = None) -> Dict:
         overflow_info = {"inv_overflow_drop": drop_iid}
     _save_player(p)
     itemsreg.save_instances()
+    _sync_state_manager(ctx, p.get("inventory") or [])
     return {"ok": True, "iid": chosen_iid, "overflow": overflow_info, "inv_count": len(p["inventory"])}
 
 
@@ -222,6 +246,7 @@ def drop_to_ground(ctx, prefix: str, *, seed: Optional[int] = None) -> Dict:
             overflow_info = {"ground_overflow_pick": pick}
     _save_player(p)
     itemsreg.save_instances()
+    _sync_state_manager(ctx, p.get("inventory") or [])
     return {"ok": True, "iid": iid, "overflow": overflow_info, "inv_count": len(p["inventory"])}
 
 
@@ -304,6 +329,7 @@ def throw_to_direction(ctx, direction: str, prefix: str, *, seed: Optional[int] 
             overflow_info = {"ground_overflow_pick": pick}
     _save_player(p)
     itemsreg.save_instances()
+    _sync_state_manager(ctx, p.get("inventory") or [])
     return {
         "ok": True,
         "iid": iid,

--- a/src/mutants/ui/inventory_final.py
+++ b/src/mutants/ui/inventory_final.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from mutants.ui.item_display import item_label
+
+try:  # pragma: no cover - defensive import for optional catalog
+    from mutants.registries import items_catalog
+except Exception:  # pragma: no cover - catalog may be unavailable in tests
+    items_catalog = None  # type: ignore[assignment]
+
+
+def render_inventory_final(player: dict, items_reg: Any) -> Tuple[List[str], int]:
+    """Render the final BBS-style inventory list.
+
+    Args:
+        player: Player dictionary obtained from ``StateManager.get_active().to_dict()``.
+        items_reg: Items registry providing optional lookup helpers.
+
+    Returns:
+        A tuple ``(lines, total_weight_lb)``. ``lines`` contains either
+        ``["Nothing."]`` when the inventory is empty or one line per item name.
+        ``total_weight_lb`` is the integer total of the weights (unknown weights
+        count as ``0``).
+    """
+
+    raw_inventory = player.get("inventory")
+    if isinstance(raw_inventory, Iterable) and not isinstance(raw_inventory, (str, bytes, dict)):
+        inventory = list(raw_inventory)
+    elif raw_inventory:
+        inventory = [raw_inventory]
+    else:
+        inventory = []
+
+    lines: List[str] = []
+    total = 0
+
+    catalog: Optional[Any] = None
+    catalog_failed = False
+
+    def _load_catalog():
+        nonlocal catalog, catalog_failed
+        if catalog_failed:
+            return None
+        if catalog is None:
+            if items_catalog is None:
+                catalog_failed = True
+                return None
+            try:
+                catalog = items_catalog.load_catalog()
+            except Exception:
+                catalog_failed = True
+                catalog = None
+        return catalog
+
+    def _coerce_iid(entry: Any) -> Any:
+        if isinstance(entry, dict):
+            for key in ("id", "iid", "instance_id", "item_id", "name"):
+                value = entry.get(key)
+                if value:
+                    return value
+        return entry
+
+    def _resolve_instance(iid: Any) -> Optional[Dict[str, Any]]:
+        if items_reg is None:
+            return None
+        fn = getattr(items_reg, "get_instance", None)
+        if callable(fn):
+            try:
+                inst = fn(iid)
+                if isinstance(inst, dict):
+                    return inst
+            except Exception:
+                return None
+        return None
+
+    def _resolve_template(inst: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        if not isinstance(inst, dict):
+            return None
+        item_id = inst.get("item_id")
+        if not item_id:
+            return None
+        cat = _load_catalog()
+        if cat is None:
+            return None
+        try:
+            tpl = cat.get(str(item_id))  # type: ignore[call-arg]
+        except Exception:
+            tpl = None
+        if isinstance(tpl, dict):
+            return tpl
+        return None
+
+    def _name(iid: Any, inst: Optional[Dict[str, Any]], tpl: Optional[Dict[str, Any]]) -> str:
+        for attr in ("get_display_name", "display_name", "name_of", "describe"):
+            fn = getattr(items_reg, attr, None)
+            if callable(fn):
+                try:
+                    val = fn(iid)
+                    if isinstance(val, dict):
+                        name = val.get("name")
+                        if name:
+                            return str(name)
+                    elif val is not None:
+                        return str(val)
+                except Exception:
+                    pass
+        if tpl or inst:
+            try:
+                return item_label(inst or {}, tpl or {}, show_charges=False)
+            except Exception:
+                pass
+            if tpl:
+                for key in ("display_name", "name", "title"):
+                    value = tpl.get(key)
+                    if isinstance(value, str) and value.strip():
+                        return value.strip()
+        if inst:
+            for key in ("display_name", "name"):
+                value = inst.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+        return str(iid)
+
+    def _weight(
+        iid: Any,
+        inst: Optional[Dict[str, Any]],
+        tpl: Optional[Dict[str, Any]],
+        entry: Any,
+    ) -> int:
+        for attr in ("weight_lb", "get_weight_lb", "describe"):
+            fn = getattr(items_reg, attr, None)
+            if callable(fn):
+                try:
+                    val = fn(iid)
+                    if isinstance(val, dict):
+                        cand = val.get("weight_lb")
+                        if cand is not None:
+                            return int(cand)
+                    else:
+                        return int(val)
+                except Exception:
+                    pass
+        if inst:
+            for key in ("weight_lb", "weight"):
+                cand = inst.get(key)
+                if cand is not None:
+                    try:
+                        return int(cand)
+                    except Exception:
+                        continue
+        if tpl:
+            for key in ("weight_lb", "weight"):
+                cand = tpl.get(key)
+                if cand is not None:
+                    try:
+                        return int(cand)
+                    except Exception:
+                        continue
+        if isinstance(entry, dict):
+            for key in ("weight_lb", "weight"):
+                cand = entry.get(key)
+                if cand is not None:
+                    try:
+                        return int(cand)
+                    except Exception:
+                        continue
+        return 0
+
+    if not inventory:
+        return (["Nothing."], 0)
+
+    for entry in inventory:
+        iid = _coerce_iid(entry)
+        inst = _resolve_instance(iid)
+        tpl = _resolve_template(inst)
+        nm = _name(iid, inst, tpl)
+        wt = _weight(iid, inst, tpl, entry)
+        lines.append(nm)
+        total += max(0, wt)
+
+    return (lines, total)

--- a/tests/ui/test_inventory_unified.py
+++ b/tests/ui/test_inventory_unified.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from mutants.commands import inv, statistics
+from mutants.ui.inventory_final import render_inventory_final
+
+
+class FakeItems:
+    def __init__(self) -> None:
+        self._data: Dict[str, Dict[str, Any]] = {
+            "ion_pack": {"name": "Ion Pack", "weight_lb": 3},
+            "med_kit": {"name": "Med Kit", "weight_lb": 2},
+            "mystery_box": {"name": "Mystery Box", "weight_lb": 0},
+        }
+
+    def get_display_name(self, iid: str) -> Dict[str, Any]:
+        return dict(self._data.get(iid, {"name": f"Item {iid}"}))
+
+    def get_weight_lb(self, iid: str) -> int:
+        info = self._data.get(iid)
+        if info is None:
+            return 0
+        return int(info.get("weight_lb", 0))
+
+
+class FakePlayer:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._data = data
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self._data
+
+
+class FakeStateManager:
+    def __init__(self, player: Dict[str, Any]) -> None:
+        self._player = player
+
+    def get_active(self) -> FakePlayer:
+        return FakePlayer(self._player)
+
+
+class FakeBus:
+    def __init__(self) -> None:
+        self.events: List[tuple[str, str]] = []
+
+    def push(self, kind: str, text: str, **_meta: Any) -> None:
+        self.events.append((kind, text))
+
+
+def _inventory_section(events: List[tuple[str, str]]) -> List[str]:
+    texts = [text for _, text in events]
+    for idx, text in enumerate(texts):
+        if text.startswith("You are carrying the following items:"):
+            return texts[idx:]
+    return []
+
+
+def test_render_inventory_empty() -> None:
+    lines, total = render_inventory_final({"inventory": []}, FakeItems())
+    assert lines == ["Nothing."]
+    assert total == 0
+
+
+def test_inventory_command_matches_statistics_inventory() -> None:
+    player = {
+        "name": "Test Subject",
+        "class": "Wizard",
+        "hp": {"current": 5, "max": 10},
+        "stats": {"str": 3, "int": 9, "wis": 4, "dex": 5, "con": 6, "cha": 7},
+        "armour": {"armour_class": 1},
+        "pos": [2000, 0, 0],
+        "riblets": 0,
+        "ions": 0,
+        "exp_points": 0,
+        "exhaustion": 0,
+        "level": 1,
+        "inventory": ["ion_pack", "med_kit", "mystery_box"],
+    }
+    items = FakeItems()
+
+    bus_inv = FakeBus()
+    ctx_inv = {"feedback_bus": bus_inv, "state_manager": FakeStateManager(player), "items": items}
+    inv.inv_cmd("", ctx_inv)
+    inventory_output = [text for _, text in bus_inv.events]
+
+    bus_stat = FakeBus()
+    ctx_stat = {"feedback_bus": bus_stat, "state_manager": FakeStateManager(player), "items": items}
+    statistics.statistics_cmd("", ctx_stat)
+    statistics_output = _inventory_section(bus_stat.events)
+
+    assert statistics_output
+    assert inventory_output == statistics_output


### PR DESCRIPTION
## Summary
- add a shared `render_inventory_final` renderer that resolves item names/weights and emits the final BBS-format list
- update the inventory and statistics commands to use the shared renderer and state-manager data
- keep the state manager in sync when inventory changes and add coverage plus docs for the unified output

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9541aea5c832b9eb28d7635113813