### PR TITLE
Add total weight header to inventory output

### DIFF
--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -6,6 +6,25 @@ from ..ui import wrap as uwrap
 from ..ui.textutils import harden_final_display
 
 
+def _total_weight(inst_tpl_pairs):
+    total = 0.0
+    for inst, tpl in inst_tpl_pairs:
+        qty_raw = (inst or {}).get("quantity", 1)
+        try:
+            qty_val = float(qty_raw)
+        except (TypeError, ValueError):
+            qty_val = 1.0
+
+        weight_raw = (tpl or {}).get("weight", 0)
+        try:
+            weight_val = float(weight_raw)
+        except (TypeError, ValueError):
+            weight_val = 0.0
+
+        total += weight_val * qty_val
+    return total
+
+
 def _player_file() -> str:
     return os.path.join(os.getcwd(), "state", "playerlivestate.json")
 
@@ -22,17 +41,23 @@ def inv_cmd(arg: str, ctx):
     inv = list(p.get("inventory") or [])
     cat = items_catalog.load_catalog()
     names = []
+    inst_tpl_pairs = []
     for iid in inv:
         inst = itemsreg.get_instance(iid) or {}
         tpl = cat.get(inst.get("item_id")) or {}
+        inst_tpl_pairs.append((inst, tpl))
         names.append(item_label(inst, tpl, show_charges=False))
     numbered = number_duplicates(names)
     display = [harden_final_display(with_article(n)) for n in numbered]
     bus = ctx["feedback_bus"]
+    total_weight = _total_weight(inst_tpl_pairs)
+    header = (
+        f"You are carrying the following items: (Total Weight: {round(total_weight)} LB's)"
+    )
+    bus.push("SYSTEM/OK", header)
     if not display:
-        bus.push("SYSTEM/OK", "You are carrying nothing.")
+        bus.push("SYSTEM/OK", "Nothing.")
         return
-    bus.push("SYSTEM/OK", "You are carrying:")
     for ln in uwrap.wrap_list(display):
         bus.push("SYSTEM/OK", ln)
 

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -1,0 +1,91 @@
+from mutants.commands import inv
+
+
+class FakeBus:
+    def __init__(self):
+        self.events = []
+
+    def push(self, key, message):
+        self.events.append((key, message))
+
+
+class FakeCatalog:
+    def __init__(self, items):
+        self._items = items
+
+    def get(self, item_id):
+        return self._items.get(item_id)
+
+
+def test_inventory_empty_shows_header_and_nothing(monkeypatch):
+    bus = FakeBus()
+    ctx = {"feedback_bus": bus}
+
+    monkeypatch.setattr(inv, "_load_player", lambda: {"inventory": []})
+    monkeypatch.setattr(inv.items_catalog, "load_catalog", lambda: FakeCatalog({}))
+
+    inv.inv_cmd("", ctx)
+
+    assert bus.events == [
+        ("SYSTEM/OK", "You are carrying the following items: (Total Weight: 0 LB's)"),
+        ("SYSTEM/OK", "Nothing."),
+    ]
+
+
+def test_inventory_header_includes_single_item_weight(monkeypatch):
+    bus = FakeBus()
+    ctx = {"feedback_bus": bus}
+
+    monkeypatch.setattr(inv, "_load_player", lambda: {"inventory": ["iid-1"]})
+
+    catalog_items = {
+        "test_sword": {"item_id": "test_sword", "weight": 2.6, "name": "Sword"}
+    }
+    monkeypatch.setattr(
+        inv.items_catalog, "load_catalog", lambda: FakeCatalog(catalog_items)
+    )
+    monkeypatch.setattr(
+        inv.itemsreg, "get_instance", lambda iid: {"item_id": "test_sword"}
+    )
+
+    inv.inv_cmd("", ctx)
+
+    assert bus.events[0] == (
+        "SYSTEM/OK",
+        "You are carrying the following items: (Total Weight: 3 LB's)",
+    )
+    assert all(event[1] != "Nothing." for event in bus.events[1:])
+
+
+def test_inventory_header_sums_multiple_items_with_quantities(monkeypatch):
+    bus = FakeBus()
+    ctx = {"feedback_bus": bus}
+
+    monkeypatch.setattr(
+        inv,
+        "_load_player",
+        lambda: {"inventory": ["iid-1", "iid-2"]},
+    )
+
+    catalog_items = {
+        "item_a": {"item_id": "item_a", "weight": 1.6},
+        "item_b": {"item_id": "item_b", "weight": 0.5},
+    }
+    monkeypatch.setattr(
+        inv.items_catalog, "load_catalog", lambda: FakeCatalog(catalog_items)
+    )
+
+    instances = {
+        "iid-1": {"item_id": "item_a", "quantity": 2},
+        "iid-2": {"item_id": "item_b", "quantity": 3},
+    }
+
+    monkeypatch.setattr(inv.itemsreg, "get_instance", lambda iid: instances[iid])
+
+    inv.inv_cmd("", ctx)
+
+    assert bus.events[0] == (
+        "SYSTEM/OK",
+        "You are carrying the following items: (Total Weight: 5 LB's)",
+    )
+    assert len(bus.events) > 1


### PR DESCRIPTION
## Summary
- compute the player's total carried weight from catalog metadata and display it in the inventory header
- keep the existing item rendering while printing "Nothing." only when empty
- cover the new header behavior, single item rounding, and quantity sums with unit tests

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68c98da75670832bac41de02eb47b680