### PR TITLE
Unify inventory rendering for inventory and statistics

### DIFF
--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -1,28 +1,7 @@
 from __future__ import annotations
 import json, os
 from mutants.registries import items_catalog, items_instances as itemsreg
-from ..ui.item_display import item_label, number_duplicates, with_article
-from ..ui import wrap as uwrap
-from ..ui.textutils import harden_final_display
-
-
-def _total_weight(inst_tpl_pairs):
-    total = 0.0
-    for inst, tpl in inst_tpl_pairs:
-        qty_raw = (inst or {}).get("quantity", 1)
-        try:
-            qty_val = float(qty_raw)
-        except (TypeError, ValueError):
-            qty_val = 1.0
-
-        weight_raw = (tpl or {}).get("weight", 0)
-        try:
-            weight_val = float(weight_raw)
-        except (TypeError, ValueError):
-            weight_val = 0.0
-
-        total += weight_val * qty_val
-    return total
+from mutants.ui.inventory_section import render_inventory_section
 
 
 def _player_file() -> str:
@@ -39,27 +18,17 @@ def _load_player():
 def inv_cmd(arg: str, ctx):
     p = _load_player()
     inv = list(p.get("inventory") or [])
-    cat = items_catalog.load_catalog()
-    names = []
-    inst_tpl_pairs = []
-    for iid in inv:
-        inst = itemsreg.get_instance(iid) or {}
-        tpl = cat.get(inst.get("item_id")) or {}
-        inst_tpl_pairs.append((inst, tpl))
-        names.append(item_label(inst, tpl, show_charges=False))
-    numbered = number_duplicates(names)
-    display = [harden_final_display(with_article(n)) for n in numbered]
     bus = ctx["feedback_bus"]
-    total_weight = _total_weight(inst_tpl_pairs)
-    header = (
-        f"You are carrying the following items: (Total Weight: {round(total_weight)} LB's)"
-    )
-    bus.push("SYSTEM/OK", header)
-    if not display:
-        bus.push("SYSTEM/OK", "Nothing.")
-        return
-    for ln in uwrap.wrap_list(display):
-        bus.push("SYSTEM/OK", ln)
+    if isinstance(ctx, dict):
+        render_ctx = dict(ctx)
+    else:
+        render_ctx = {}
+    render_ctx.setdefault("items_catalog_loader", items_catalog.load_catalog)
+    render_ctx.setdefault("items_instance_resolver", itemsreg.get_instance)
+
+    lines = render_inventory_section(render_ctx, inv)
+    for line in lines:
+        bus.push("SYSTEM/OK", line)
 
 
 def register(dispatch, ctx) -> None:

--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -1,6 +1,8 @@
 """Statistics command for inspecting the active player."""
 from __future__ import annotations
 
+from mutants.ui.inventory_section import render_inventory_section
+
 
 def _col(label: str, value: str, width: int = 16) -> str:
     return f"{label:<{width}} : {value}"
@@ -49,34 +51,6 @@ def _year(player: dict) -> int:
     if isinstance(pos, (list, tuple)) and pos:
         return _num(pos[0], 2000)
     return 2000
-
-
-def _item_display(items, iid) -> str:
-    for attr in ("get_display_name", "display_name", "name_of", "describe"):
-        fn = getattr(items, attr, None)
-        if callable(fn):
-            try:
-                info = fn(iid)
-                if isinstance(info, dict):
-                    return str(info.get("name") or iid)
-                return str(info)
-            except Exception:
-                pass
-    return str(iid)
-
-
-def _item_weight_lb(items, iid) -> int:
-    for attr in ("weight_lb", "get_weight_lb", "describe"):
-        fn = getattr(items, attr, None)
-        if callable(fn):
-            try:
-                info = fn(iid)
-                if isinstance(info, dict):
-                    return _num(info.get("weight_lb"), 0)
-                return _num(info, 0)
-            except Exception:
-                pass
-    return 0
 
 
 def _armour_name(player: dict) -> str:
@@ -155,51 +129,7 @@ def statistics_cmd(arg: str, ctx) -> None:
     if not isinstance(inventory, (list, tuple)):
         inventory = [inventory] if inventory else []
 
-    items_registry = ctx.get("items")
-    inventory_lines = []
-    total_weight = 0
-
-    for entry in inventory:
-        item_dict = entry if isinstance(entry, dict) else None
-        iid = None
-        if isinstance(entry, dict):
-            iid = entry.get("id") or entry.get("name")
-        else:
-            iid = entry
-
-        display_name = None
-        if items_registry is not None and iid is not None:
-            try:
-                display_name = _item_display(items_registry, iid)
-            except Exception:
-                display_name = None
-        if display_name is None and item_dict:
-            display_name = item_dict.get("name") or item_dict.get("display_name")
-        if display_name is None:
-            display_name = str(iid)
-
-        weight = 0
-        if items_registry is not None and iid is not None:
-            try:
-                weight = _item_weight_lb(items_registry, iid)
-            except Exception:
-                weight = 0
-        if weight == 0 and item_dict:
-            candidate = item_dict.get("weight_lb") or item_dict.get("weight")
-            if candidate is not None:
-                weight = _num(candidate, 0)
-        try:
-            total_weight += int(weight)
-        except Exception:
-            pass
-
-        inventory_lines.append(str(display_name))
-
-    lines.append(f"You are carrying the following items:  (Total Weight: {total_weight} LB's)")
-    if inventory_lines:
-        lines.extend(inventory_lines)
-    else:
-        lines.append("Nothing.")
+    lines.extend(render_inventory_section(ctx, inventory))
 
     for line in lines:
         bus.push("SYSTEM/OK", line)

--- a/src/mutants/ui/inventory_section.py
+++ b/src/mutants/ui/inventory_section.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, Callable
+
+from mutants.registries import items_catalog, items_instances as itemsreg
+from .item_display import item_label, number_duplicates, with_article
+from .textutils import harden_final_display
+from .wrap import wrap_list
+
+DEFAULT_EXCLUDE_SLOTS: frozenset[str] = frozenset({'armor'})
+
+CatalogLike = Any
+InstanceResolver = Callable[[str], Any]
+
+
+def _call_maybe(fn: Callable[[], CatalogLike] | None) -> CatalogLike | None:
+    if not callable(fn):
+        return None
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+def _coerce_quantity(raw: Any) -> float:
+    try:
+        if raw is None:
+            return 1.0
+        return float(raw)
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def _coerce_weight(raw: Any) -> float:
+    try:
+        if raw is None:
+            return 0.0
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _truthy(raw: Any) -> bool:
+    if isinstance(raw, str):
+        return raw.strip().lower() not in {'', 'false', 'no', '0'}
+    return bool(raw)
+
+
+def _catalog_from_ctx(ctx: Any) -> CatalogLike:
+    if isinstance(ctx, Mapping):
+        candidate = ctx.get('items_catalog')
+        if candidate is not None:
+            if callable(candidate):
+                resolved = _call_maybe(candidate)  # type: ignore[arg-type]
+                if resolved is not None:
+                    return resolved
+            else:
+                return candidate
+        loader = ctx.get('items_catalog_loader')
+        resolved = _call_maybe(loader) if callable(loader) else None
+        if resolved is not None:
+            return resolved
+        registries = ctx.get('registries')
+        if isinstance(registries, Mapping):
+            candidate = registries.get('items_catalog')
+            if candidate is not None:
+                if callable(candidate):
+                    resolved = _call_maybe(candidate)  # type: ignore[arg-type]
+                    if resolved is not None:
+                        return resolved
+                else:
+                    return candidate
+    try:
+        return items_catalog.load_catalog()
+    except Exception:
+        return {}
+
+
+def _instance_resolver_from_ctx(ctx: Any) -> InstanceResolver:
+    if isinstance(ctx, Mapping):
+        resolver = ctx.get('items_instance_resolver')
+        if callable(resolver):
+            return resolver
+        items_obj = ctx.get('items')
+        getter = getattr(items_obj, 'get_instance', None)
+        if callable(getter):
+            return getter  # type: ignore[return-value]
+        registries = ctx.get('registries')
+        if isinstance(registries, Mapping):
+            inst_reg = registries.get('items_instances')
+            getter = getattr(inst_reg, 'get_instance', None)
+            if callable(getter):
+                return getter  # type: ignore[return-value]
+    return itemsreg.get_instance
+
+
+def _lookup_template(catalog: CatalogLike, item_id: Any) -> dict[str, Any]:
+    if not item_id:
+        return {}
+    key = str(item_id)
+    if isinstance(catalog, Mapping):
+        tpl = catalog.get(key)
+        return tpl if isinstance(tpl, Mapping) else {}
+    getter = getattr(catalog, 'get', None)
+    if callable(getter):
+        try:
+            tpl = getter(key)
+        except Exception:
+            return {}
+        return tpl if isinstance(tpl, Mapping) else {}
+    return {}
+
+
+def _resolve_entry(entry: Any, resolver: InstanceResolver) -> dict[str, Any]:
+    inst_data: dict[str, Any] = {}
+    entry_dict = entry if isinstance(entry, Mapping) else None
+    inst_id: Any = None
+    if entry_dict is not None:
+        for key in ('iid', 'instance_id', 'id'):
+            val = entry_dict.get(key)
+            if val:
+                inst_id = val
+                break
+    elif entry is not None:
+        inst_id = entry
+    resolved: Any = None
+    if inst_id is not None and callable(resolver):
+        try:
+            resolved = resolver(str(inst_id))
+        except Exception:
+            resolved = None
+    if isinstance(resolved, Mapping):
+        inst_data.update(resolved)
+    if entry_dict is not None:
+        inst_data.update(entry_dict)
+    if isinstance(inst_id, str) and 'instance_id' not in inst_data:
+        inst_data['instance_id'] = inst_id
+    return inst_data
+
+
+def _should_exclude(inst: Mapping[str, Any], exclude_slots: set[str]) -> bool:
+    if not exclude_slots:
+        return False
+    if not _truthy(inst.get('equipped')):
+        return False
+    slot = inst.get('slot')
+    if slot is None:
+        return False
+    return str(slot) in exclude_slots
+
+
+def _iter_entries(inv_instances: Any) -> list[Any]:
+    if inv_instances is None:
+        return []
+    if isinstance(inv_instances, list):
+        return inv_instances
+    if isinstance(inv_instances, tuple):
+        return list(inv_instances)
+    if isinstance(inv_instances, set):
+        return list(inv_instances)
+    if isinstance(inv_instances, Iterable) and not isinstance(inv_instances, (str, bytes, Mapping)):
+        return list(inv_instances)
+    return [inv_instances]
+
+
+def render_inventory_section(
+    ctx: Any,
+    inv_instances: Any,
+    *,
+    show_header: bool = True,
+    exclude_equipped_slots: Iterable[str] | None = None,
+) -> list[str]:
+    """Return lines describing *inv_instances* using the inventory format."""
+
+    raw_exclude = (
+        exclude_equipped_slots if exclude_equipped_slots is not None else DEFAULT_EXCLUDE_SLOTS
+    )
+    exclude_slots = {str(slot) for slot in raw_exclude if slot is not None}
+
+    catalog = _catalog_from_ctx(ctx)
+    resolver = _instance_resolver_from_ctx(ctx)
+
+    names: list[str] = []
+    total_weight = 0.0
+
+    for entry in _iter_entries(inv_instances):
+        inst = _resolve_entry(entry, resolver)
+        if _should_exclude(inst, exclude_slots):
+            continue
+
+        item_id = inst.get('item_id')
+        if item_id is None:
+            for alt_key in ('catalog_id', 'id'):
+                alt = inst.get(alt_key)
+                if alt:
+                    item_id = alt
+                    break
+        tpl = _lookup_template(catalog, item_id)
+
+        label = item_label(inst, tpl, show_charges=False)
+        names.append(str(label))
+
+        qty = _coerce_quantity(inst.get('quantity'))
+        weight_val = _coerce_weight(tpl.get('weight') if isinstance(tpl, Mapping) else None)
+        total_weight += weight_val * qty
+
+    rounded_total = round(total_weight)
+    lines: list[str] = []
+    if show_header:
+        lines.append(
+            f"You are carrying the following items: (Total Weight: {rounded_total} LB's)"
+        )
+
+    if not names:
+        lines.append('Nothing.')
+        return lines
+
+    numbered = number_duplicates(names)
+    display = [harden_final_display(with_article(name)) for name in numbered]
+    lines.extend(wrap_list(display))
+    return lines


### PR DESCRIPTION
## Summary
- add a shared `render_inventory_section` helper so inventory rendering logic lives in one place
- switch the `inv` command to use the shared renderer
- update the statistics command to append the shared inventory section instead of bespoke output

## Testing
- PYTHONPATH=src pytest tests/commands/test_inventory.py tests/commands/test_statistics_format.py

------
https://chatgpt.com/codex/tasks/task_e_68c9a3d556c4832b897b1af2ef7b46ba