### PR TITLE
Unify inventory source for inv and statistics commands

### DIFF
--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -1,23 +1,11 @@
 from __future__ import annotations
-import json, os
+
 from mutants.registries import items_catalog, items_instances as itemsreg
+from mutants.services.inventory_source import get_player_inventory_instances
 from mutants.ui.inventory_section import render_inventory_section
 
 
-def _player_file() -> str:
-    return os.path.join(os.getcwd(), "state", "playerlivestate.json")
-
-
-def _load_player():
-    try:
-        return json.load(open(_player_file(), "r", encoding="utf-8"))
-    except FileNotFoundError:
-        return {}
-
-
 def inv_cmd(arg: str, ctx):
-    p = _load_player()
-    inv = list(p.get("inventory") or [])
     bus = ctx["feedback_bus"]
     if isinstance(ctx, dict):
         render_ctx = dict(ctx)
@@ -26,7 +14,8 @@ def inv_cmd(arg: str, ctx):
     render_ctx.setdefault("items_catalog_loader", items_catalog.load_catalog)
     render_ctx.setdefault("items_instance_resolver", itemsreg.get_instance)
 
-    lines = render_inventory_section(render_ctx, inv)
+    inv_instances = get_player_inventory_instances(ctx)
+    lines = render_inventory_section(render_ctx, inv_instances)
     for line in lines:
         bus.push("SYSTEM/OK", line)
 

--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -1,6 +1,7 @@
 """Statistics command for inspecting the active player."""
 from __future__ import annotations
 
+from mutants.services.inventory_source import get_player_inventory_instances
 from mutants.ui.inventory_section import render_inventory_section
 
 
@@ -125,11 +126,9 @@ def statistics_cmd(arg: str, ctx) -> None:
         "",
     ]
 
-    inventory = player.get("inventory") or []
-    if not isinstance(inventory, (list, tuple)):
-        inventory = [inventory] if inventory else []
+    inv_instances = get_player_inventory_instances(ctx)
 
-    lines.extend(render_inventory_section(ctx, inventory))
+    lines.extend(render_inventory_section(ctx, inv_instances))
 
     for line in lines:
         bus.push("SYSTEM/OK", line)

--- a/src/mutants/services/inventory_source.py
+++ b/src/mutants/services/inventory_source.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping
+from typing import Any, List
+
+InventoryEntry = Any
+
+
+def _player_file() -> str:
+    return os.path.join(os.getcwd(), "state", "playerlivestate.json")
+
+
+def _load_player_state() -> Mapping[str, Any]:
+    try:
+        with open(_player_file(), "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+    return data if isinstance(data, Mapping) else {}
+
+
+def _ensure_list(raw: Any) -> list[Any]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return list(raw)
+    if isinstance(raw, tuple):
+        return list(raw)
+    if isinstance(raw, set):
+        return list(raw)
+    return [raw]
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in {"", "false", "no", "0"}
+    return bool(value)
+
+
+def _should_skip(entry: Any, excluded_slots: set[str]) -> bool:
+    if not excluded_slots:
+        return False
+    if not isinstance(entry, Mapping):
+        return False
+    if not _truthy(entry.get("equipped")):
+        return False
+    slot = entry.get("slot")
+    if slot is None:
+        return False
+    return str(slot) in excluded_slots
+
+
+def get_player_inventory_instances(
+    ctx: Any,
+    *,
+    exclude_equipped_slots: Iterable[str] | None = None,
+) -> List[InventoryEntry]:
+    """Return the authoritative list of inventory entries for the active player."""
+
+    player_state = _load_player_state()
+    raw_inventory = player_state.get("inventory") if isinstance(player_state, Mapping) else []
+    entries = _ensure_list(raw_inventory)
+
+    excluded_slots = (
+        {str(slot) for slot in exclude_equipped_slots if slot is not None}
+        if exclude_equipped_slots
+        else set()
+    )
+
+    if not excluded_slots:
+        return entries
+
+    filtered: list[Any] = []
+    for entry in entries:
+        if _should_skip(entry, excluded_slots):
+            continue
+        filtered.append(entry)
+    return filtered

--- a/tests/commands/test_inventory.py
+++ b/tests/commands/test_inventory.py
@@ -21,7 +21,7 @@ def test_inventory_empty_shows_header_and_nothing(monkeypatch):
     bus = FakeBus()
     ctx = {"feedback_bus": bus}
 
-    monkeypatch.setattr(inv, "_load_player", lambda: {"inventory": []})
+    monkeypatch.setattr(inv, "get_player_inventory_instances", lambda _ctx: [])
     monkeypatch.setattr(inv.items_catalog, "load_catalog", lambda: FakeCatalog({}))
 
     inv.inv_cmd("", ctx)
@@ -36,7 +36,7 @@ def test_inventory_header_includes_single_item_weight(monkeypatch):
     bus = FakeBus()
     ctx = {"feedback_bus": bus}
 
-    monkeypatch.setattr(inv, "_load_player", lambda: {"inventory": ["iid-1"]})
+    monkeypatch.setattr(inv, "get_player_inventory_instances", lambda _ctx: ["iid-1"])
 
     catalog_items = {
         "test_sword": {"item_id": "test_sword", "weight": 2.6, "name": "Sword"}
@@ -63,8 +63,8 @@ def test_inventory_header_sums_multiple_items_with_quantities(monkeypatch):
 
     monkeypatch.setattr(
         inv,
-        "_load_player",
-        lambda: {"inventory": ["iid-1", "iid-2"]},
+        "get_player_inventory_instances",
+        lambda _ctx: ["iid-1", "iid-2"],
     )
 
     catalog_items = {

--- a/tests/commands/test_statistics.py
+++ b/tests/commands/test_statistics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from mutants.commands import statistics
+from mutants.commands import inv, statistics
 
 
 class FakeBus:
@@ -39,11 +39,79 @@ class FakeStateManager:
         return self.player
 
 
-def test_statistics_pushes_summary():
+def test_statistics_pushes_summary(monkeypatch):
     bus = FakeBus()
     ctx = {"feedback_bus": bus, "state_manager": FakeStateManager()}
+    monkeypatch.setattr(statistics, "get_player_inventory_instances", lambda _ctx: [])
     statistics.statistics_cmd("", ctx)
     lines = [text for _kind, text in bus.events]
     assert any(line.startswith("Name:") for line in lines)
     assert any("Hit Points" in line and "Level" in line for line in lines)
     assert any("Year A.D." in line for line in lines)
+
+
+def test_statistics_inventory_section_matches_inventory_when_empty(monkeypatch):
+    entries: list[str] = []
+    monkeypatch.setattr(inv, "get_player_inventory_instances", lambda _ctx: list(entries))
+    monkeypatch.setattr(statistics, "get_player_inventory_instances", lambda _ctx: list(entries))
+
+    inv_bus = FakeBus()
+    stat_bus = FakeBus()
+
+    inv_ctx = {"feedback_bus": inv_bus}
+    stat_ctx = {"feedback_bus": stat_bus}
+
+    inv.inv_cmd("", inv_ctx)
+    statistics.statistics_cmd("", stat_ctx)
+
+    inv_lines = [text for _kind, text in inv_bus.events]
+    stat_lines = [text for _kind, text in stat_bus.events]
+
+    assert len(inv_lines) > 0
+    assert stat_lines[-len(inv_lines) :] == inv_lines
+
+
+def test_statistics_inventory_section_matches_inventory_when_populated(monkeypatch):
+    entries = ["iid-1", "iid-2", "iid-3"]
+    monkeypatch.setattr(inv, "get_player_inventory_instances", lambda _ctx: list(entries))
+    monkeypatch.setattr(statistics, "get_player_inventory_instances", lambda _ctx: list(entries))
+
+    catalog = {
+        "test_sword": {"item_id": "test_sword", "weight": 2.6, "name": "Sword"},
+        "test_potion": {"item_id": "test_potion", "weight": 0.5, "name": "Potion"},
+    }
+    instances = {
+        "iid-1": {"item_id": "test_sword", "quantity": 1},
+        "iid-2": {"item_id": "test_potion", "quantity": 2},
+        "iid-3": {"item_id": "test_potion", "quantity": 1},
+    }
+
+    def loader():
+        return catalog
+
+    def resolver(iid: str):
+        return dict(instances.get(iid, {}))
+
+    inv_bus = FakeBus()
+    stat_bus = FakeBus()
+
+    inv_ctx = {
+        "feedback_bus": inv_bus,
+        "items_catalog_loader": loader,
+        "items_instance_resolver": resolver,
+    }
+    stat_ctx = {
+        "feedback_bus": stat_bus,
+        "items_catalog_loader": loader,
+        "items_instance_resolver": resolver,
+    }
+
+    inv.inv_cmd("", inv_ctx)
+    statistics.statistics_cmd("", stat_ctx)
+
+    inv_lines = [text for _kind, text in inv_bus.events]
+    stat_lines = [text for _kind, text in stat_bus.events]
+
+    assert len(inv_lines) > 0
+    assert stat_lines[-len(inv_lines) :] == inv_lines
+    assert inv_lines[0] == "You are carrying the following items: (Total Weight: 4 LB's)"

--- a/tests/commands/test_statistics_format.py
+++ b/tests/commands/test_statistics_format.py
@@ -42,10 +42,11 @@ class SM:
         return P(self.p)
 
 
-def test_statistics_renders_core_lines():
+def test_statistics_renders_core_lines(monkeypatch):
     bus = Bus()
     sm = SM()
     ctx = {"feedback_bus": bus, "state_manager": sm, "items": FakeItems()}
+    monkeypatch.setattr(stat, "get_player_inventory_instances", lambda _ctx: [])
     stat.statistics_cmd("", ctx)
     out = [text for _, text in bus.events]
     assert any(line.startswith("Name:") for line in out)


### PR DESCRIPTION
## Summary
- add a shared inventory source service that reads player inventory entries from the save file
- switch the `inv` and `statistics` commands to use the shared helper so they render identical inventory sections
- update the command tests to mock the new helper and add parity checks covering the empty and populated inventory cases

## Testing
- PYTHONPATH=src pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9dc3c5d84832bae5c9c72021677c3