### PR TITLE
Fix gate commands to use active player state

### DIFF
--- a/src/mutants/commands/close.py
+++ b/src/mutants/commands/close.py
@@ -1,18 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from mutants.registries.world import BASE_GATE
+from mutants.services.player_source import get_active_player
 
 from .argcmd import coerce_direction
-
-
-def _active(state: Dict[str, Any]) -> Dict[str, Any]:
-    aid = state.get("active_id")
-    for p in state.get("players", []):
-        if p.get("id") == aid:
-            return p
-    return state["players"][0]
 
 
 def register(dispatch, ctx) -> None:
@@ -30,8 +23,24 @@ def register(dispatch, ctx) -> None:
             return
         D = dir_full[0].upper()
 
-        p = _active(ctx["player_state"])
-        year, x, y = p.get("pos", [0, 0, 0])
+        player = get_active_player(ctx)
+        pos_raw = player.get("pos") if hasattr(player, "get") else None
+        if not isinstance(pos_raw, (list, tuple)):
+            pos = [0, 0, 0]
+        else:
+            pos = list(pos_raw) + [0, 0, 0]
+        try:
+            year = int(pos[0])
+        except Exception:
+            year = 0
+        try:
+            x = int(pos[1])
+        except Exception:
+            x = 0
+        try:
+            y = int(pos[2])
+        except Exception:
+            y = 0
         world = ctx["world_loader"](year)
         tile = world.get_tile(x, y)
         if not tile:

--- a/src/mutants/commands/lock.py
+++ b/src/mutants/commands/lock.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 from mutants.registries.world import BASE_GATE
 from mutants.registries import dynamics as dyn
 from mutants.registries import items_instances as itemsreg, items_catalog
-from ..services import item_transfer as it  # source of truth for player inventory
+from mutants.services.player_source import get_active_player
 
 from .argcmd import PosArg, PosArgSpec, run_argcmd_positional
 
@@ -13,8 +13,10 @@ from .argcmd import PosArg, PosArgSpec, run_argcmd_positional
 def _has_any_key(ctx: Dict[str, Any]) -> tuple[bool, Optional[str]]:
     """Return (has_key, key_type) by scanning the live player state."""
     cat = items_catalog.load_catalog()
-    p = it._load_player()  # live inventory (same source as GET/DROP/THROW)
-    inv = p.get("inventory") or []
+    player = get_active_player(ctx)
+    inv = player.get("inventory") if hasattr(player, "get") else []
+    if not isinstance(inv, list):
+        inv = list(inv or [])
     for iid in inv:
         inst = itemsreg.get_instance(iid) or {}
         item_id = inst.get("item_id")
@@ -40,8 +42,24 @@ def lock_cmd(arg: str, ctx: Dict[str, Any]) -> None:
     )
 
     def action(dir: str) -> Dict[str, Any]:
-        p = ctx["player_state"]["players"][0]
-        year, x, y = p.get("pos", [0, 0, 0])
+        player = get_active_player(ctx)
+        pos_raw = player.get("pos") if hasattr(player, "get") else None
+        if not isinstance(pos_raw, (list, tuple)):
+            pos = [0, 0, 0]
+        else:
+            pos = list(pos_raw) + [0, 0, 0]
+        try:
+            year = int(pos[0])
+        except Exception:
+            year = 0
+        try:
+            x = int(pos[1])
+        except Exception:
+            x = 0
+        try:
+            y = int(pos[2])
+        except Exception:
+            y = 0
         D = dir[0].upper()
         world = ctx["world_loader"](year)
         tile = world.get_tile(x, y) or {}

--- a/src/mutants/commands/open.py
+++ b/src/mutants/commands/open.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from mutants.registries.world import BASE_GATE
 from mutants.registries import dynamics as dyn
+from mutants.services.player_source import get_active_player
 
 from .argcmd import coerce_direction
-
-
-def _active(state: Dict[str, Any]) -> Dict[str, Any]:
-    aid = state.get("active_id")
-    for p in state.get("players", []):
-        if p.get("id") == aid:
-            return p
-    return state["players"][0]
 
 
 def register(dispatch, ctx) -> None:
@@ -31,8 +24,24 @@ def register(dispatch, ctx) -> None:
             return
         D = dir_full[0].upper()
 
-        p = _active(ctx["player_state"])
-        year, x, y = p.get("pos", [0, 0, 0])
+        player = get_active_player(ctx)
+        pos_raw = player.get("pos") if hasattr(player, "get") else None
+        if not isinstance(pos_raw, (list, tuple)):
+            pos = [0, 0, 0]
+        else:
+            pos = list(pos_raw) + [0, 0, 0]
+        try:
+            year = int(pos[0])
+        except Exception:
+            year = 0
+        try:
+            x = int(pos[1])
+        except Exception:
+            x = 0
+        try:
+            y = int(pos[2])
+        except Exception:
+            y = 0
         world = ctx["world_loader"](year)
         tile = world.get_tile(x, y)
         if not tile:

--- a/src/mutants/services/player_source.py
+++ b/src/mutants/services/player_source.py
@@ -1,0 +1,59 @@
+"""Helpers for reading the active player's live state."""
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+
+def _coerce_mapping(value: Any) -> MutableMapping[str, Any] | dict[str, Any]:
+    if isinstance(value, MutableMapping):
+        return value
+    if isinstance(value, Mapping):  # type: ignore[return-value]
+        return dict(value)
+    return {}
+
+
+def get_active_player(ctx: Mapping[str, Any] | None) -> MutableMapping[str, Any]:
+    """Return the active player's mutable state dictionary.
+
+    The state manager is treated as the single source of truth.  Callers should
+    always use this helper instead of caching player state at import time so
+    that class switches pick up the latest inventory/position.
+    """
+
+    if not ctx:
+        return {}
+    state_mgr = ctx.get("state_manager") if isinstance(ctx, Mapping) else None
+    if state_mgr is None:
+        return {}
+    try:
+        active = state_mgr.get_active()
+    except Exception:
+        return {}
+    if active is None:
+        return {}
+    if hasattr(active, "to_dict"):
+        try:
+            data = active.to_dict()
+        except Exception:
+            data = None
+        if isinstance(data, MutableMapping):
+            return data
+        if isinstance(data, Mapping):
+            return _coerce_mapping(data)
+        if hasattr(active, "data"):
+            maybe_data = getattr(active, "data")
+            if isinstance(maybe_data, MutableMapping):
+                return maybe_data
+            if isinstance(maybe_data, Mapping):
+                return _coerce_mapping(maybe_data)
+    if isinstance(active, MutableMapping):
+        return active
+    if isinstance(active, Mapping):
+        return _coerce_mapping(active)
+    data_attr = getattr(active, "data", None)
+    if isinstance(data_attr, MutableMapping):
+        return data_attr
+    if isinstance(data_attr, Mapping):
+        return _coerce_mapping(data_attr)
+    return {}

--- a/tests/commands/test_lock_gate.py
+++ b/tests/commands/test_lock_gate.py
@@ -1,4 +1,7 @@
-import types
+from __future__ import annotations
+
+import copy
+import pytest
 
 from mutants.commands import lock as lock_cmd
 from mutants.commands import open as open_cmd
@@ -7,48 +10,6 @@ from mutants.repl.dispatch import Dispatch
 from mutants.registries.world import BASE_GATE
 from mutants.registries import dynamics as dyn
 from mutants.registries import items_instances as itemsreg, items_catalog
-
-
-class DummyWorld:
-    def __init__(self, edge):
-        self._edge = edge
-        self.saved = False
-
-    def get_tile(self, x, y):
-        return {"edges": {"S": self._edge}}
-
-    def set_edge(self, x, y, D, *, gate_state=None, force_gate_base=False, key_type=None):
-        if force_gate_base:
-            self._edge["base"] = BASE_GATE
-        if gate_state is not None:
-            self._edge["gate_state"] = gate_state
-        if key_type is not None:
-            self._edge["key_type"] = key_type
-
-    def save(self):
-        self.saved = True
-
-
-def mk_ctx(inv, edge, monkeypatch):
-    bus = types.SimpleNamespace(msgs=[])
-
-    def push(chan, msg):
-        bus.msgs.append((chan, msg))
-
-    bus.push = push
-    world = DummyWorld(edge)
-    ctx = {
-        "feedback_bus": bus,
-        "player_state": {
-            "active_id": 1,
-            "players": [{"id": 1, "pos": [2000, 0, 0], "inventory": list(inv)}],
-        },
-        "world_loader": lambda year: world,
-    }
-    # ensure commands see this test inventory via live loader
-    monkeypatch.setattr(lock_cmd.it, "_load_player", lambda: {"inventory": ctx["player_state"]["players"][0]["inventory"]})
-    monkeypatch.setattr(unlock_cmd.it, "_load_player", lambda: {"inventory": ctx["player_state"]["players"][0]["inventory"]})
-    return world, ctx, bus
 
 
 CAT = {
@@ -61,16 +22,103 @@ INSTANCES = {
     "KB1": {"item_id": "gate_key_b"},
     "KG1": {"item_id": "gate_key_generic"},
 }
+CLASS_IDS = [
+    "player_thief",
+    "player_priest",
+    "player_wizard",
+    "player_warrior",
+    "player_mage",
+]
+
+
+class DummyPlayerState:
+    def __init__(self, data: dict[str, object]) -> None:
+        self.data = data
+
+    def to_dict(self) -> dict[str, object]:
+        return self.data
+
+
+class DummyStateManager:
+    def __init__(self, players: list[dict[str, object]], active_id: str) -> None:
+        self._order = [p["id"] for p in players]
+        self._players: dict[str, DummyPlayerState] = {}
+        for raw in players:
+            pid = raw["id"]
+            self._players[pid] = DummyPlayerState(copy.deepcopy(raw))
+        self._active_id = active_id
+        self.legacy_state = {
+            "players": [self._players[cid].data for cid in self._order],
+            "active_id": active_id,
+        }
+
+    def get_active(self) -> DummyPlayerState:
+        return self._players[self._active_id]
+
+    def switch_active(self, class_id: str) -> None:
+        if class_id not in self._players:
+            raise KeyError(class_id)
+        self._active_id = class_id
+        self.legacy_state["active_id"] = class_id
+
+    def data_for(self, class_id: str) -> dict[str, object]:
+        return self._players[class_id].data
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.msgs: list[tuple[str, str]] = []
+
+    def push(self, chan: str, msg: str) -> None:
+        self.msgs.append((chan, msg))
+
+
+class DummyWorld:
+    def __init__(self, edge: dict[str, object]) -> None:
+        self._edge = edge
+        self.saved = False
+
+    def get_tile(self, x: int, y: int) -> dict[str, object]:
+        return {"edges": {"S": self._edge}}
+
+    def set_edge(self, x: int, y: int, D: str, *, gate_state=None, force_gate_base=False, key_type=None):
+        if force_gate_base:
+            self._edge["base"] = BASE_GATE
+        if gate_state is not None:
+            self._edge["gate_state"] = gate_state
+        if key_type is not None:
+            self._edge["key_type"] = key_type
+
+    def save(self) -> None:
+        self.saved = True
+
+
+def mk_ctx_with_players(players: list[dict[str, object]], edge: dict[str, object], active_id: str | None = None):
+    bus = DummyBus()
+    world = DummyWorld(edge)
+    state_mgr = DummyStateManager(players, active_id or players[0]["id"])
+    ctx = {
+        "feedback_bus": bus,
+        "state_manager": state_mgr,
+        "player_state": state_mgr.legacy_state,
+        "world_loader": lambda year: world,
+    }
+    return world, ctx, bus, state_mgr
+
+
+def mk_ctx(inv, edge):
+    player = {"id": "player_thief", "pos": [2000, 0, 0], "inventory": list(inv)}
+    return mk_ctx_with_players([player], edge, "player_thief")
 
 
 def patch_items_and_dyn(monkeypatch):
     monkeypatch.setattr(items_catalog, "load_catalog", lambda: CAT)
     monkeypatch.setattr(itemsreg, "get_instance", lambda iid: INSTANCES.get(iid))
 
-    locks = {}
+    locks: dict[tuple[int, int, int, str], dict[str, object]] = {}
 
     def _key(year, x, y, d):
-        return (year, x, y, d)
+        return (int(year), int(x), int(y), d)
 
     def get_lock(year, x, y, d):
         return locks.get(_key(year, x, y, d))
@@ -90,6 +138,7 @@ def patch_items_and_dyn(monkeypatch):
     monkeypatch.setattr(dyn, "get_lock", get_lock)
     monkeypatch.setattr(dyn, "set_lock", set_lock)
     monkeypatch.setattr(dyn, "clear_lock", clear_lock)
+    return locks
 
 
 def build_dispatch(ctx):
@@ -112,7 +161,7 @@ def run(dispatch, bus, cmd):
 def test_lock_requires_key(monkeypatch):
     patch_items_and_dyn(monkeypatch)
     edge = {"base": BASE_GATE, "gate_state": 1}
-    world, ctx, bus = mk_ctx([], edge, monkeypatch)
+    world, ctx, bus, state_mgr = mk_ctx([], edge)
     dispatch = build_dispatch(ctx)
     events = run(dispatch, bus, "lock south")
     assert ("SYSTEM/WARN", "You need a key to lock a gate.") in events
@@ -123,13 +172,13 @@ def test_lock_open_or_non_gate_warns(monkeypatch):
     patch_items_and_dyn(monkeypatch)
     # Open gate
     edge = {"base": BASE_GATE, "gate_state": 0}
-    world, ctx, bus = mk_ctx(["KA1"], edge, monkeypatch)
+    world, ctx, bus, state_mgr = mk_ctx(["KA1"], edge)
     dispatch = build_dispatch(ctx)
     events = run(dispatch, bus, "lock south")
     assert ("SYSTEM/WARN", "You can only lock a closed gate.") in events
     # Non-gate
     edge2 = {"base": 0, "gate_state": 0}
-    world2, ctx2, bus2 = mk_ctx(["KA1"], edge2, monkeypatch)
+    world2, ctx2, bus2, state_mgr2 = mk_ctx(["KA1"], edge2)
     dispatch2 = build_dispatch(ctx2)
     events2 = run(dispatch2, bus2, "lock south")
     assert ("SYSTEM/WARN", "You can only lock a closed gate.") in events2
@@ -138,7 +187,7 @@ def test_lock_open_or_non_gate_warns(monkeypatch):
 def test_lock_prefixes_and_unlock_requires_matching_key(monkeypatch):
     patch_items_and_dyn(monkeypatch)
     edge = {"base": BASE_GATE, "gate_state": 1}
-    world, ctx, bus = mk_ctx(["KA1"], edge, monkeypatch)
+    world, ctx, bus, state_mgr = mk_ctx(["KA1"], edge)
     dispatch = build_dispatch(ctx)
 
     for tok in ["s", "so", "sou", "sout"]:
@@ -150,17 +199,17 @@ def test_lock_prefixes_and_unlock_requires_matching_key(monkeypatch):
     assert ("SYSTEM/WARN", "The south gate is locked.") in events
 
     # No key
-    ctx["player_state"]["players"][0]["inventory"] = []
+    state_mgr.data_for("player_thief")["inventory"] = []
     events = run(dispatch, bus, "unlock south")
     assert ("SYSTEM/WARN", "You don't have a key.") in events
 
     # Wrong key for unlock
-    ctx["player_state"]["players"][0]["inventory"] = ["KB1"]
+    state_mgr.data_for("player_thief")["inventory"] = ["KB1"]
     events = run(dispatch, bus, "unlock south")
     assert ("SYSTEM/WARN", "That key doesn't fit.") in events
 
     # Correct key
-    ctx["player_state"]["players"][0]["inventory"] = ["KA1"]
+    state_mgr.data_for("player_thief")["inventory"] = ["KA1"]
     events = run(dispatch, bus, "unlock south")
     assert ("SYSTEM/OK", "You unlock the gate south.") in events
 
@@ -175,14 +224,55 @@ def test_lock_prefixes_and_unlock_requires_matching_key(monkeypatch):
 def test_unlock_generic_key(monkeypatch):
     patch_items_and_dyn(monkeypatch)
     edge = {"base": BASE_GATE, "gate_state": 1}
-    world, ctx, bus = mk_ctx(["KG1"], edge, monkeypatch)
+    world, ctx, bus, state_mgr = mk_ctx(["KG1"], edge)
     dispatch = build_dispatch(ctx)
 
     events = run(dispatch, bus, "lock south")
     assert ("SYSTEM/OK", "You lock the gate south.") in events
 
     # Any key should unlock
-    ctx["player_state"]["players"][0]["inventory"] = ["KB1"]
+    state_mgr.data_for("player_thief")["inventory"] = ["KB1"]
     events = run(dispatch, bus, "unlock south")
     assert ("SYSTEM/OK", "You unlock the gate south.") in events
 
+
+@pytest.mark.parametrize("class_id", CLASS_IDS)
+def test_lock_uses_active_player_inventory(monkeypatch, class_id):
+    locks = patch_items_and_dyn(monkeypatch)
+    edge = {"base": BASE_GATE, "gate_state": 1}
+    players = [
+        {"id": cid, "pos": [2000, idx * 2, -idx], "inventory": []}
+        for idx, cid in enumerate(CLASS_IDS)
+    ]
+    world, ctx, bus, state_mgr = mk_ctx_with_players(players, edge, class_id)
+    dispatch = build_dispatch(ctx)
+
+    # Without a key the active class should fail to lock.
+    locks.clear()
+    edge["gate_state"] = 1
+    events = run(dispatch, bus, "lock south")
+    assert ("SYSTEM/WARN", "You need a key to lock a gate.") in events
+    assert not locks
+
+    # Give the active class a key and ensure the lock uses their coordinates.
+    data = state_mgr.data_for(class_id)
+    data["inventory"] = ["KA1"]
+    locks.clear()
+    edge["gate_state"] = 1
+    events = run(dispatch, bus, "lock south")
+    assert ("SYSTEM/OK", "You lock the gate south.") in events
+    year, x, y = data.get("pos", [2000, 0, 0])
+    assert locks.get((int(year), int(x), int(y), "S")) is not None
+
+    # Switching to another class without a key should fail cleanly.
+    for other in CLASS_IDS:
+        if other == class_id:
+            continue
+        state_mgr.switch_active(other)
+        bus.msgs.clear()
+        locks.clear()
+        edge["gate_state"] = 1
+        state_mgr.data_for(other)["inventory"] = []
+        events = run(dispatch, bus, "lock south")
+        assert ("SYSTEM/WARN", "You need a key to lock a gate.") in events
+        assert not locks

--- a/tests/commands/test_lock_live_inventory.py
+++ b/tests/commands/test_lock_live_inventory.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from mutants.app import context
 from mutants.repl.dispatch import Dispatch
-from mutants.commands import lock as lock_cmd, debug as debug_cmd
+from mutants.commands import lock as lock_cmd
 from mutants.registries.world import BASE_GATE
 from mutants.registries import items_instances as itemsreg
 
@@ -25,12 +25,21 @@ def test_lock_uses_live_inventory(tmp_path, monkeypatch):
     ctx = context.build_context()
     ctx["world_loader"] = lambda year: DummyWorld()
 
+    state_mgr = ctx["state_manager"]
+    player = state_mgr.get_active().to_dict()
+    pos = player.get("pos") or [2000, 0, 0]
+    year, x, y = int(pos[0]), int(pos[1]), int(pos[2])
+    iid = itemsreg.create_and_save_instance("gate_key_b", year, x, y, origin="test_lock")
+    itemsreg.clear_position(iid)
+    inv = player.setdefault("inventory", [])
+    if iid not in inv:
+        inv.append(iid)
+    itemsreg.save_instances()
+
     disp = Dispatch()
     disp.set_feedback_bus(ctx["feedback_bus"])
-    debug_cmd.register(disp, ctx)
     lock_cmd.register(disp, ctx)
 
-    disp.call("debug", "add gate_key_b")
     disp.call("lock", "w")
     events = ctx["feedback_bus"].drain()
     assert any("lock" in e["text"].lower() or "locked" in e["text"].lower() for e in events) \


### PR DESCRIPTION
## Summary
- add a player_source service that returns the active class' state from the StateManager
- update gate commands to read inventory and position from the active player instead of legacy snapshots
- expand gate and state manager tests to cover per-class inventories and locking semantics across classes

## Testing
- PYTHONPATH=src pytest -q -k "lock or unlock or open or close or state_manager"


------
https://chatgpt.com/codex/tasks/task_e_68c9f0036d54832bb5b2d6581a417f4e