### PR TITLE
Add party and switch commands for player management

### DIFF
--- a/src/mutants/commands/party.py
+++ b/src/mutants/commands/party.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Any
+from mutants.services import player_active as act
+
+def party_list(ctx: dict[str, Any]) -> None:
+    state = act.load_state()
+    aid = state.get("active_id")
+    lines = []
+    for i, p in enumerate(state.get("players", []), start=1):
+        marker = "★" if p.get("id") == aid else " "
+        lines.append(f"{marker} {i}. {p.get('name')} [{p.get('class')}]  id={p.get('id')}")
+    ctx["feedback_bus"].push("SYSTEM/INFO", "\n".join(lines) if lines else "No players found.")
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("party", lambda arg: party_list(ctx))

--- a/src/mutants/commands/switch.py
+++ b/src/mutants/commands/switch.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Any
+from mutants.services import player_active as act
+
+def do_switch(arg: str, ctx: dict[str, Any]) -> None:
+    q = (arg or "").strip()
+    state = act.load_state()
+    target = act.resolve_candidate(state, q)
+    if not target:
+        ctx["feedback_bus"].push("SYSTEM/ERROR", "Switch whom? Try: switch <id|name|class|index> or run `party`.")
+        return
+    try:
+        new_state = act.set_active(target)
+    except ValueError as e:
+        ctx["feedback_bus"].push("SYSTEM/ERROR", str(e))
+        return
+    # Keep runtime context coherent so VM/UI update immediately.
+    ctx["player_state"] = new_state
+    ctx["render_next"] = True
+    # Optional: nudge the renderer to show the new room without extra text noise.
+    ctx["feedback_bus"].push("SYSTEM/OK", f"Now controlling {target}.")
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("switch", lambda arg: do_switch(arg, ctx))

--- a/src/mutants/services/player_active.py
+++ b/src/mutants/services/player_active.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+from typing import Dict, Any, Optional
+from pathlib import Path
+from mutants.io.atomic import atomic_write_json
+import json, os
+
+PLAYER_PATH = Path(os.getcwd()) / "state" / "playerlivestate.json"
+
+def _path() -> Path:
+    return PLAYER_PATH
+
+def load_state() -> Dict[str, Any]:
+    with _path().open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+def save_state(state: Dict[str, Any]) -> None:
+    atomic_write_json(_path(), state)
+
+def set_active(active_id: str) -> Dict[str, Any]:
+    """
+    Switches the active player by id, writes state atomically, returns new state.
+    No-op if already active.
+    """
+    state = load_state()
+    ids = [p.get("id") for p in state.get("players", [])]
+    if active_id not in ids:
+        raise ValueError(f"Unknown player id: {active_id}")
+    if state.get("active_id") == active_id:
+        return state
+    state["active_id"] = active_id
+    save_state(state)
+    return state
+
+def resolve_candidate(state: Dict[str, Any], q: str) -> Optional[str]:
+    """
+    Accepts id | name | class | 1-based index and returns a matching player id.
+    """
+    qn = (q or "").strip().lower()
+    if not qn:
+        return None
+    players = state.get("players", [])
+    # 1) direct id
+    for p in players:
+        pid = (p.get("id") or "").lower()
+        if pid == qn:
+            return p.get("id")
+    # 2) by name or class
+    for p in players:
+        if (p.get("name") or "").lower() == qn or (p.get("class") or "").lower() == qn:
+            return p.get("id")
+    # 3) by 1-based index
+    if qn.isdigit():
+        i = int(qn) - 1
+        if 0 <= i < len(players):
+            return players[i].get("id")
+    return None


### PR DESCRIPTION
## Summary
- add a service to load/save the active player state and resolve player identifiers
- add a `party` command to show stored players and highlight the active one
- add a `switch` command to change the active player and refresh the runtime context

## Testing
- PYTHONPATH=src:. pytest

------
https://chatgpt.com/codex/tasks/task_e_68caa7860eb0832b8d35cc0803f156f2