### PR TITLE
Add class selection menu to REPL

### DIFF
--- a/src/mutants/commands/classmenu.py
+++ b/src/mutants/commands/classmenu.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mutants.ui.class_menu import render_menu
+
+
+def open_menu(ctx: dict[str, Any]) -> None:
+    ctx["mode"] = "class_select"
+    render_menu(ctx)
+
+
+def register(dispatch, ctx) -> None:
+    """Register the class menu command bindings."""
+
+    dispatch.register("x", lambda arg: open_menu(ctx))

--- a/src/mutants/commands/register_all.py
+++ b/src/mutants/commands/register_all.py
@@ -13,7 +13,7 @@ def register_all(dispatch: Any, ctx: dict) -> None:
     modules = []
     for m in pkgutil.iter_modules(pkg.__path__):  # type: ignore[attr-defined]
         name = m.name
-        if name in {"__init__", "register_all"} or name.startswith("_"):
+        if name in {"__init__", "register_all", "switch"} or name.startswith("_"):
             continue
         modules.append(name)
 

--- a/src/mutants/repl/loop.py
+++ b/src/mutants/repl/loop.py
@@ -4,6 +4,7 @@ from mutants.repl.dispatch import Dispatch
 from mutants.commands.register_all import register_all
 from mutants.repl.prompt import make_prompt
 from mutants.repl.help import startup_banner
+from mutants.ui.class_menu import handle_input, render_menu
 
 
 def main() -> None:
@@ -13,6 +14,10 @@ def main() -> None:
 
     # Auto-register all commands in mutants.commands
     register_all(dispatch, ctx)
+
+    ctx["mode"] = "class_select"
+    render_menu(ctx)
+    flush_feedback(ctx)
 
     # Optional: print a small banner or first-help hint once
     print(startup_banner(ctx))
@@ -27,8 +32,11 @@ def main() -> None:
             print()  # newline on ^D/^C
             break
 
-        token, _, arg = raw.strip().partition(" ")
-        dispatch.call(token, arg)
+        if ctx.get("mode") == "class_select":
+            handle_input(raw, ctx)
+        else:
+            token, _, arg = raw.strip().partition(" ")
+            dispatch.call(token, arg)
 
         if ctx.get("render_next"):
             render_frame(ctx)

--- a/src/mutants/repl/prompt.py
+++ b/src/mutants/repl/prompt.py
@@ -3,4 +3,6 @@ from __future__ import annotations
 
 def make_prompt(ctx) -> str:
     # Simple for now; later you can colorize based on theme palette
+    if ctx.get("mode") == "class_select":
+        return "Select (Bury, 1–5, ?) "
     return "> "

--- a/src/mutants/ui/class_menu.py
+++ b/src/mutants/ui/class_menu.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from mutants.services import player_active as act
+from mutants.services import player_state as pstate
+
+
+ROW_FMT = "{idx:>2}. Mutant {cls:<7}  Level: {lvl:<2}  Year: {yr:<4}  ({x:>2} {y:>2})"
+
+
+def _coerce_pos(player) -> Tuple[int, int, int]:
+    pos = player.get("pos") or [2000, 0, 0]
+    try:
+        yr = int(pos[0])
+        x = int(pos[1])
+        y = int(pos[2])
+        return (yr, x, y)
+    except Exception:  # pragma: no cover - fallback for unexpected shapes
+        return (2000, 0, 0)
+
+
+def render_menu(ctx: dict) -> None:
+    """Push the class selection menu into the feedback bus."""
+
+    state = pstate.load_state()
+    players = state.get("players", [])
+    bus = ctx["feedback_bus"]
+    for i, player in enumerate(players, start=1):
+        yr, x, y = _coerce_pos(player)
+        lvl = int(player.get("level", 1) or 1)
+        cls = str(player.get("class") or "Unknown")
+        bus.push(
+            "SYSTEM/OK",
+            ROW_FMT.format(idx=i, cls=cls, lvl=lvl, yr=yr, x=x, y=y),
+        )
+    bus.push("SYSTEM/OK", "Type BURY [class number] to reset a player.")
+    bus.push("SYSTEM/OK", "***")
+
+
+def _select_index(value: str, max_n: int) -> int | None:
+    value = value.strip()
+    if not value.isdigit():
+        return None
+    selected = int(value)
+    return selected if 1 <= selected <= max_n else None
+
+
+def handle_input(raw: str, ctx: dict) -> None:
+    """Handle input while in the class selection menu."""
+
+    s = (raw or "").strip()
+    state = pstate.load_state()
+    players = state.get("players", [])
+    bus = ctx["feedback_bus"]
+    if not s:
+        return
+    lowered = s.lower()
+    if lowered == "?":
+        bus.push(
+            "SYSTEM/INFO",
+            "Select a class by number. Type BURY [class number] to reset a player (not implemented).",
+        )
+        return
+    if lowered.startswith("bury"):
+        bus.push("SYSTEM/INFO", "Bury is not implemented yet.")
+        return
+    idx = _select_index(lowered, len(players))
+    if idx is None:
+        bus.push(
+            "SYSTEM/ERROR",
+            f"Please enter a number (1–{len(players)}), 'bury <n>', or '?'.",
+        )
+        return
+    target_id = players[idx - 1].get("id")
+    if not target_id:
+        bus.push("SYSTEM/ERROR", "No player id for that slot.")
+        return
+    new_state = act.set_active(target_id)
+    ctx["player_state"] = new_state
+    ctx["mode"] = None
+    ctx["render_next"] = True


### PR DESCRIPTION
## Summary
- introduce a class selection UI that lists saved player slots and routes selections through the feedback bus
- wire the REPL loop and prompt to enter and exit the menu, and expose the menu behind the `x` key command
- retire the legacy `switch` command from automatic registration

## Testing
- `pytest` *(fails: package imports expect the project to be installed; modules such as `mutants` and `src` are not on PYTHONPATH in this environment)*
- `PYTHONPATH=src pytest` *(fails: tests importing `src.*` still cannot locate the package due to mixed import styles)*
- `PYTHONPATH=. pytest` *(fails: tests importing `mutants.*` still cannot locate the package without installation)*

------
https://chatgpt.com/codex/tasks/task_e_68cad2fdcd28832ba5ea406fab2d68cc