### PR TITLE
Prevent locking already locked gates

### DIFF
--- a/src/mutants/commands/lock.py
+++ b/src/mutants/commands/lock.py
@@ -44,6 +44,7 @@ def lock_cmd(arg: str, ctx: Dict[str, Any]) -> None:
         reason_messages={
             "not_gate": "You can only lock a closed gate.",
             "already_open": "You can only lock a closed gate.",
+            "already_locked": "The gate is already locked.",
             "no_key": "You need a key to lock a gate.",
         },
     )
@@ -72,6 +73,9 @@ def lock_cmd(arg: str, ctx: Dict[str, Any]) -> None:
             return {"ok": False, "reason": "not_gate"}
         if gs == 0 and ngs == 0:
             return {"ok": False, "reason": "already_open"}
+        lock_meta = dyn.get_lock(year, x, y, D)
+        if lock_meta or gs == 2 or ngs == 2:
+            return {"ok": False, "reason": "already_locked"}
         has_key, key_type = _has_any_key(ctx)
         if not has_key:
             return {"ok": False, "reason": "no_key"}

--- a/tests/commands/test_lock_gate.py
+++ b/tests/commands/test_lock_gate.py
@@ -144,8 +144,15 @@ def test_lock_prefixes_and_unlock_requires_matching_key(monkeypatch):
     for tok in ["s", "so", "sou", "sout"]:
         events = run(dispatch, bus, f"loc {tok}")
         assert ("SYSTEM/OK", "You lock the gate south.") in events
+        # Re-locking without unlocking should warn.
+        events = run(dispatch, bus, "lock south")
+        assert ("SYSTEM/WARN", "The gate is already locked.") in events
+        dyn.clear_lock(2000, 0, 0, "S")
+        edge["gate_state"] = 1
 
     # Open should fail even with key
+    events = run(dispatch, bus, "lock south")
+    assert ("SYSTEM/OK", "You lock the gate south.") in events
     events = run(dispatch, bus, "open south")
     assert ("SYSTEM/WARN", "The south gate is locked.") in events
 


### PR DESCRIPTION
## Summary
- stop the LOCK command from succeeding on gates that are already locked
- add user feedback for already-locked gates and extend coverage

## Testing
- PYTHONPATH=src pytest tests/commands/test_lock_gate.py

------
https://chatgpt.com/codex/tasks/task_e_68cae640b924832ba68b975394b25a22