### PR TITLE
Implement player bury reset in class menu

### DIFF
--- a/src/mutants/registries/items_instances.py
+++ b/src/mutants/registries/items_instances.py
@@ -285,6 +285,27 @@ def save_instances() -> None:
     data = _cache()
     _save_instances_raw(data)
 
+
+def remove_instances(instance_ids: List[str]) -> int:
+    """Remove all instances whose ids are in ``instance_ids``."""
+
+    targets = {str(i) for i in instance_ids if i}
+    if not targets:
+        return 0
+
+    raw = _cache()
+    before = len(raw)
+
+    def _iid(inst: Dict[str, Any]) -> Optional[str]:
+        value = inst.get("iid") or inst.get("instance_id")
+        return str(value) if value else None
+
+    raw[:] = [inst for inst in raw if _iid(inst) not in targets]
+    _save_instances_raw(raw)
+    global _CACHE
+    _CACHE = None
+    return before - len(raw)
+
 def list_instances_at(year: int, x: int, y: int) -> List[Dict[str, Any]]:
     raw = _cache()
     out: List[Dict[str, Any]] = []

--- a/src/mutants/services/player_reset.py
+++ b/src/mutants/services/player_reset.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+
+from mutants.bootstrap.lazyinit import compute_ac_from_dex
+from mutants.registries import items_instances as itemsreg
+from mutants.services import player_state as pstate
+
+
+def _load_templates() -> List[Dict[str, Any]]:
+    """Load the starting class templates from packaged data."""
+
+    try:
+        with resources.open_text(
+            "mutants.data", "startingclasstemplates.json", encoding="utf-8"
+        ) as f:
+            return json.load(f)
+    except Exception:
+        # Fallback for environments running from a checkout
+        data_path = Path("src/mutants/data/startingclasstemplates.json")
+        return json.loads(data_path.read_text(encoding="utf-8"))
+
+
+def _template_for(cls_name: str, templates: List[Dict[str, Any]]) -> Dict[str, Any]:
+    for t in templates:
+        if (t.get("class") or "").lower() == (cls_name or "").lower():
+            return t
+    raise KeyError(f"No starting template for class: {cls_name}")
+
+
+def _reset_fields_from_template(player: Dict[str, Any], template: Dict[str, Any]) -> None:
+    stats = template.get("base_stats", {}) or {}
+    dex = int(stats.get("dex", 0) or 0)
+    hp_max = int(template.get("hp_max_start", 0) or 0)
+
+    player["pos"] = list(template.get("start_pos", [2000, 0, 0]))
+    player["stats"] = {
+        "str": int(stats.get("str", 0) or 0),
+        "int": int(stats.get("int", 0) or 0),
+        "wis": int(stats.get("wis", 0) or 0),
+        "dex": dex,
+        "con": int(stats.get("con", 0) or 0),
+        "cha": int(stats.get("cha", 0) or 0),
+    }
+    player["hp"] = {"current": hp_max, "max": hp_max}
+    player["exhaustion"] = int(template.get("exhaustion_start", 0) or 0)
+    player["exp_points"] = int(template.get("exp_start", 0) or 0)
+    player["level"] = int(template.get("level_start", 1) or 1)
+    player["riblets"] = int(template.get("riblets_start", 0) or 0)
+    player["ions"] = int(template.get("ions_start", 0) or 0)
+    player["armour"] = {
+        "wearing": template.get("armour_start", None),
+        "armour_class": compute_ac_from_dex(dex),
+    }
+    player["readied_spell"] = template.get("readied_spell_start", None)
+    player["target_monster_id"] = None
+    player["inventory"] = []
+    player["carried_weight"] = 0
+    player["conditions"] = {
+        "poisoned": False,
+        "encumbered": False,
+        "ion_starving": False,
+    }
+
+
+def bury_by_index(index_0: int) -> Dict[str, Any]:
+    """Reset the player at ``index_0`` (0-based) to their starting template."""
+
+    state, _ = pstate.get_active_pair()
+    players = state.get("players", [])
+    if not (0 <= index_0 < len(players)):
+        raise IndexError("Player index out of range")
+
+    player = players[index_0]
+    inventory_ids = [iid for iid in (player.get("inventory") or []) if iid]
+    if inventory_ids:
+        itemsreg.remove_instances(inventory_ids)
+
+    templates = _load_templates()
+    template = _template_for(player.get("class"), templates)
+    _reset_fields_from_template(player, template)
+
+    pstate.save_state(state)
+    return state


### PR DESCRIPTION
## Summary
- wire the class menu BURY command to a new player_reset service
- reset player state from starting templates and drop inventory instances
- expose a helper for deleting item instances by id in the registry

## Testing
- PYTHONPATH=.:src pytest *(fails: numerous existing inventory/throw command tests already failing in baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68caeadd52e0832ba81cb25c12a95261