### PR TITLE
Fix inventory command weight summary

### DIFF
--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -6,26 +6,66 @@ from ..ui import wrap as uwrap
 from ..ui.textutils import harden_final_display
 
 
+def _coerce_weight(value):
+    """Return an integer weight or ``None`` when the value is unusable."""
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_weight(inst, tpl) -> int | None:
+    """Resolve the weight for an item instance using overrides and catalog."""
+
+    raw = inst.get("weight")
+    if raw is None and tpl:
+        for key in ("weight", "weight_lbs", "lbs"):
+            if key in tpl:
+                raw = tpl.get(key)
+                if raw is not None:
+                    break
+    return _coerce_weight(raw)
+
+
 def inv_cmd(arg: str, ctx):
     _, player = pstate.get_active_pair()
     inv = list(player.get("inventory") or [])
     cat = items_catalog.load_catalog()
     names = []
+    total_weight = 0
+    weight_known = False
+
     for iid in inv:
         inst = itemsreg.get_instance(iid)
         if not inst:
-            names.append(iid)
+            names.append(str(iid))
             continue
         tpl_id = inst.get("item_id") or inst.get("catalog_id") or inst.get("id")
         tpl = cat.get(str(tpl_id)) if tpl_id else {}
         names.append(item_label(inst, tpl or {}, show_charges=False))
+
+        weight = _resolve_weight(inst, tpl or {})
+        if weight is not None:
+            weight_known = True
+            total_weight += weight
+
     numbered = number_duplicates(names)
     display = [harden_final_display(with_article(n)) for n in numbered]
     bus = ctx["feedback_bus"]
     if not display:
         bus.push("SYSTEM/OK", "You are carrying nothing.")
         return
-    bus.push("SYSTEM/OK", "You are carrying:")
+
+    if weight_known:
+        unit = "lb" if total_weight == 1 else "lbs"
+        bus.push("SYSTEM/OK", f"You are carrying: (Total weight: {total_weight} {unit})")
+    else:
+        bus.push("SYSTEM/OK", "You are carrying:")
     for ln in uwrap.wrap_list(display):
         bus.push("SYSTEM/OK", ln)
 

--- a/tests/commands/test_inv_command.py
+++ b/tests/commands/test_inv_command.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import types
+
+from mutants.commands import inv as inv_cmd
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def push(self, chan: str, msg: str) -> None:
+        self.events.append((chan, msg))
+
+
+def _mk_ctx() -> tuple[DummyBus, dict[str, object]]:
+    bus = DummyBus()
+    ctx = {"feedback_bus": bus}
+    return bus, ctx
+
+
+def test_inv_empty_inventory_uses_legacy_message(monkeypatch):
+    bus, ctx = _mk_ctx()
+
+    monkeypatch.setattr(
+        inv_cmd.pstate,
+        "get_active_pair",
+        lambda: ({"players": []}, {"inventory": []}),
+    )
+    monkeypatch.setattr(inv_cmd.itemsreg, "get_instance", lambda _iid: None)
+    monkeypatch.setattr(inv_cmd.items_catalog, "load_catalog", lambda: types.SimpleNamespace(get=lambda *_: {}))
+
+    inv_cmd.inv_cmd("", ctx)
+
+    assert bus.events == [("SYSTEM/OK", "You are carrying nothing.")]
+
+
+def test_inv_reports_total_weight_when_known(monkeypatch):
+    bus, ctx = _mk_ctx()
+
+    inv = ["sword#1"]
+    inst = {"iid": "sword#1", "instance_id": "sword#1", "item_id": "sword", "weight": 2}
+
+    monkeypatch.setattr(
+        inv_cmd.pstate,
+        "get_active_pair",
+        lambda: ({"players": []}, {"inventory": inv}),
+    )
+    monkeypatch.setattr(inv_cmd.itemsreg, "get_instance", lambda iid: inst if iid == "sword#1" else None)
+
+    class DummyCatalog:
+        def get(self, item_id: str):
+            if item_id == "sword":
+                return {"item_id": "sword", "weight": 2}
+            return {}
+
+    monkeypatch.setattr(inv_cmd.items_catalog, "load_catalog", lambda: DummyCatalog())
+
+    inv_cmd.inv_cmd("", ctx)
+
+    assert bus.events[0] == ("SYSTEM/OK", "You are carrying: (Total weight: 2 lbs)")
+    # Display line uses NBSP for the article binding. Ensure item is listed.
+    assert any("Sword" in msg for _, msg in bus.events[1:])


### PR DESCRIPTION
## Summary
- preserve the legacy "carrying nothing" response for an empty inventory
- compute carried weight from instances/catalog metadata and include it when available
- add regression tests covering empty inventory and weight summaries

## Testing
- PYTHONPATH=src:. pytest tests/commands/test_inv_command.py


------
https://chatgpt.com/codex/tasks/task_e_68caefa90b48832bbe0a74394179c735