### PR TITLE
Update inventory command header format

### DIFF
--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -38,7 +38,6 @@ def inv_cmd(arg: str, ctx):
     cat = items_catalog.load_catalog()
     names = []
     total_weight = 0
-    weight_known = False
 
     for iid in inv:
         inst = itemsreg.get_instance(iid)
@@ -51,21 +50,19 @@ def inv_cmd(arg: str, ctx):
 
         weight = _resolve_weight(inst, tpl or {})
         if weight is not None:
-            weight_known = True
             total_weight += weight
 
     numbered = number_duplicates(names)
     display = [harden_final_display(with_article(n)) for n in numbered]
     bus = ctx["feedback_bus"]
+    # Header must read exactly as specified; note the two spaces before '('
+    bus.push(
+        "SYSTEM/OK",
+        f"You are carrying the following items:  (Total Weight: {total_weight} LB's)",
+    )
     if not display:
-        bus.push("SYSTEM/OK", "You are carrying nothing.")
+        bus.push("SYSTEM/OK", "Nothing.")
         return
-
-    if weight_known:
-        unit = "lb" if total_weight == 1 else "lbs"
-        bus.push("SYSTEM/OK", f"You are carrying: (Total weight: {total_weight} {unit})")
-    else:
-        bus.push("SYSTEM/OK", "You are carrying:")
     for ln in uwrap.wrap_list(display):
         bus.push("SYSTEM/OK", ln)
 

--- a/tests/commands/test_inv_command.py
+++ b/tests/commands/test_inv_command.py
@@ -32,7 +32,10 @@ def test_inv_empty_inventory_uses_legacy_message(monkeypatch):
 
     inv_cmd.inv_cmd("", ctx)
 
-    assert bus.events == [("SYSTEM/OK", "You are carrying nothing.")]
+    assert bus.events == [
+        ("SYSTEM/OK", "You are carrying the following items:  (Total Weight: 0 LB's)"),
+        ("SYSTEM/OK", "Nothing."),
+    ]
 
 
 def test_inv_reports_total_weight_when_known(monkeypatch):
@@ -58,6 +61,9 @@ def test_inv_reports_total_weight_when_known(monkeypatch):
 
     inv_cmd.inv_cmd("", ctx)
 
-    assert bus.events[0] == ("SYSTEM/OK", "You are carrying: (Total weight: 2 lbs)")
+    assert bus.events[0] == (
+        "SYSTEM/OK",
+        "You are carrying the following items:  (Total Weight: 2 LB's)",
+    )
     # Display line uses NBSP for the article binding. Ensure item is listed.
     assert any("Sword" in msg for _, msg in bus.events[1:])


### PR DESCRIPTION
## Summary
- update the inventory command to always emit the new header message that includes the total weight
- adjust the inventory command tests to expect the new messaging

## Testing
- PYTHONPATH=src pytest tests/commands/test_inv_command.py


------
https://chatgpt.com/codex/tasks/task_e_68caf3cfdd3c832bab45b4b13cb88489