### PR TITLE
Add exit shortcut to class menu

### DIFF
--- a/src/mutants/ui/class_menu.py
+++ b/src/mutants/ui/class_menu.py
@@ -33,7 +33,10 @@ def render_menu(ctx: dict) -> None:
             "SYSTEM/OK",
             ROW_FMT.format(idx=i, cls=cls, lvl=lvl, yr=yr, x=x, y=y),
         )
-    bus.push("SYSTEM/OK", "Type BURY [class number] to reset a player.")
+    bus.push(
+        "SYSTEM/OK",
+        "Type BURY [class number] to reset a player. Type X to exit.",
+    )
     bus.push("SYSTEM/OK", "***")
 
 
@@ -56,9 +59,11 @@ def handle_input(raw: str, ctx: dict) -> None:
     if lowered == "?":
         bus.push(
             "SYSTEM/INFO",
-            "Select a class by number. Type BURY [class number] to reset a player.",
+            "Select a class by number. Type BURY [class number] to reset a player. Type X to exit.",
         )
         return
+    if lowered == "x":
+        raise SystemExit(0)
     if lowered.startswith("bury"):
         parts = lowered.split()
         if len(parts) != 2 or not parts[1].isdigit():

--- a/tests/ui/test_class_menu.py
+++ b/tests/ui/test_class_menu.py
@@ -1,0 +1,28 @@
+import pytest
+
+from mutants.app import context
+from mutants.ui.class_menu import handle_input, render_menu
+
+
+def make_ctx():
+    ctx = context.build_context()
+    ctx["feedback_bus"].drain()
+    return ctx
+
+
+def test_render_menu_mentions_exit_instruction():
+    ctx = make_ctx()
+    render_menu(ctx)
+    events = ctx["feedback_bus"].drain()
+    assert any(
+        ev["kind"] == "SYSTEM/OK"
+        and "Type BURY [class number] to reset a player. Type X to exit." in ev["text"]
+        for ev in events
+    )
+
+
+def test_handle_input_x_exits_cleanly():
+    ctx = make_ctx()
+    with pytest.raises(SystemExit) as excinfo:
+        handle_input("x", ctx)
+    assert excinfo.value.code == 0


### PR DESCRIPTION
## Summary
- allow the class menu to exit cleanly when the user enters X
- update the menu instructions to describe the new shortcut
- add tests that cover the exit shortcut and updated instructions

## Testing
- PYTHONPATH=src pytest tests/ui/test_class_menu.py


------
https://chatgpt.com/codex/tasks/task_e_68cb0bfaf1d4832b94db009854601d0b