### PR TITLE
Add blank line before class menu hint

### DIFF
--- a/src/mutants/ui/class_menu.py
+++ b/src/mutants/ui/class_menu.py
@@ -33,6 +33,8 @@ def render_menu(ctx: dict) -> None:
             "SYSTEM/OK",
             ROW_FMT.format(idx=i, cls=cls, lvl=lvl, yr=yr, x=x, y=y),
         )
+    # Blank line between the list and the hint line.
+    bus.push("SYSTEM/OK", "")
     bus.push(
         "SYSTEM/OK",
         "Type BURY [class number] to reset a player. Type X to exit.",


### PR DESCRIPTION
## Summary
- insert an empty SYSTEM/OK push between the class listing and the menu hint to create a visual break

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0f900d34832b9dc4b87fa83a75c1