### PR TITLE
Add travel command for century hopping

### DIFF
--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+import random
+import re
+from typing import Any, Dict, List
+
+from mutants.services import player_state as pstate
+
+
+def _active(state: Dict[str, Any]) -> Dict[str, Any]:
+    aid = state.get("active_id")
+    for player in state.get("players", []):
+        if player.get("id") == aid:
+            return player
+    return (state.get("players") or [{}])[0]
+
+
+def _floor_century(year: int) -> int:
+    return (int(year) // 100) * 100
+
+
+def _century_label(year: int) -> str:
+    # Match existing UI tone (e.g., "21th Century!")
+    return f"{(int(year) // 100) + 1}th Century!"
+
+
+_YEAR_RE = re.compile(r"^(\d{1,6})\.json$", re.I)
+
+
+def _installed_years() -> List[int]:
+    """Return all installed century years discovered on the filesystem."""
+
+    world_dir = os.path.join(os.getcwd(), "state", "world")
+    years: List[int] = []
+    try:
+        for filename in os.listdir(world_dir):
+            match = _YEAR_RE.match(filename)
+            if not match:
+                continue
+            year = int(match.group(1))
+            if year % 100 == 0:  # centuries only
+                years.append(year)
+    except FileNotFoundError:
+        pass
+    return sorted(set(years))
+
+
+def _year_installed(year: int) -> bool:
+    return year in _installed_years()
+
+
+def _cost_per_years(delta_years: int) -> int:
+    return 3000 * max(0, int(delta_years))
+
+
+def travel_cmd(arg: str, ctx) -> None:
+    bus = ctx["feedback_bus"]
+    tokens = (arg or "").strip().split()
+    if not tokens:
+        bus.push("SYSTEM/ERROR", "Usage: TRAVEL [year]")
+        return
+    # parse and round down to the lower century
+    try:
+        raw_year = int(tokens[0])
+    except ValueError:
+        bus.push("SYSTEM/ERROR", "Year must be an integer (e.g., 2100).")
+        return
+    target_year = _floor_century(raw_year)
+
+    # Check availability (filesystem-driven; future-proof)
+    if not _year_installed(target_year):
+        bus.push("SYSTEM/ERROR", "That year doesn't exist yet.")
+        return
+
+    # Get active player and current year
+    state = pstate.load_state()
+    player = _active(state)
+    pos = player.get("pos") or [2000, 0, 0]
+    cur_year = int(pos[0]) if isinstance(pos, (list, tuple)) and len(pos) >= 1 else 2000
+    ions = int(player.get("ions", 0) or 0)
+
+    # Same-year travel is free and allowed even with < 3000 ions
+    if target_year == cur_year:
+        bus.push("SYSTEM/OK", f"You're already in the {_century_label(cur_year)}")
+        return
+
+    # Compute cost for a normal trip
+    cost = _cost_per_years(abs(target_year - cur_year))
+
+    # Not enough to even create a portal
+    if ions < 3000:
+        bus.push("SYSTEM/OK", "You don't have enough ions to create a portal.")
+        return
+
+    if ions >= cost:
+        # Full travel succeeds
+        def _apply(_, active):
+            active["ions"] = ions - cost
+            active["pos"] = [target_year, 0, 0]
+
+        pstate.mutate_active(_apply)
+        ctx["render_next"] = False  # traveling does not render a tile
+        bus.push("SYSTEM/OK", f"ZAAAPPPP!! You've been sent to the year {target_year} A.D.")
+        return
+
+    # Partial travel: choose randomly among installed decades 2000..3000 only
+    pool = [year for year in _installed_years() if 2000 <= year <= 3000]
+    if not pool:
+        # Extremely unlikely (we usually have at least 2000); fail safely
+        bus.push("SYSTEM/ERROR", "The portal destabilizes—no safe century anchors available.")
+        return
+    rnd_year = random.choice(pool)
+
+    def _apply_partial(_, active):
+        active["ions"] = 0
+        active["pos"] = [rnd_year, 0, 0]
+
+    pstate.mutate_active(_apply_partial)
+    ctx["render_next"] = False
+    bus.push("SYSTEM/OK", "ZAAAPPPP!!!! You suddenly feel something has gone terribly wrong!")
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("travel", lambda arg: travel_cmd(arg, ctx))
+    for alias in ["tra", "trav", "trave"]:
+        dispatch.alias(alias, "travel")


### PR DESCRIPTION
## Summary
- add a travel command that lets the active player jump across centuries when enough ions are available
- round requested years down to the nearest century and refuse travel to centuries that are not installed on disk
- handle insufficient ions by warning or by flinging the player to a random available century when the portal collapses

## Testing
- PYTHONPATH=src:. pytest *(fails: numerous pre-existing command/item tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb18e36c4c832b9005e5b105951bfe