### PR TITLE
Adjust ground item selection to use iid listings

### DIFF
--- a/docs/architecture_dense.md
+++ b/docs/architecture_dense.md
@@ -132,7 +132,7 @@ VM → Formatters (build strings + **group**) → Styles (resolve color by group
 * **Safety**: runs once at bootstrap; missing files/worlds merely log and skip.
 
 #### Items Registry
-* **Reader**: `registries/items_instances.py` provides `list_ids_at(year,x,y)` (IDs) and legacy `list_at(year,x,y)` (display names). Both recognize `{"pos":{...}}` and flat `{"year":...}` shapes.
+* **Reader**: `registries/items_instances.py` provides `list_ids_at(year,x,y)` (instance IDs) and legacy `list_at(year,x,y)` (display names). Both recognize `{"pos":{...}}` and flat `{"year":...}` shapes.
 * **VM plumbing**: context uses this registry so `build_room_vm` sets `has_ground`/`ground_item_ids` for the renderer.
 
 #### Item Display Rules

--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -141,7 +141,24 @@ def build_room_vm(
     ground_ids: List[str] = []
     if items and hasattr(items, "list_ids_at"):
         try:
-            ground_ids = items.list_ids_at(year, x, y)  # type: ignore[attr-defined]
+            iid_list = items.list_ids_at(year, x, y)  # type: ignore[attr-defined]
+            if hasattr(items, "get_instance"):
+                resolved: List[str] = []
+                for iid in iid_list:
+                    inst = items.get_instance(iid)  # type: ignore[attr-defined]
+                    if isinstance(inst, dict):
+                        item_id = (
+                            inst.get("item_id")
+                            or inst.get("catalog_id")
+                            or inst.get("id")
+                        )
+                        if item_id:
+                            resolved.append(str(item_id))
+                            continue
+                    resolved.append(str(iid))
+                ground_ids = resolved
+            else:
+                ground_ids = [str(i) for i in iid_list]
         except Exception:
             ground_ids = []
 

--- a/src/mutants/registries/items_instances.py
+++ b/src/mutants/registries/items_instances.py
@@ -253,20 +253,16 @@ def list_at(year: int, x: int, y: int) -> List[str]:
 
 
 def list_ids_at(year: int, x: int, y: int) -> List[str]:
-    """Return raw item_ids for instances at (year, x, y)."""
+    """Return instance IDs located at (year, x, y)."""
     raw = _load_instances_raw()
     out: List[str] = []
     tgt = (int(year), int(x), int(y))
     for inst in raw:
         pos = _pos_of(inst)
         if pos and pos == tgt:
-            item_id = (
-                inst.get("item_id")
-                or inst.get("catalog_id")
-                or inst.get("id")
-            )
-            if item_id:
-                out.append(str(item_id))
+            inst_id = inst.get("iid") or inst.get("instance_id")
+            if inst_id:
+                out.append(str(inst_id))
     return out
 
 # ---------------------------------------------------------------------------

--- a/tests/commands/test_get_command.py
+++ b/tests/commands/test_get_command.py
@@ -76,9 +76,12 @@ def test_get_prefix_picks_first(monkeypatch, tmp_path, token):
     with pfile.open("r", encoding="utf-8") as f:
         pdata = json.load(f)
     assert iids[0] in pdata.get("inventory", [])
-    ground_ids = itemsreg.list_ids_at(2000, 0, 0)
-    assert "ion_pack" not in ground_ids
-    assert "ion_booster" in ground_ids
+    ground_iids = itemsreg.list_ids_at(2000, 0, 0)
+    assert iids[0] not in ground_iids
+    remaining = {
+        (itemsreg.get_instance(g) or {}).get("item_id") for g in ground_iids
+    }
+    assert "ion_booster" in remaining
 
 
 def test_get_longer_prefix_picks_second(monkeypatch, tmp_path):
@@ -90,9 +93,12 @@ def test_get_longer_prefix_picks_second(monkeypatch, tmp_path):
     with pfile.open("r", encoding="utf-8") as f:
         pdata = json.load(f)
     assert iids[1] in pdata.get("inventory", [])
-    ground_ids = itemsreg.list_ids_at(2000, 0, 0)
-    assert "ion_booster" not in ground_ids
-    assert "ion_pack" in ground_ids
+    ground_iids = itemsreg.list_ids_at(2000, 0, 0)
+    assert iids[1] not in ground_iids
+    remaining = {
+        (itemsreg.get_instance(g) or {}).get("item_id") for g in ground_iids
+    }
+    assert "ion_pack" in remaining
 
 
 @pytest.mark.skip(reason="Unicode dash naming no longer validated")
@@ -114,5 +120,8 @@ def test_get_not_found(monkeypatch, tmp_path):
     with pfile.open("r", encoding="utf-8") as f:
         pdata = json.load(f)
     assert not pdata.get("inventory")
-    ground_ids = itemsreg.list_ids_at(2000, 0, 0)
-    assert "ion_pack" in ground_ids
+    ground_iids = itemsreg.list_ids_at(2000, 0, 0)
+    assert any(
+        (itemsreg.get_instance(g) or {}).get("item_id") == "ion_pack"
+        for g in ground_iids
+    )

--- a/tests/test_throw_command.py
+++ b/tests/test_throw_command.py
@@ -91,7 +91,7 @@ def test_thrown_item_can_be_picked_up(monkeypatch, tmp_path):
     ctx, pfile, inv = _setup(monkeypatch, tmp_path, ["nuclear_decay"])
     iid = inv[0]
     throw_cmd("north nuclear", ctx)
-    assert "nuclear_decay" in itemsreg.list_ids_at(2000, 0, 1)
+    assert iid in itemsreg.list_ids_at(2000, 0, 1)
     ctx["player_state"]["players"][0]["pos"] = [2000, 0, 1]
     dec = itx.pick_from_ground(ctx, "nuclear")
     assert dec.get("ok")


### PR DESCRIPTION
## Summary
- use `itemsreg.list_ids_at` to drive ground ordering and prefix selection with fresh instance lookups
- return instance identifiers from `list_ids_at` and resolve ground display ids via `build_room_vm`
- update documentation and tests to match the new semantics

## Testing
- `PYTHONPATH=.:src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb4a550aa8832b8f97cb8516299e9e