### PR TITLE
Fix ghost item duplication in room view

### DIFF
--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -142,6 +142,21 @@ def build_room_vm(
     if items and hasattr(items, "list_ids_at"):
         try:
             iid_list = items.list_ids_at(year, x, y)  # type: ignore[attr-defined]
+            # Ghost-dup guard: filter out any instance IDs that live in any player's inventory.
+            try:
+                inv_iids: set[str] = set()
+                players = state.get("players") if isinstance(state, dict) else None
+                if isinstance(players, list):
+                    for pl in players:
+                        inv = pl.get("inventory") if isinstance(pl, dict) else None
+                        if isinstance(inv, list):
+                            for iid in inv:
+                                if isinstance(iid, str):
+                                    inv_iids.add(iid)
+                iid_list = [iid for iid in iid_list if iid not in inv_iids]
+            except Exception:
+                # rendering should never crash, ignore guard failures
+                pass
             if hasattr(items, "get_instance"):
                 resolved: List[str] = []
                 for iid in iid_list:

--- a/src/mutants/registries/items_instances.py
+++ b/src/mutants/registries/items_instances.py
@@ -336,6 +336,8 @@ def clear_position(iid: str) -> None:
             break
     if changed:
         _save_instances_raw(raw)
+        global _CACHE
+        _CACHE = None
 
 def set_position(iid: str, year: int, x: int, y: int) -> None:
     raw = _cache()
@@ -351,6 +353,8 @@ def set_position(iid: str, year: int, x: int, y: int) -> None:
             break
     if changed:
         _save_instances_raw(raw)
+        global _CACHE
+        _CACHE = None
 
 
 def create_and_save_instance(item_id: str, year: int, x: int, y: int, origin: str = "debug_add") -> str:
@@ -373,5 +377,7 @@ def create_and_save_instance(item_id: str, year: int, x: int, y: int, origin: st
         inst["charges"] = int(tpl.get("charges_max"))
     raw.append(inst)
     _save_instances_raw(raw)
+    global _CACHE
+    _CACHE = None
     return iid
 


### PR DESCRIPTION
## Summary
- filter ground item instance IDs to avoid showing duplicates for items held in player inventories
- reset the cached instances list whenever positions or new instances are persisted to disk

## Testing
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68cb56173dc0832ba72f8e8d6dd87fec