### PR TITLE
Fix stale items cache when instance file timestamp decreases

### DIFF
--- a/src/mutants/bootstrap/daily_litter.py
+++ b/src/mutants/bootstrap/daily_litter.py
@@ -410,6 +410,14 @@ def run_daily_litter_reset(root: str | Path | None = None) -> None:
 
     _mkdir_p(paths["instances"].parent)
     _save_instances_list(paths["instances"], instances)
+    try:
+        from mutants.registries import items_instances as itemsreg
+
+        invalidate = getattr(itemsreg, "invalidate_cache", None)
+        if callable(invalidate):
+            invalidate()
+    except Exception:
+        pass
     _mkdir_p(runtime_dir)
     _save_json_atomic(epoch_path, {"last_reset": today})
 

--- a/tests/test_instances_cache_reload.py
+++ b/tests/test_instances_cache_reload.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+from src.mutants.registries import items_instances as itemsreg
+
+
+def _copy_state(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+
+
+def test_cache_refreshes_when_timestamp_moves_backwards(monkeypatch, tmp_path):
+    src_state = Path(__file__).resolve().parents[1] / "state"
+    dst_state = tmp_path / "state"
+    _copy_state(src_state, dst_state)
+
+    monkeypatch.chdir(tmp_path)
+    itemsreg.invalidate_cache()
+
+    iid = itemsreg.create_and_save_instance("skull", 2000, 0, 0)
+    cached = itemsreg.list_instances_at(2000, 0, 0)
+    assert any((inst.get("iid") or inst.get("instance_id")) == iid for inst in cached)
+
+    path = Path("state/items/instances.json")
+    before_mtime = path.stat().st_mtime
+
+    with path.open("w", encoding="utf-8") as f:
+        json.dump([], f)
+
+    older = before_mtime - 10 if before_mtime else 0
+    os.utime(path, (older, older))
+
+    refreshed = itemsreg.list_instances_at(2000, 0, 0)
+    try:
+        assert refreshed == []
+    finally:
+        itemsreg.invalidate_cache()


### PR DESCRIPTION
## Summary
- reload the instances registry cache whenever the backing file path or mtime changes, even if the timestamp moves backwards
- invalidate the instances cache after the daily litter bootstrap rewrites the instances list
- add a regression test covering cache refresh when the file mtime decreases

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc1e4fbc98832b8af3aa290b21df11