### PR TITLE
Improve ground item selection feedback

### DIFF
--- a/src/mutants/commands/argcmd.py
+++ b/src/mutants/commands/argcmd.py
@@ -63,6 +63,8 @@ def run_argcmd(
             fmt_vals["candidates"] = ", ".join(cands)
         if spec.reason_messages and r in spec.reason_messages:
             msg = _fmt(spec.reason_messages[r], **fmt_vals)
+        if not msg and decision.get("message"):
+            msg = str(decision["message"])
         if not msg:
             msg = _fmt((spec.messages or {}).get("invalid"), subject=subject)
         bus.push(spec.warn_kind, msg or "Nothing happens.")
@@ -196,6 +198,8 @@ def run_argcmd_positional(
         fmt_vals.setdefault("item", values.get("item"))
         if spec.reason_messages and r in spec.reason_messages:
             msg = _fmt(spec.reason_messages[r], **fmt_vals)
+        if not msg and decision.get("message"):
+            msg = str(decision["message"])
         if not msg:
             msg = _fmt((spec.messages or {}).get("invalid"), **fmt_vals)
         bus.push(spec.warn_kind, msg or "Nothing happens.")

--- a/src/mutants/commands/get.py
+++ b/src/mutants/commands/get.py
@@ -27,7 +27,7 @@ def get_cmd(arg: str, ctx):
         q = normalize_item_query(prefix)
         if not q:
             return {"ok": False, "reason": "usage"}
-        dec = itx.pick_from_ground(ctx, q)
+        dec = itx.pick_from_ground(ctx, prefix)
         if dec.get("ok") and dec.get("iid"):
             inst = itemsreg.get_instance(dec["iid"]) or {}
             tpl = cat.get(inst.get("item_id")) or {}

--- a/tests/commands/test_get_command.py
+++ b/tests/commands/test_get_command.py
@@ -67,17 +67,17 @@ import pytest
 
 
 @pytest.mark.parametrize("token", ["i", "ion"])
-def test_get_prefix_picks_first(monkeypatch, tmp_path, token):
+def test_get_prefix_requires_disambiguation(monkeypatch, tmp_path, token):
     ctx, pfile, iids = _setup(monkeypatch, tmp_path, ["ion_pack", "ion_booster"])
     get_cmd(token, ctx)
     assert ctx["feedback_bus"].events == [
-        ("LOOT/PICKUP", "You pick up the Ion-Pack."),
+        ("SYSTEM/WARN", "Ambiguous: Ion-Pack, Ion-Booster."),
     ]
     with pfile.open("r", encoding="utf-8") as f:
         pdata = json.load(f)
-    assert iids[0] in pdata.get("inventory", [])
+    assert not pdata.get("inventory")
     ground_ids = itemsreg.list_ids_at(2000, 0, 0)
-    assert "ion_pack" not in ground_ids
+    assert "ion_pack" in ground_ids
     assert "ion_booster" in ground_ids
 
 


### PR DESCRIPTION
## Summary
- add catalog-aware display matching and disambiguation when selecting ground items
- allow command runners to surface service-provided failure messages and pass original GET prefixes through
- update GET command coverage for the new disambiguation behaviour

## Testing
- PYTHONPATH=src:. pytest tests/test_argcmd_core.py tests/test_argcmd_positional_core.py tests/commands/test_get_command.py
- PYTHONPATH=src:. pytest tests/services/test_item_transfer.py

------
https://chatgpt.com/codex/tasks/task_e_68cc59fd1158832b9683bc9c8977b3d5