### PR TITLE
Improve instrumentation for item pickup debugging

### DIFF
--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -147,6 +147,7 @@ def build_room_vm(
             # Emit a renderer-side probe of exactly what we're about to show.
             try:
                 items_probe.probe("renderer", items, year, x, y)
+                items_probe.dump_tile_instances(items, year, x, y, tag="renderer-dump")
             except Exception:
                 pass
         except Exception:


### PR DESCRIPTION
## Summary
- add tile dump and cache search helpers to the items debug probe
- extend pick_from_ground with detailed logging and consistency checks when ITEMS_DEBUG is enabled
- dump renderer-side tile state to correlate ground listings during debugging

## Testing
- pytest *(fails: import errors for tests that import from `src.*` when package isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5e33c614832b8d59472c1b6f447c