### PR TITLE
Improve item instance IDs and clearing

### DIFF
--- a/src/mutants/bootstrap/daily_litter.py
+++ b/src/mutants/bootstrap/daily_litter.py
@@ -20,6 +20,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 
+from ..util.ids import new_instance_id
+
 
 LOG = logging.getLogger(__name__)
 
@@ -274,7 +276,7 @@ def _count_item_per_year(instances: List[Dict]) -> Dict[int, Dict[str, int]]:
 
 def _new_instance_dict(item_id: str, year: int, x: int, y: int, epoch: str, seq: int) -> Dict:
     return {
-        "iid": f"dl_{epoch.replace('-', '')}_{seq}",
+        "iid": new_instance_id(year=year, item_id=item_id, tag="dl"),
         "item_id": item_id,
         "pos": {"year": year, "x": x, "y": y},
         "year": year,

--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -355,7 +355,9 @@ def pick_from_ground(ctx, prefix: str, *, seed: Optional[int] = None) -> Dict:
             "message": "No such item on the ground here.",
         }
 
-    itemsreg.clear_position(chosen_iid)
+    ok = itemsreg.clear_position_at(chosen_iid, year, x, y)
+    if not ok:
+        return {"ok": False, "reason": "That item is no longer on the ground here."}
     inv = list(player.get("inventory", []))
     inv.append(chosen_iid)
     player["inventory"] = inv

--- a/src/mutants/util/ids.py
+++ b/src/mutants/util/ids.py
@@ -1,0 +1,36 @@
+"""Helpers for generating unique identifiers."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+import uuid
+
+
+def new_instance_id(*, year: int | None = None, item_id: str | None = None, tag: str | None = None) -> str:
+    """Return a globally-unique, URL-safe instance identifier.
+
+    The identifier is composed of dot-separated segments to aid debugging while
+    keeping the token easy to slice when analysing logs.
+
+    Format: ``i.<yyyymmdd>[.<year>][.<tag>][.<item_hash>].<12hex>``
+    """
+
+    yyyymmdd = time.strftime("%Y%m%d", time.gmtime())
+    core = uuid.uuid4().hex[:12]
+    parts = ["i", yyyymmdd]
+
+    if year is not None:
+        parts.append(str(int(year)))
+
+    if tag:
+        safe = "".join(ch for ch in tag if ch.isalnum() or ch in ("-", "_"))[:24]
+        if safe:
+            parts.append(safe)
+
+    if item_id:
+        digest = hashlib.blake2s(item_id.encode("utf-8"), digest_size=4).hexdigest()
+        parts.append(digest)
+
+    parts.append(core)
+    return ".".join(parts)

--- a/tests/commands/test_throw_blocked.py
+++ b/tests/commands/test_throw_blocked.py
@@ -45,7 +45,15 @@ def patch_items(monkeypatch, player):
     monkeypatch.setattr(item_transfer, "_save_player", lambda p: None)
     positions = {}
     monkeypatch.setattr(itemsreg, "set_position", lambda iid, yr, x, y: positions.update({iid: (yr, x, y)}))
+
+    def _clear_at(iid, yr, x, y):
+        if positions.get(iid) == (yr, x, y):
+            positions.pop(iid, None)
+            return True
+        return False
+
     monkeypatch.setattr(itemsreg, "clear_position", lambda iid: positions.pop(iid, None))
+    monkeypatch.setattr(itemsreg, "clear_position_at", _clear_at)
     monkeypatch.setattr(itemsreg, "list_instances_at", lambda yr, x, y: [])
     monkeypatch.setattr(itemsreg, "save_instances", lambda: None)
     monkeypatch.setattr(itemsreg, "get_instance", lambda iid: {"item_id": iid})

--- a/tests/services/test_item_transfer.py
+++ b/tests/services/test_item_transfer.py
@@ -19,6 +19,7 @@ def patch_items(monkeypatch, player):
     monkeypatch.setattr(item_transfer, "_save_player", lambda p: None)
     monkeypatch.setattr(itemsreg, "set_position", lambda iid, yr, x, y: None)
     monkeypatch.setattr(itemsreg, "clear_position", lambda iid: None)
+    monkeypatch.setattr(itemsreg, "clear_position_at", lambda iid, yr, x, y: True)
     monkeypatch.setattr(itemsreg, "list_instances_at", lambda yr, x, y: [])
     monkeypatch.setattr(itemsreg, "save_instances", lambda: None)
     monkeypatch.setattr(itemsreg, "get_instance", lambda iid: None)


### PR DESCRIPTION
## Summary
- add a utility helper to mint globally unique instance IDs and use it when spawning daily litter
- detect duplicate instance IDs on load and add a coordinate-aware `clear_position_at` helper alongside defensive logging
- have item pickup clear ground items via the new helper and adjust related tests

## Testing
- PYTHONPATH=.:src pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc6188f448832ba50e975de2e81884