### PR TITLE
Add travel command for century-based fast travel

### DIFF
--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from mutants.registries.world import load_nearest_year
+from mutants.services import player_state as pstate
+from ..services import item_transfer as itx
+
+
+def _floor_to_century(year: int) -> int:
+    """Return the start of the century for ``year`` (e.g., 2314 -> 2300)."""
+
+    return (int(year) // 100) * 100
+
+
+def _parse_year(arg: str) -> Optional[int]:
+    """Extract the first integer value from ``arg`` if possible."""
+
+    if arg is None:
+        return None
+    s = arg.strip()
+    if not s:
+        return None
+    sign = 1
+    if s[0] in {"+", "-"}:
+        if s[0] == "-":
+            sign = -1
+        s = s[1:]
+    digits: list[str] = []
+    for ch in s:
+        if ch.isdigit():
+            digits.append(ch)
+        elif digits:
+            break
+    if not digits:
+        return None
+    return sign * int("".join(digits))
+
+
+def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
+    bus = ctx["feedback_bus"]
+
+    year_raw = _parse_year(arg or "")
+    if year_raw is None:
+        bus.push("SYSTEM/WARN", "Usage: TRAVEL <year>  (e.g., 'tra 2100').")
+        return
+
+    target = _floor_to_century(year_raw)
+    loader = ctx.get("world_loader", load_nearest_year)
+    try:
+        world = loader(target)
+    except FileNotFoundError:
+        bus.push("SYSTEM/ERROR", "No worlds found in state/world/.")
+        return
+
+    resolved_year = int(getattr(world, "year", target))
+
+    player = itx._load_player()
+    itx._ensure_inventory(player)
+    player["pos"] = [resolved_year, 0, 0]
+    itx._save_player(player)
+
+    ctx["player_state"] = pstate.load_state()
+    ctx["render_next"] = True
+    ctx["peek_vm"] = None
+    bus.push("SYSTEM/OK", f"Travel complete. Year: {resolved_year}.")
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("travel", lambda arg: travel_cmd(arg, ctx))

--- a/tests/commands/test_travel_command.py
+++ b/tests/commands/test_travel_command.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from mutants.commands.travel import _floor_to_century, _parse_year, travel_cmd
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def push(self, kind: str, text: str, **_: object) -> None:
+        self.events.append((kind, text))
+
+
+class DummyWorld:
+    def __init__(self, year: int) -> None:
+        self.year = year
+
+
+def test_floor_to_century() -> None:
+    assert _floor_to_century(2314) == 2300
+    assert _floor_to_century(2100) == 2100
+    assert _floor_to_century(-50) == -100
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("2100", 2100),
+        ("+2100", 2100),
+        ("  2455ad", 2455),
+        ("", None),
+        ("abc", None),
+    ],
+)
+def test_parse_year(raw: str, expected: int | None) -> None:
+    assert _parse_year(raw) == expected
+
+
+def test_travel_requires_year() -> None:
+    ctx = {"feedback_bus": DummyBus(), "render_next": False, "peek_vm": object()}
+    travel_cmd("", ctx)
+    assert ctx["feedback_bus"].events[-1] == (
+        "SYSTEM/WARN", "Usage: TRAVEL <year>  (e.g., 'tra 2100')."
+    )
+    assert ctx["render_next"] is False
+    assert ctx["peek_vm"] is not None
+
+
+def test_travel_no_worlds(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = {
+        "feedback_bus": DummyBus(),
+        "world_loader": lambda year: (_ for _ in ()).throw(FileNotFoundError()),
+        "render_next": False,
+        "peek_vm": object(),
+    }
+
+    # Ensure player load/save helpers are not called.
+    monkeypatch.setattr(
+        "mutants.commands.travel.itx._load_player",
+        lambda: pytest.fail("should not load player"),
+    )
+
+    travel_cmd("2300", ctx)
+    assert ctx["feedback_bus"].events[-1] == (
+        "SYSTEM/ERROR",
+        "No worlds found in state/world/.",
+    )
+    assert ctx["render_next"] is False
+
+
+def test_travel_updates_player_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    bus = DummyBus()
+    ctx: dict[str, object] = {
+        "feedback_bus": bus,
+        "world_loader": lambda year: DummyWorld(2400),
+        "render_next": False,
+        "peek_vm": "not-none",
+    }
+
+    player = {"id": "player_thief", "pos": [2000, 3, 4], "inventory": []}
+    saved: dict[str, object] = {}
+
+    monkeypatch.setattr("mutants.commands.travel.itx._load_player", lambda: player)
+    monkeypatch.setattr("mutants.commands.travel.itx._ensure_inventory", lambda p: None)
+    monkeypatch.setattr(
+        "mutants.commands.travel.itx._save_player",
+        lambda payload: saved.update({"player": payload.copy()}),
+    )
+    new_state = {"players": [player], "active_id": "player_thief"}
+    monkeypatch.setattr("mutants.commands.travel.pstate.load_state", lambda: new_state)
+
+    travel_cmd("2356", ctx)
+
+    assert saved["player"]["pos"] == [2400, 0, 0]
+    assert ctx["player_state"] is new_state
+    assert ctx["render_next"] is True
+    assert ctx["peek_vm"] is None
+    assert bus.events[-1] == ("SYSTEM/OK", "Travel complete. Year: 2400.")


### PR DESCRIPTION
## Summary
- add a travel command that resolves the nearest available world year from a requested century
- persist the player move to the new year, refresh in-memory state, and request a render
- cover the new command and helper functions with targeted tests

## Testing
- PYTHONPATH=src pytest tests/commands/test_travel_command.py

------
https://chatgpt.com/codex/tasks/task_e_68cc7d8af914832b8238b27a03b079f9