### PR TITLE
Add convert command for inventory items

### DIFF
--- a/src/mutants/commands/convert.py
+++ b/src/mutants/commands/convert.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..services import item_transfer as itx
+from ..registries import items_catalog as catreg
+from ..registries import items_instances as itemsreg
+from ..util.textnorm import normalize_item_query
+
+
+def _get_ions(player: Dict[str, object]) -> int:
+    if "Ions" in player:
+        try:
+            return int(player["Ions"])
+        except Exception:
+            return 0
+    if "ions" in player:
+        try:
+            return int(player["ions"])
+        except Exception:
+            return 0
+    stats = player.get("stats")
+    if isinstance(stats, dict):
+        if "Ions" in stats:
+            try:
+                return int(stats["Ions"])
+            except Exception:
+                return 0
+        if "ions" in stats:
+            try:
+                return int(stats["ions"])
+            except Exception:
+                return 0
+    return 0
+
+
+def _set_ions(player: Dict[str, object], value: int) -> None:
+    clamped = int(max(0, value))
+    if "Ions" in player:
+        player["Ions"] = clamped
+        return
+    if "ions" in player:
+        player["ions"] = clamped
+        return
+    stats = player.get("stats")
+    if isinstance(stats, dict):
+        if "Ions" in stats:
+            stats["Ions"] = clamped
+            return
+        if "ions" in stats:
+            stats["ions"] = clamped
+            return
+    player["Ions"] = clamped
+
+
+def _resolve_meta(catalog: Any, item_id: str) -> Dict[str, object]:
+    getter = getattr(catalog, "get", None)
+    if callable(getter):
+        try:
+            meta = getter(str(item_id))
+        except Exception:
+            meta = None
+        if isinstance(meta, dict):
+            return meta
+    if isinstance(catalog, dict):
+        meta = catalog.get(str(item_id))
+        if isinstance(meta, dict):
+            return meta
+    return {}
+
+
+def _display_name(item_id: str, catalog: Any) -> str:
+    meta = _resolve_meta(catalog, item_id)
+    return str(meta.get("display") or meta.get("name") or item_id)
+
+
+def _convert_value(item_id: str, catalog: Any) -> int:
+    meta = _resolve_meta(catalog, item_id)
+    if not meta:
+        return 0
+    for key in ("convert_ions", "ion_value", "value"):
+        if key in meta:
+            try:
+                return int(meta[key])
+            except Exception:
+                return 0
+    return 0
+
+
+def _choose_inventory_item(
+    player: Dict[str, object],
+    prefix: str,
+    catalog: Any,
+) -> Tuple[Optional[str], Optional[str]]:
+    inventory: List[str] = list(player.get("inventory") or [])
+    if not inventory:
+        return None, None
+
+    query = normalize_item_query(prefix).lower()
+    if not query:
+        return None, None
+
+    candidates: List[Tuple[str, str]] = []
+    for iid in inventory:
+        inst = itemsreg.get_instance(iid)
+        if not inst:
+            continue
+        item_id = (
+            inst.get("item_id")
+            or inst.get("catalog_id")
+            or inst.get("id")
+            or iid
+        )
+        candidates.append((str(iid), str(item_id)))
+
+    matches: List[Tuple[str, str]] = []
+    for iid, item_id in candidates:
+        name = _display_name(item_id, catalog).lower()
+        if item_id.lower().startswith(query) or name.startswith(query):
+            matches.append((iid, item_id))
+
+    if not matches:
+        return None, None
+
+    exact = [m for m in matches if m[1].lower() == query or _display_name(m[1], catalog).lower() == query]
+    return exact[0] if exact else matches[0]
+
+
+def convert_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
+    bus = ctx["feedback_bus"]
+    prefix = (arg or "").strip()
+    if not prefix:
+        bus.push("SYSTEM/WARN", "You're not carrying a .")
+        return {"ok": False, "reason": "missing_argument"}
+
+    catalog = catreg.load_catalog() or {}
+    player = itx._load_player()
+    itx._ensure_inventory(player)
+
+    iid, item_id = _choose_inventory_item(player, prefix, catalog)
+    if not iid or not item_id:
+        bus.push("SYSTEM/WARN", f"You're not carrying a {prefix}.")
+        return {"ok": False, "reason": "not_found"}
+
+    value = _convert_value(item_id, catalog)
+
+    inventory = list(player.get("inventory") or [])
+    try:
+        inventory.remove(iid)
+    except ValueError:
+        pass
+    player["inventory"] = inventory
+
+    itemsreg.delete_instance(iid)
+    _set_ions(player, _get_ions(player) + value)
+    itx._save_player(player)
+
+    name = _display_name(item_id, catalog)
+    bus.push("SYSTEM/OK", f"The {name} vanishes with a flash!")
+    bus.push("SYSTEM/OK", f"You convert the {name} into {value} ions.")
+
+    return {"ok": True, "iid": iid, "item_id": item_id, "ions": value}
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("convert", lambda arg: convert_cmd(arg, ctx))

--- a/src/mutants/registries/items_instances.py
+++ b/src/mutants/registries/items_instances.py
@@ -372,12 +372,27 @@ def list_instances_at(year: int, x: int, y: int) -> List[Dict[str, Any]]:
     return out
 
 def get_instance(iid: str) -> Optional[Dict[str, Any]]:
+    """Return the cached instance matching ``iid`` if present."""
+
     raw = _cache()
+    siid = str(iid)
     for inst in raw:
-        inst_id = inst.get("iid") or inst.get("instance_id")
-        if inst_id and str(inst_id) == str(iid):
+        inst_id = str(inst.get("iid") or inst.get("instance_id") or "")
+        if inst_id == siid:
             return inst
     return None
+
+
+def delete_instance(iid: str) -> int:
+    """Remove the instance identified by ``iid`` from the cache and persist."""
+
+    raw = _cache()
+    siid = str(iid)
+    before = len(raw)
+    raw[:] = [inst for inst in raw if str(inst.get("iid") or inst.get("instance_id") or "") != siid]
+    removed = before - len(raw)
+    _save_instances_raw(raw)
+    return removed
 
 def clear_position(iid: str) -> None:
     """Back-compat: clear by iid (may hit wrong object if duplicate iids exist)."""

--- a/tests/commands/test_convert_command.py
+++ b/tests/commands/test_convert_command.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from mutants.commands.convert import convert_cmd
+from mutants.registries import items_instances as itemsreg
+from mutants.services import item_transfer as itx
+
+
+class FakeBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def push(self, kind: str, text: str, **_ignored) -> None:
+        self.events.append((kind, text))
+
+
+def _copy_state(src: Path, dst: Path) -> None:
+    shutil.copytree(src, dst)
+
+
+def _setup_state(monkeypatch, tmp_path) -> tuple[dict, Path]:
+    src_state = Path(__file__).resolve().parents[2] / "state"
+    dst_state = tmp_path / "state"
+    _copy_state(src_state, dst_state)
+    monkeypatch.chdir(tmp_path)
+    itemsreg.invalidate_cache()
+    itx._STATE_CACHE = None
+    return {"feedback_bus": FakeBus()}, dst_state / "playerlivestate.json"
+
+
+def _prime_inventory(pfile: Path, iid: str, *, ions: int = 0) -> None:
+    with pfile.open("r", encoding="utf-8") as f:
+        pdata = json.load(f)
+    pdata["players"][0]["inventory"] = [iid]
+    pdata["players"][0]["ions"] = ions
+    with pfile.open("w", encoding="utf-8") as f:
+        json.dump(pdata, f, indent=2)
+
+
+def test_convert_requires_argument() -> None:
+    ctx = {"feedback_bus": FakeBus()}
+    result = convert_cmd("", ctx)
+    assert result == {"ok": False, "reason": "missing_argument"}
+    assert ctx["feedback_bus"].events == [("SYSTEM/WARN", "You're not carrying a .")]
+
+
+def test_convert_not_found(monkeypatch, tmp_path) -> None:
+    ctx, pfile = _setup_state(monkeypatch, tmp_path)
+    iid = itemsreg.create_and_save_instance("nuclear_decay", 2000, 0, 0)
+    itemsreg.clear_position(iid)
+    _prime_inventory(pfile, iid, ions=10)
+
+    result = convert_cmd("zzz", ctx)
+
+    assert result == {"ok": False, "reason": "not_found"}
+    assert ctx["feedback_bus"].events == [("SYSTEM/WARN", "You're not carrying a zzz.")]
+    with pfile.open("r", encoding="utf-8") as f:
+        pdata = json.load(f)
+    assert pdata["players"][0]["inventory"] == [iid]
+
+
+def test_convert_success(monkeypatch, tmp_path) -> None:
+    ctx, pfile = _setup_state(monkeypatch, tmp_path)
+    iid = itemsreg.create_and_save_instance("nuclear_decay", 2000, 0, 0)
+    itemsreg.clear_position(iid)
+    _prime_inventory(pfile, iid, ions=5)
+
+    result = convert_cmd("nuc", ctx)
+
+    assert result == {"ok": True, "iid": iid, "item_id": "nuclear_decay", "ions": 85000}
+    assert ctx["feedback_bus"].events == [
+        ("SYSTEM/OK", "The Nuclear-Decay vanishes with a flash!"),
+        ("SYSTEM/OK", "You convert the Nuclear-Decay into 85000 ions."),
+    ]
+
+    with pfile.open("r", encoding="utf-8") as f:
+        pdata = json.load(f)
+    assert pdata["players"][0]["inventory"] == []
+    assert pdata["players"][0]["ions"] == 85005
+    assert itemsreg.get_instance(iid) is None


### PR DESCRIPTION
## Summary
- add a convert command that locates inventory items by prefix and converts them into ions
- extend the item instance registry with helpers to fetch and delete cached instances safely
- cover the new command with tests for argument validation, missing items, and successful conversion

## Testing
- PYTHONPATH=src pytest tests/commands/test_convert_command.py

------
https://chatgpt.com/codex/tasks/task_e_68cc8fe9a1cc832ba0116e5abe216f44