### PR TITLE
Allow skipping fsync when FAST_SAVE=1

### DIFF
--- a/src/mutants/io/atomic.py
+++ b/src/mutants/io/atomic.py
@@ -7,15 +7,21 @@ def atomic_write_json(path: str | Path, data: Any) -> None:
     """
     Write JSON atomically: tmp → fsync → replace.
     Creates parent directories as needed.
+
+    Setting ``FAST_SAVE=1`` in the environment skips the ``fsync`` call. This
+    preserves the existing durable behaviour by default while still allowing
+    callers (mainly fixtures/tests) to opt into a best-effort fast mode.
     """
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(prefix=p.name, dir=str(p.parent))
+    fast_save = os.environ.get("FAST_SAVE", "0") == "1"
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
             f.flush()
-            os.fsync(f.fileno())
+            if not fast_save:
+                os.fsync(f.fileno())
         os.replace(tmp_name, p)
     finally:
         try:


### PR DESCRIPTION
## Summary
- allow opting out of the fsync step inside `atomic_write_json` when `FAST_SAVE=1`
- document the behaviour so callers know the default is still durable writes

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc949e895c832b8fe9e0c0c85b09dd