### PR TITLE
Bind inventories to active player profiles

### DIFF
--- a/src/mutants/commands/_helpers.py
+++ b/src/mutants/commands/_helpers.py
@@ -4,10 +4,14 @@ from typing import Optional
 from ..registries import items_catalog, items_instances as itemsreg
 from ..util.textnorm import normalize_item_query as normalize
 from ..services import item_transfer as itx
+from ..services import player_state as pstate
 
 
 def inventory_iids_for_active_player(ctx) -> list[str]:
     p = itx._load_player()
+    pstate.ensure_active_profile(p, ctx)
+    pstate.bind_inventory_to_active_class(p)
+    itx._ensure_inventory(p)
     inv = p.get("inventory") or []
     return [str(i) for i in inv]
 

--- a/src/mutants/commands/convert.py
+++ b/src/mutants/commands/convert.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..services import item_transfer as itx
+from ..services import player_state as pstate
 from ..registries import items_catalog as catreg
 from ..registries import items_instances as itemsreg
 from ..util.textnorm import normalize_item_query
@@ -135,6 +136,8 @@ def convert_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
 
     catalog = catreg.load_catalog() or {}
     player = itx._load_player()
+    pstate.ensure_active_profile(player, ctx)
+    pstate.bind_inventory_to_active_class(player)
     itx._ensure_inventory(player)
 
     iid, item_id = _choose_inventory_item(player, prefix, catalog)

--- a/src/mutants/commands/debug.py
+++ b/src/mutants/commands/debug.py
@@ -53,6 +53,8 @@ def _add_to_inventory(ctx, item_id: str, count: int) -> None:
     """Create *count* instances of item_id and add them to the active player's inventory."""
     year, x, y = _pos_from_ctx(ctx)
     p = it._load_player()
+    pstate.ensure_active_profile(p, ctx)
+    pstate.bind_inventory_to_active_class(p)
     it._ensure_inventory(p)
     inv = p["inventory"]
     for _ in range(count):

--- a/src/mutants/commands/lock.py
+++ b/src/mutants/commands/lock.py
@@ -6,6 +6,7 @@ from mutants.registries.world import BASE_GATE
 from mutants.registries import dynamics as dyn
 from mutants.registries import items_instances as itemsreg, items_catalog
 from ..services import item_transfer as it  # source of truth for player inventory
+from mutants.services import player_state as pstate
 from mutants.util.directions import OPP, DELTA
 
 from .argcmd import PosArg, PosArgSpec, run_argcmd_positional
@@ -23,6 +24,9 @@ def _has_any_key(ctx: Dict[str, Any]) -> tuple[bool, Optional[str]]:
     """Return (has_key, key_type) by scanning the live player state."""
     cat = items_catalog.load_catalog()
     p = it._load_player()  # live inventory (same source as GET/DROP/THROW)
+    pstate.ensure_active_profile(p, ctx)
+    pstate.bind_inventory_to_active_class(p)
+    it._ensure_inventory(p)
     inv = p.get("inventory") or []
     for iid in inv:
         inst = itemsreg.get_instance(iid) or {}

--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -168,6 +168,8 @@ def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
         return
 
     player = itx._load_player()
+    pstate.ensure_active_profile(player, ctx)
+    pstate.bind_inventory_to_active_class(player)
     itx._ensure_inventory(player)
     pos = player.get("pos") or [2000, 0, 0]
     try:

--- a/src/mutants/services/player_state.py
+++ b/src/mutants/services/player_state.py
@@ -127,3 +127,161 @@ def mutate_active(
     mutator(state, active)
     save_state(state)
     return state
+
+
+def _coerce_pos(value: Any) -> Optional[Tuple[int, int, int]]:
+    """Return a normalized ``(year, x, y)`` tuple when possible."""
+
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        try:
+            return (int(value[0]), int(value[1]), int(value[2]))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _infer_class_from_ctx(ctx: Any) -> Optional[str]:
+    """Best-effort extraction of a class name from an execution context."""
+
+    if ctx is None:
+        return None
+
+    def _pull(obj: Any, key: str) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(key)
+        return getattr(obj, key, None)
+
+    for key in ("player", "active"):
+        payload = _pull(ctx, key)
+        if isinstance(payload, dict):
+            klass = payload.get("class") or payload.get("name")
+            if isinstance(klass, str) and klass:
+                return klass
+
+    candidate = _pull(ctx, "class_name")
+    if isinstance(candidate, str) and candidate:
+        return candidate
+
+    return None
+
+
+def _infer_pos_from_ctx(ctx: Any) -> Optional[Tuple[int, int, int]]:
+    """Try to recover a position triple from assorted context hints."""
+
+    if ctx is None:
+        return None
+
+    def _pull(obj: Any, key: str) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(key)
+        return getattr(obj, key, None)
+
+    for key in ("pos", "position"):
+        pos = _coerce_pos(_pull(ctx, key))
+        if pos:
+            return pos
+
+    player_state = _pull(ctx, "player_state")
+    if isinstance(player_state, dict):
+        active_id = player_state.get("active_id")
+        players = player_state.get("players")
+        if isinstance(players, list) and players:
+            chosen: Optional[Dict[str, Any]] = None
+            for candidate in players:
+                if not isinstance(candidate, dict):
+                    continue
+                if active_id is None or candidate.get("id") == active_id:
+                    chosen = candidate
+                    break
+            if chosen is None:
+                first = players[0]
+                chosen = first if isinstance(first, dict) else None
+            if isinstance(chosen, dict):
+                for key in ("pos", "position"):
+                    pos = _coerce_pos(chosen.get(key))
+                    if pos:
+                        return pos
+        for key in ("pos", "position"):
+            pos = _coerce_pos(player_state.get(key))
+            if pos:
+                return pos
+
+    world = _pull(ctx, "world")
+    if isinstance(world, dict):
+        for key in ("pos", "position"):
+            pos = _coerce_pos(world.get(key))
+            if pos:
+                return pos
+
+    return None
+
+
+def ensure_active_profile(player: Dict[str, Any], ctx: Any) -> None:
+    """Ensure ``player['active']`` has a class and position derived from context."""
+
+    active = player.get("active")
+    if not isinstance(active, dict):
+        active = {}
+        player["active"] = active
+
+    klass = active.get("class") or player.get("class") or player.get("name")
+    if not isinstance(klass, str) or not klass:
+        klass = _infer_class_from_ctx(ctx) or "Thief"
+    active["class"] = klass
+    if "class" not in player or not player.get("class"):
+        player["class"] = klass
+
+    pos = _coerce_pos(active.get("pos"))
+    if pos is None:
+        pos = _infer_pos_from_ctx(ctx)
+    if pos is None:
+        pos = _coerce_pos(player.get("pos")) or _coerce_pos(player.get("position"))
+    if pos is None:
+        year = player.get("year")
+        try:
+            year_val = int(year)
+        except Exception:
+            year_val = 2000
+        pos = (year_val, 0, 0)
+    active["pos"] = [int(pos[0]), int(pos[1]), int(pos[2])]
+    if "pos" not in player or _coerce_pos(player.get("pos")) is None:
+        player["pos"] = list(active["pos"])
+
+
+def bind_inventory_to_active_class(player: Dict[str, Any]) -> None:
+    """Bind ``player['inventory']`` to a per-class bag under ``player['bags']``."""
+
+    active = player.get("active")
+    if not isinstance(active, dict):
+        active = {}
+        player["active"] = active
+
+    klass_raw = active.get("class") or player.get("class") or player.get("name")
+    if isinstance(klass_raw, str) and klass_raw:
+        klass = klass_raw
+    else:
+        klass = "Thief"
+    active["class"] = klass
+    if "class" not in player or not player.get("class"):
+        player["class"] = klass
+
+    bags = player.get("bags")
+    if not isinstance(bags, dict):
+        bags = {}
+        player["bags"] = bags
+
+    inventory = player.get("inventory")
+    inv_list = list(inventory) if isinstance(inventory, list) else []
+
+    bag = bags.get(klass)
+    if isinstance(bag, list):
+        if inv_list and bag is not inv_list:
+            for item in inv_list:
+                if item and item not in bag:
+                    bag.append(item)
+    else:
+        bag = [item for item in inv_list if item]
+
+    bags[klass] = bag
+    player["inventory"] = bag
+    active["inventory"] = bag


### PR DESCRIPTION
## Summary
- add helpers in `player_state` to infer active class/position and bind inventories to per-class bags
- ensure item transfer utilities and commands load the active profile and bind the appropriate inventory before use
- keep inventory sanitisation syncing the active bag for key/throw/convert/travel flows

## Testing
- `PYTHONPATH=.:src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc9d97f2e0832ba4d20311fa14e758