### PR TITLE
Ensure active class persists across commands

### DIFF
--- a/src/mutants/engine/session.py
+++ b/src/mutants/engine/session.py
@@ -1,0 +1,17 @@
+"""In-process session utilities for REPL state sharing."""
+from __future__ import annotations
+
+_ACTIVE_CLASS: str | None = None
+
+
+def set_active_class(name: str | None) -> None:
+    """Remember the currently selected class name for this process."""
+
+    global _ACTIVE_CLASS
+    _ACTIVE_CLASS = name
+
+
+def get_active_class() -> str | None:
+    """Return the class chosen during this process, if any."""
+
+    return _ACTIVE_CLASS

--- a/src/mutants/repl/loop.py
+++ b/src/mutants/repl/loop.py
@@ -11,6 +11,7 @@ def main() -> None:
     ctx = build_context()
     dispatch = Dispatch()
     dispatch.set_feedback_bus(ctx["feedback_bus"])
+    dispatch.set_context(ctx)
 
     # Auto-register all commands in mutants.commands
     register_all(dispatch, ctx)


### PR DESCRIPTION
## Summary
- add a lightweight session module to track the in-process active class
- persist the selected class in player state and context when exiting the class menu
- inject the active class into command contexts and player-state helpers during dispatch

## Testing
- PYTHONPATH=src:. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccad9ab1d4832b9770527294ce1110