### PR TITLE
Select first matching ground item for GET

### DIFF
--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -220,20 +220,9 @@ def _choose_instance_from_prefix(
             info["candidates"] = tips
         return None, info
 
-    if len(filtered) > 1:
-        exact = [t for t in filtered if t[0].lower() == qq or normalize_item_query(t[1]) == q]
-        if len(exact) == 1:
-            return exact[0][2], None
-        # If all candidates resolve to the same canonical name, treat as non-ambiguous.
-        names_norm = {normalize_item_query(t[1]) for t in filtered}
-        if len(names_norm) == 1:
-            return filtered[0][2], None
-        names = [name for _, name, _ in filtered]
-        return None, {
-            "reason": "ambiguous",
-            "message": f"Ambiguous: {', '.join(names[:5])}.",
-            "candidates": names,
-        }
+    for item_id, name, inst in filtered:
+        if item_id.lower() == qq or normalize_item_query(name) == q:
+            return inst, None
 
     return filtered[0][2], None
 

--- a/tests/commands/test_get_command.py
+++ b/tests/commands/test_get_command.py
@@ -67,17 +67,17 @@ import pytest
 
 
 @pytest.mark.parametrize("token", ["i", "ion"])
-def test_get_prefix_requires_disambiguation(monkeypatch, tmp_path, token):
+def test_get_prefix_picks_first_match(monkeypatch, tmp_path, token):
     ctx, pfile, iids = _setup(monkeypatch, tmp_path, ["ion_pack", "ion_booster"])
     get_cmd(token, ctx)
     assert ctx["feedback_bus"].events == [
-        ("SYSTEM/WARN", "Ambiguous: Ion-Pack, Ion-Booster."),
+        ("LOOT/PICKUP", "You pick up the Ion-Pack."),
     ]
     with pfile.open("r", encoding="utf-8") as f:
         pdata = json.load(f)
-    assert not pdata.get("inventory")
+    assert iids[0] in pdata.get("inventory", [])
     ground_ids = itemsreg.list_ids_at(2000, 0, 0)
-    assert "ion_pack" in ground_ids
+    assert "ion_pack" not in ground_ids
     assert "ion_booster" in ground_ids
 
 


### PR DESCRIPTION
## Summary
- choose the first matching ground instance when resolving GET prefixes
- update GET command test to expect the first matching item to be picked up

## Testing
- PYTHONPATH=src:. pytest tests/commands/test_get_command.py

------
https://chatgpt.com/codex/tasks/task_e_68cd4c0f12d4832bb4b8b9d8ac6d3242