### PR TITLE
Update convert command to award ions per class

### DIFF
--- a/tests/commands/test_convert_command.py
+++ b/tests/commands/test_convert_command.py
@@ -44,7 +44,7 @@ def test_convert_requires_argument() -> None:
     ctx = {"feedback_bus": FakeBus()}
     result = convert_cmd("", ctx)
     assert result == {"ok": False, "reason": "missing_argument"}
-    assert ctx["feedback_bus"].events == [("SYSTEM/WARN", "You're not carrying a .")]
+    assert ctx["feedback_bus"].events == [("SYSTEM/WARN", "Usage: convert <item>")]
 
 
 def test_convert_not_found(monkeypatch, tmp_path) -> None:
@@ -80,4 +80,7 @@ def test_convert_success(monkeypatch, tmp_path) -> None:
         pdata = json.load(f)
     assert pdata["players"][0]["inventory"] == []
     assert pdata["players"][0]["ions"] == 85005
+    assert pdata["players"][0]["ions_by_class"] == {"Thief": 85005}
+    assert pdata["ions"] == 85005
+    assert pdata["ions_by_class"] == {"Thief": 85005}
     assert itemsreg.get_instance(iid) is None


### PR DESCRIPTION
## Summary
- ensure the convert command tallies currency against the active class and keeps legacy ion fields in sync
- add lightweight player-debug logging around conversions and correct the usage warning copy
- extend tests to cover the per-class ion bookkeeping updates

## Testing
- PYTHONPATH=src pytest tests/commands/test_convert_command.py

------
https://chatgpt.com/codex/tasks/task_e_68cd6db3b8f0832b8e1d15d9e5f0440f