### PR TITLE
Ensure riblets and ions are stored per instance

### DIFF
--- a/src/game/classes.py
+++ b/src/game/classes.py
@@ -14,8 +14,8 @@ class Thief:
 
     name: str
     class_name: str = "Thief"
-    riblets: List[str] = field(default_factory=list)
-    ions: Dict[str, int] = field(default_factory=dict)
+    riblets: int = 0
+    ions: int = 0
     experience: int = 0
     stats: BaseStats = field(default_factory=lambda: {"agi": 8, "str": 4, "int": 4})
     inventory: List[str] = field(default_factory=list)
@@ -33,8 +33,8 @@ class Priest:
 
     name: str
     class_name: str = "Priest"
-    riblets: List[str] = field(default_factory=list)
-    ions: Dict[str, int] = field(default_factory=dict)
+    riblets: int = 0
+    ions: int = 0
     experience: int = 0
     stats: BaseStats = field(default_factory=lambda: {"agi": 3, "str": 3, "int": 9})
     inventory: List[str] = field(default_factory=list)
@@ -52,8 +52,8 @@ class Wizard:
 
     name: str
     class_name: str = "Wizard"
-    riblets: List[str] = field(default_factory=list)
-    ions: Dict[str, int] = field(default_factory=dict)
+    riblets: int = 0
+    ions: int = 0
     experience: int = 0
     stats: BaseStats = field(default_factory=lambda: {"agi": 4, "str": 2, "int": 10})
     inventory: List[str] = field(default_factory=list)
@@ -71,8 +71,8 @@ class Warrior:
 
     name: str
     class_name: str = "Warrior"
-    riblets: List[str] = field(default_factory=list)
-    ions: Dict[str, int] = field(default_factory=dict)
+    riblets: int = 0
+    ions: int = 0
     experience: int = 0
     stats: BaseStats = field(default_factory=lambda: {"agi": 5, "str": 9, "int": 2})
     inventory: List[str] = field(default_factory=list)
@@ -90,8 +90,8 @@ class Mage:
 
     name: str
     class_name: str = "Mage"
-    riblets: List[str] = field(default_factory=list)
-    ions: Dict[str, int] = field(default_factory=dict)
+    riblets: int = 0
+    ions: int = 0
     experience: int = 0
     stats: BaseStats = field(default_factory=lambda: {"agi": 5, "str": 3, "int": 9})
     inventory: List[str] = field(default_factory=list)

--- a/src/game/interfaces.py
+++ b/src/game/interfaces.py
@@ -8,8 +8,8 @@ class Character(Protocol):
 
     name: str
     class_name: str
-    riblets: List[str]
-    ions: Dict[str, int]
+    riblets: int
+    ions: int
     experience: int
     stats: Dict[str, int]
     inventory: List[str]

--- a/tests/test_independence.py
+++ b/tests/test_independence.py
@@ -11,27 +11,24 @@ def test_independence() -> None:
     e = Mage("Sera")
 
     a.add_item("lockpick")
-    a.riblets.append("shadow shard")
-    a.ions["volt"] = 1
+    a.riblets = 111
+    a.ions = 7
     a.add_xp(10)
 
     b.add_item("rosary")
-    b.riblets.append("holy mote")
-    b.ions["bless"] = 3
+    b.riblets = 222
+    b.ions = 9
     b.add_xp(20)
 
     assert a.inventory == ["lockpick"]
     assert b.inventory == ["rosary"]
 
-    assert "shadow shard" in a.riblets
-    assert "shadow shard" not in b.riblets
+    assert a.riblets == 111
+    assert b.riblets == 222
 
-    assert "holy mote" in b.riblets
-    assert "holy mote" not in a.riblets
+    assert a.ions == 7
+    assert b.ions == 9
 
-    assert a.ions == {"volt": 1}
-    assert b.ions == {"bless": 3}
-
-    assert c.ions == {}
-    assert d.riblets == []
+    assert c.ions == 0
+    assert d.riblets == 0
     assert e.inventory == []

--- a/tests/test_riblets_ions_instance_only.py
+++ b/tests/test_riblets_ions_instance_only.py
@@ -1,0 +1,17 @@
+"""Riblets/ions assignments should affect only the instance."""
+
+from src.game.classes import Warrior, Wizard
+
+
+def test_riblets_ions_are_instance_fields() -> None:
+    wiz = Wizard("Merla")
+    war = Warrior("Thok")
+
+    wiz.riblets = 1212
+    wiz.ions = 7
+
+    assert wiz.riblets == 1212
+    assert wiz.ions == 7
+
+    assert war.riblets == 0
+    assert war.ions == 0


### PR DESCRIPTION
## Summary
- change each character class to give riblets and ions integer instance fields instead of shared containers
- update the character protocol plus existing independence test to use the new per-instance currency values
- add a regression test that ensures editing a wizard's currencies leaves the warrior's values untouched

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd7aaafdf8832ba9fa78d7215806fd