### PR TITLE
Add per-class player state management helpers

### DIFF
--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Mapping
+from typing import Dict
 
 from mutants.services import player_state as pstate
 
@@ -15,17 +15,13 @@ def _int(value: object, default: int = 0) -> int:
 
 
 def statistics_cmd(arg: str, ctx) -> None:
-    # Get both the full state and the active player snapshot so we can read
-    # per-class currency maps (authoritative) in addition to legacy fields.
     state, active = pstate.get_active_pair()
     player: Dict[str, object] = active if isinstance(active, dict) else {}
-    state_map: Mapping[str, object] = state if isinstance(state, Mapping) else {}
     bus = ctx["feedback_bus"]
 
     name = player.get("name", "Unknown")
     cls = player.get("class", "Unknown")
-    stats = player.get("stats")
-    stats_map: Mapping[str, object] = stats if isinstance(stats, Mapping) else {}
+    stats_map = pstate.get_stats_for_active(state)
     STR = _int(stats_map.get("str"))
     INT = _int(stats_map.get("int"))
     WIS = _int(stats_map.get("wis"))
@@ -39,19 +35,14 @@ def statistics_cmd(arg: str, ctx) -> None:
     else:
         year = 2000
 
-    exhaustion = _int(player.get("exhaustion"))
-    hp = player.get("hp")
-    hp_map: Mapping[str, object] = hp if isinstance(hp, Mapping) else {}
-    hp_cur = _int(hp_map.get("current"))
-    hp_max = _int(hp_map.get("max"))
-    exp_pts = _int(player.get("exp_points"))
-    # Prefer authoritative per-class maps; fall back to legacy per-player fields.
-    cls_name = str(player.get("class", "Unknown"))
-    ions_map: Mapping[str, object] = state_map.get("ions_by_class", {}) if isinstance(state_map.get("ions_by_class"), Mapping) else {}
-    riblets_map: Mapping[str, object] = state_map.get("riblets_by_class", {}) if isinstance(state_map.get("riblets_by_class"), Mapping) else {}
-    ions = _int(ions_map.get(cls_name, player.get("ions")))
-    riblets = _int(riblets_map.get(cls_name, player.get("riblets")))
-    level = _int(player.get("level"), default=1)
+    exhaustion = pstate.get_exhaustion_for_active(state)
+    hp = pstate.get_hp_for_active(state)
+    hp_cur = _int(hp.get("current"))
+    hp_max = _int(hp.get("max"))
+    exp_pts = pstate.get_exp_for_active(state)
+    level = pstate.get_level_for_active(state)
+    riblets = pstate.get_riblets_for_active(state)
+    ions = pstate.get_ions_for_active(state)
 
     armour = player.get("armour")
     if isinstance(armour, Mapping):

--- a/tests/services/test_player_state.py
+++ b/tests/services/test_player_state.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import copy
+
+from mutants.services import player_state
+
+
+def _base_state() -> dict[str, object]:
+    return {
+        "active": {"class": "Thief", "pos": [2000, 0, 0]},
+        "active_id": "p1",
+        "bags": {"Thief": [], "Wizard": []},
+        "inventory": [],
+        "players": [
+            {
+                "id": "p1",
+                "name": "Thief",
+                "class": "Thief",
+                "pos": [2000, 0, 0],
+                "stats": {
+                    "str": 2,
+                    "int": 3,
+                    "wis": 4,
+                    "dex": 5,
+                    "con": 6,
+                    "cha": 7,
+                },
+                "hp": {"current": 8, "max": 9},
+                "exhaustion": 1,
+                "exp_points": 20,
+                "level": 2,
+                "ions": 10,
+                "riblets": 3,
+            },
+            {
+                "id": "p2",
+                "name": "Wizard",
+                "class": "Wizard",
+                "pos": [2000, 0, 0],
+                "stats": {
+                    "str": 12,
+                    "int": 13,
+                    "wis": 14,
+                    "dex": 15,
+                    "con": 16,
+                    "cha": 17,
+                },
+                "hp": {"current": 18, "max": 20},
+                "exhaustion": 2,
+                "exp_points": 40,
+                "level": 4,
+                "ions": 50,
+                "riblets": 5,
+            },
+        ],
+        "ions_by_class": {"Thief": 10, "Wizard": 50},
+        "riblets_by_class": {"Thief": 3, "Wizard": 5},
+        "exhaustion_by_class": {"Thief": 1, "Wizard": 2},
+        "exp_by_class": {"Thief": 20, "Wizard": 40},
+        "level_by_class": {"Thief": 2, "Wizard": 4},
+        "hp_by_class": {
+            "Thief": {"current": 8, "max": 9},
+            "Wizard": {"current": 18, "max": 20},
+        },
+        "stats_by_class": {
+            "Thief": {
+                "str": 2,
+                "int": 3,
+                "wis": 4,
+                "dex": 5,
+                "con": 6,
+                "cha": 7,
+            },
+            "Wizard": {
+                "str": 12,
+                "int": 13,
+                "wis": 14,
+                "dex": 15,
+                "con": 16,
+                "cha": 17,
+            },
+        },
+    }
+
+
+def test_migrate_per_class_fields_populates_maps():
+    state = {
+        "active": {"class": "Thief", "pos": [2000, 0, 0]},
+        "players": [
+            {
+                "id": "p1",
+                "name": "Thief",
+                "class": "Thief",
+                "pos": [2000, 0, 0],
+                "stats": {
+                    "str": 2,
+                    "int": 3,
+                    "wis": 4,
+                    "dex": 5,
+                    "con": 6,
+                    "cha": 7,
+                },
+                "hp": {"current": 8, "max": 9},
+                "exhaustion": 1,
+                "exp_points": 20,
+                "level": 2,
+                "ions": 10,
+                "riblets": 3,
+            },
+            {
+                "id": "p2",
+                "name": "Wizard",
+                "class": "Wizard",
+                "pos": [2000, 0, 0],
+                "stats": {
+                    "str": 12,
+                    "int": 13,
+                    "wis": 14,
+                    "dex": 15,
+                    "con": 16,
+                    "cha": 17,
+                },
+                "hp": {"current": 18, "max": 20},
+                "exhaustion": 2,
+                "exp_points": 40,
+                "level": 4,
+                "ions": 50,
+                "riblets": 5,
+            },
+        ],
+        "bags": {},
+        "inventory": [],
+    }
+
+    migrated = player_state.migrate_per_class_fields(state)
+
+    assert migrated["ions_by_class"] == {"Thief": 10, "Wizard": 50}
+    assert migrated["riblets_by_class"] == {"Thief": 3, "Wizard": 5}
+    assert migrated["exhaustion_by_class"] == {"Thief": 1, "Wizard": 2}
+    assert migrated["exp_by_class"] == {"Thief": 20, "Wizard": 40}
+    assert migrated["level_by_class"] == {"Thief": 2, "Wizard": 4}
+    assert migrated["hp_by_class"]["Thief"] == {"current": 8, "max": 9}
+    assert migrated["hp_by_class"]["Wizard"] == {"current": 18, "max": 20}
+    assert migrated["stats_by_class"]["Wizard"]["int"] == 13
+    assert migrated["ions"] == 10
+    assert migrated["riblets"] == 3
+    assert migrated["active"]["hp"] == {"current": 8, "max": 9}
+
+
+def test_active_setters_affect_only_active_class(monkeypatch):
+    base = _base_state()
+    normalized = player_state._normalize_player_state(copy.deepcopy(base))
+
+    saved: dict[str, object] = {}
+
+    def fake_save(st):
+        saved["state"] = copy.deepcopy(st)
+
+    monkeypatch.setattr(player_state, "save_state", fake_save)
+
+    player_state.set_ions_for_active(normalized, 123)
+    normalized = copy.deepcopy(saved["state"])
+    player_state.set_riblets_for_active(normalized, 77)
+    normalized = copy.deepcopy(saved["state"])
+    player_state.set_exhaustion_for_active(normalized, 5)
+    normalized = copy.deepcopy(saved["state"])
+    player_state.set_exp_for_active(normalized, 250)
+    normalized = copy.deepcopy(saved["state"])
+    player_state.set_level_for_active(normalized, 6)
+    normalized = copy.deepcopy(saved["state"])
+    player_state.set_hp_for_active(normalized, 31, 40)
+    normalized = copy.deepcopy(saved["state"])
+    player_state.set_stats_for_active(
+        normalized,
+        {"str": 9, "int": 8, "wis": 7, "dex": 6, "con": 5, "cha": 4},
+    )
+
+    final_state = saved["state"]
+
+    assert final_state["ions_by_class"]["Thief"] == 123
+    assert final_state["ions_by_class"]["Wizard"] == 50
+    assert final_state["riblets_by_class"]["Thief"] == 77
+    assert final_state["riblets_by_class"]["Wizard"] == 5
+    assert final_state["exhaustion_by_class"]["Thief"] == 5
+    assert final_state["exhaustion_by_class"]["Wizard"] == 2
+    assert final_state["exp_by_class"]["Thief"] == 250
+    assert final_state["exp_by_class"]["Wizard"] == 40
+    assert final_state["level_by_class"]["Thief"] == 6
+    assert final_state["level_by_class"]["Wizard"] == 4
+    assert final_state["hp_by_class"]["Thief"] == {"current": 31, "max": 40}
+    assert final_state["hp_by_class"]["Wizard"] == {"current": 18, "max": 20}
+    assert final_state["stats_by_class"]["Thief"] == {
+        "str": 9,
+        "int": 8,
+        "wis": 7,
+        "dex": 6,
+        "con": 5,
+        "cha": 4,
+    }
+    assert final_state["stats_by_class"]["Wizard"]["int"] == 13
+
+    assert final_state["Ions"] == 123
+    assert final_state["active"]["ions"] == 123
+    assert final_state["riblets"] == 77
+    assert final_state["active"]["riblets"] == 77
+    assert final_state["exhaustion"] == 5
+    assert final_state["active"]["exhaustion"] == 5
+    assert final_state["exp_points"] == 250
+    assert final_state["active"]["exp_points"] == 250
+    assert final_state["level"] == 6
+    assert final_state["active"]["level"] == 6
+    assert final_state["hp"] == {"current": 31, "max": 40}
+    assert final_state["active"]["hp"] == {"current": 31, "max": 40}
+    assert final_state["stats"] == {
+        "str": 9,
+        "int": 8,
+        "wis": 7,
+        "dex": 6,
+        "con": 5,
+        "cha": 4,
+    }
+
+    assert player_state.get_ions_for_active(final_state) == 123
+    assert player_state.get_riblets_for_active(final_state) == 77
+    assert player_state.get_exhaustion_for_active(final_state) == 5
+    assert player_state.get_exp_for_active(final_state) == 250
+    assert player_state.get_level_for_active(final_state) == 6
+    assert player_state.get_hp_for_active(final_state) == {"current": 31, "max": 40}
+    assert player_state.get_stats_for_active(final_state)["str"] == 9
+
+
+def test_evaluate_invariants_detects_missing_class_entry():
+    state = player_state._normalize_player_state(copy.deepcopy(_base_state()))
+    del state["ions_by_class"]["Thief"]
+
+    assert player_state._evaluate_invariants(state) is False
+
+
+def test_evaluate_invariants_detects_hp_relation_issue():
+    state = player_state._normalize_player_state(copy.deepcopy(_base_state()))
+    state["hp_by_class"]["Thief"]["current"] = 10
+    state["hp_by_class"]["Thief"]["max"] = 5
+
+    assert player_state._evaluate_invariants(state) is False


### PR DESCRIPTION
## Summary
- normalize player state to maintain per-class maps for currencies, vitals, and stats while updating invariants
- expose uniform getters and setters for per-class exhaustion, experience, level, HP, and ability scores
- update statistics and travel commands plus add regression tests for migration, helpers, and invariants

## Testing
- PYTHONPATH=src pytest tests/services/test_player_state.py

------
https://chatgpt.com/codex/tasks/task_e_68cda07033ac832ba58af3f491a70ec4