### PR TITLE
Add per-class migration and persistence normalization

### DIFF
--- a/state/playerlivestate.json
+++ b/state/playerlivestate.json
@@ -40,7 +40,9 @@
         "encumbered": false,
         "ion_starving": false
       },
-      "notes": ""
+      "notes": "",
+      "Ions": 30000,
+      "Riblets": 0
     },
     {
       "id": "player_priest",
@@ -82,7 +84,9 @@
         "encumbered": false,
         "ion_starving": false
       },
-      "notes": ""
+      "notes": "",
+      "Ions": 30000,
+      "Riblets": 0
     },
     {
       "id": "player_wizard",
@@ -124,7 +128,9 @@
         "encumbered": false,
         "ion_starving": false
       },
-      "notes": ""
+      "notes": "",
+      "Ions": 30000,
+      "Riblets": 0
     },
     {
       "id": "player_warrior",
@@ -166,7 +172,9 @@
         "encumbered": false,
         "ion_starving": false
       },
-      "notes": ""
+      "notes": "",
+      "Ions": 30000,
+      "Riblets": 0
     },
     {
       "id": "player_mage",
@@ -208,8 +216,166 @@
         "encumbered": false,
         "ion_starving": false
       },
-      "notes": ""
+      "notes": "",
+      "Ions": 30000,
+      "Riblets": 0
     }
   ],
-  "active_id": "player_thief"
+  "active_id": "player_thief",
+  "active": {
+    "ions": 30000,
+    "Ions": 30000,
+    "riblets": 0,
+    "Riblets": 0,
+    "exhaustion": 0,
+    "exp_points": 0,
+    "level": 1,
+    "hp": {
+      "current": 18,
+      "max": 18
+    },
+    "stats": {
+      "str": 15,
+      "int": 9,
+      "wis": 8,
+      "dex": 14,
+      "con": 15,
+      "cha": 16
+    },
+    "class": "Thief",
+    "pos": [
+      2000,
+      0,
+      0
+    ],
+    "inventory": []
+  },
+  "ions_by_class": {
+    "Thief": 30000,
+    "Priest": 30000,
+    "Wizard": 30000,
+    "Warrior": 30000,
+    "Mage": 30000
+  },
+  "riblets_by_class": {
+    "Thief": 0,
+    "Priest": 0,
+    "Wizard": 0,
+    "Warrior": 0,
+    "Mage": 0
+  },
+  "exp_by_class": {
+    "Thief": 0,
+    "Priest": 0,
+    "Wizard": 0,
+    "Warrior": 0,
+    "Mage": 0
+  },
+  "level_by_class": {
+    "Thief": 1,
+    "Priest": 1,
+    "Wizard": 1,
+    "Warrior": 1,
+    "Mage": 1
+  },
+  "hp_by_class": {
+    "Thief": {
+      "current": 18,
+      "max": 18
+    },
+    "Priest": {
+      "current": 30,
+      "max": 30
+    },
+    "Wizard": {
+      "current": 23,
+      "max": 23
+    },
+    "Warrior": {
+      "current": 40,
+      "max": 40
+    },
+    "Mage": {
+      "current": 28,
+      "max": 28
+    }
+  },
+  "stats_by_class": {
+    "Thief": {
+      "str": 15,
+      "int": 9,
+      "wis": 8,
+      "dex": 14,
+      "con": 15,
+      "cha": 16
+    },
+    "Priest": {
+      "str": 20,
+      "int": 12,
+      "wis": 13,
+      "dex": 17,
+      "con": 17,
+      "cha": 14
+    },
+    "Wizard": {
+      "str": 14,
+      "int": 17,
+      "wis": 17,
+      "dex": 13,
+      "con": 14,
+      "cha": 15
+    },
+    "Warrior": {
+      "str": 23,
+      "int": 12,
+      "wis": 14,
+      "dex": 20,
+      "con": 19,
+      "cha": 9
+    },
+    "Mage": {
+      "str": 18,
+      "int": 23,
+      "wis": 20,
+      "dex": 16,
+      "con": 15,
+      "cha": 20
+    }
+  },
+  "exhaustion_by_class": {
+    "Thief": 0,
+    "Priest": 0,
+    "Wizard": 0,
+    "Warrior": 0,
+    "Mage": 0
+  },
+  "ions": 30000,
+  "Ions": 30000,
+  "riblets": 0,
+  "Riblets": 0,
+  "exhaustion": 0,
+  "exp_points": 0,
+  "level": 1,
+  "hp": {
+    "current": 18,
+    "max": 18
+  },
+  "stats": {
+    "str": 15,
+    "int": 9,
+    "wis": 8,
+    "dex": 14,
+    "con": 15,
+    "cha": 16
+  },
+  "class": "Thief",
+  "pos": [
+    2000,
+    0,
+    0
+  ],
+  "bags": {
+    "Thief": []
+  },
+  "inventory": []
 }


### PR DESCRIPTION
## Summary
- implement a per-class migration path that captures legacy scalar fields and writes them into the *_by_class maps
- enhance normalization helpers to clamp HP, reuse sanitized ints, and preserve active-class mirrors
- run migration on load/save and update the sample live state file with per-class data for every class

## Testing
- pytest -q -k smoke

------
https://chatgpt.com/codex/tasks/task_e_68cdbb60e458832bac18ecf6af5af48c