### PR TITLE
Add uniform active-class helpers and update consumers

### DIFF
--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -133,15 +133,11 @@ def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
 
     def _update_ions(new_amount: int) -> int:
         nonlocal currency_state
+        result = pstate.set_ions_for_active(currency_state, new_amount)
         try:
-            result = pstate.set_ions_for_active(currency_state, new_amount)
+            currency_state = pstate.load_state()
         except Exception:
-            result = max(0, int(new_amount))
-        else:
-            try:
-                currency_state = pstate.load_state()
-            except Exception:
-                pass
+            pass
         player["ions"] = result
         player["Ions"] = result
         active_profile = player.get("active")

--- a/tests_legacy/services/test_player_state.py
+++ b/tests_legacy/services/test_player_state.py
@@ -168,7 +168,7 @@ def test_active_setters_affect_only_active_class(monkeypatch):
     normalized = copy.deepcopy(saved["state"])
     player_state.set_level_for_active(normalized, 6)
     normalized = copy.deepcopy(saved["state"])
-    player_state.set_hp_for_active(normalized, 31, 40)
+    player_state.set_hp_for_active(normalized, {"current": 31, "max": 40})
     normalized = copy.deepcopy(saved["state"])
     player_state.set_stats_for_active(
         normalized,


### PR DESCRIPTION
## Summary
- add a shared helper to prepare active-class storage in player_state
- update active-class setters to write *_by_class maps and refresh mirrors directly
- simplify travel ion updates and adjust legacy tests for the new HP helper API

## Testing
- pytest tests_legacy/services/test_player_state.py

------
https://chatgpt.com/codex/tasks/task_e_68cdc06b64c8832b814af90335eb4202