### PR TITLE
Add per-class spell containers and finalize setter updates

### DIFF
--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -168,6 +168,15 @@ def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
     steps = abs(dest_century - current_century) // 100
     full_cost = steps * ION_COST_PER_CENTURY
     ions = pstate.get_ions_for_active(currency_state)
+    player_ions = player.get("ions")
+    if player_ions is None:
+        player_ions = player.get("Ions")
+    try:
+        legacy_ions = int(player_ions) if player_ions is not None else None
+    except (TypeError, ValueError):
+        legacy_ions = None
+    if isinstance(legacy_ions, int) and legacy_ions >= 0:
+        ions = min(ions, legacy_ions) if ions else legacy_ions
 
     if ions < ION_COST_PER_CENTURY:
         bus.push("SYSTEM/WARN", "You don't have enough ions to create a portal.")


### PR DESCRIPTION
## Summary
- add spell and effect sanitization helpers along with per-class/world normalization to the player state schema
- extend invariants and introduce a class-switch hook that clears personal spell effects while keeping world effects
- update active-player persistence and commands to use the new state accessors and keep player currency in sync

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cdc63e4864832b9cdd9bba9e4c164c