### PR TITLE
Fix convert truncation and clean player active imports

### DIFF
--- a/src/mutants/commands/convert.py
+++ b/src/mutants/commands/convert.py
@@ -194,20 +194,6 @@ def convert_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
                 iid,
                 item_id,
             )
-        players = state.get("players")
-        if isinstance(players, list):
-            filtered: list[dict[str, object]] = []
-            for entry in players:
-                if not isinstance(entry, dict):
-                    continue
-                if entry.get("id") == state.get("active_id"):
-                    filtered.append(entry)
-                    break
-                entry_class = entry.get("class") or entry.get("name")
-                if isinstance(entry_class, str) and entry_class == klass:
-                    filtered.append(entry)
-            if filtered:
-                state["players"] = filtered
         pstate.set_ions_for_active(state, new_total)
         if pstate._pdbg_enabled():  # pragma: no cover - diagnostic hook
             after_state = pstate.load_state()

--- a/src/mutants/services/player_active.py
+++ b/src/mutants/services/player_active.py
@@ -1,7 +1,4 @@
 from __future__ import annotations
-from typing import Dict, Any, Optional
-
-from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
@@ -54,10 +51,10 @@ def set_active(active_id: str) -> Dict[str, Any]:
         next_class = prev_class
 
     state["active_id"] = active_id
-    updated_state = player_state.on_class_switch(prev_class, next_class, state)
-    updated_state["active_id"] = active_id
-    save_state(updated_state)
-    return updated_state
+    updated = player_state.on_class_switch(prev_class, next_class, state)
+    updated["active_id"] = active_id
+    save_state(updated)
+    return updated
 
 def resolve_candidate(state: Dict[str, Any], q: str) -> Optional[str]:
     """


### PR DESCRIPTION
## Summary
- stop the convert command from shrinking the stored player list before updating ions
- collapse duplicate future/typing imports in `player_active` while keeping the state handoff intact

## Testing
- pytest -k smoke

------
https://chatgpt.com/codex/tasks/task_e_68cdd09e7a30832b9de476339daf8478