### PR TITLE
Fix active class resolution and seed-only migrations

### DIFF
--- a/src/mutants/services/player_active.py
+++ b/src/mutants/services/player_active.py
@@ -53,6 +53,9 @@ def set_active(active_id: str) -> Dict[str, Any]:
     state["active_id"] = active_id
     updated = player_state.on_class_switch(prev_class, next_class, state)
     updated["active_id"] = active_id
+    # keep the active snapshot aligned immediately (readers relying on it stay stable)
+    if isinstance(updated.get("active"), dict) and isinstance(next_class, str) and next_class:
+        updated["active"]["class"] = next_class
     save_state(updated)
     return updated
 


### PR DESCRIPTION
## Summary
- resolve the active class from the active player profile when available and reuse it during migration
- avoid clobbering existing per-class counters during normalization and keep the active snapshot synced on switches

## Testing
- `pytest -q -k smoke`


------
https://chatgpt.com/codex/tasks/task_e_68cdd64c9fe4832bb2eba86bdfcab023