### PR TITLE
Fix travel command state persistence

### DIFF
--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -105,6 +105,39 @@ def _persist_state(ctx: Dict[str, Any], player: Dict[str, Any]) -> None:
         ctx["render_next"] = False
 
 
+def _persist_pos_only(resolved_year: int) -> Optional[Dict[str, Any]]:
+    """Write only the active player's position to canonical state."""
+
+    try:
+        state = pstate.load_state()
+    except Exception:
+        return None
+
+    if not isinstance(state, dict):
+        if isinstance(state, Mapping):
+            state = dict(state)
+        else:
+            return None
+
+    active_id = state.get("active_id")
+    if isinstance(state.get("active"), dict):
+        state["active"]["pos"] = [resolved_year, 0, 0]
+
+    players = state.get("players")
+    if isinstance(players, list) and active_id:
+        for entry in players:
+            if isinstance(entry, dict) and entry.get("id") == active_id:
+                entry["pos"] = [resolved_year, 0, 0]
+                break
+
+    try:
+        pstate.save_state(state)
+    except Exception:
+        return None
+
+    return state
+
+
 def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
     bus = ctx["feedback_bus"]
 
@@ -247,8 +280,11 @@ def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
             return
         new_total = ions - full_cost
         _update_ions(new_total)
-        player["pos"] = [resolved_year, 0, 0]
-        _persist_state(ctx, player)
+        maybe_state = _persist_pos_only(resolved_year)
+        if isinstance(maybe_state, Mapping):
+            ctx["player_state"] = dict(maybe_state)
+            if "render_next" in ctx:
+                ctx["render_next"] = False
         if pstate._pdbg_enabled():  # pragma: no cover
             try:
                 LOG_P.info(
@@ -270,7 +306,11 @@ def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
     if not candidates:
         # Spend everything we can to get as far as possible (as before), then persist.
         _update_ions(0)
-        _persist_state(ctx, player)
+        maybe_state = _persist_pos_only(current_century)
+        if isinstance(maybe_state, Mapping):
+            ctx["player_state"] = dict(maybe_state)
+            if "render_next" in ctx:
+                ctx["render_next"] = False
         if pstate._pdbg_enabled():  # pragma: no cover
             try:
                 LOG_P.info(
@@ -290,8 +330,11 @@ def travel_cmd(arg: str, ctx: Dict[str, Any]) -> None:
     if resolved_year is None:
         return
     _update_ions(0)
-    player["pos"] = [resolved_year, 0, 0]
-    _persist_state(ctx, player)
+    maybe_state = _persist_pos_only(resolved_year)
+    if isinstance(maybe_state, Mapping):
+        ctx["player_state"] = dict(maybe_state)
+        if "render_next" in ctx:
+            ctx["render_next"] = False
     bus.push(
         "SYSTEM/WARN",
         "ZAAAPPPP!!!! You suddenly feel something has gone terribly wrong!",


### PR DESCRIPTION
## Summary
- add a helper to persist only the active player's position via canonical state
- refresh travel command branches to use the new helper instead of writing stale player payloads
- update legacy travel command tests to validate the new persistence behaviour

## Testing
- pytest tests_legacy/commands/test_travel_command.py

------
https://chatgpt.com/codex/tasks/task_e_68ce946f3c68832ba9e646453e1cd087