### PR TITLE
Hide equipped armour from inventory operations

### DIFF
--- a/src/mutants/bootstrap/lazyinit.py
+++ b/src/mutants/bootstrap/lazyinit.py
@@ -124,6 +124,7 @@ def make_player_from_template(t: Dict[str, Any], make_active: bool = False) -> D
             "wearing": t.get("armour_start", None),
             "armour_class": compute_ac_from_dex(dex),  # DEX-only at start
         },
+        "equipment_by_class": {cls: {"armour": None}},
         "readied_spell": t.get("readied_spell_start", None),
         "target_monster_id": None,
 

--- a/src/mutants/commands/_helpers.py
+++ b/src/mutants/commands/_helpers.py
@@ -12,8 +12,11 @@ def inventory_iids_for_active_player(ctx) -> list[str]:
     pstate.ensure_active_profile(p, ctx)
     pstate.bind_inventory_to_active_class(p)
     itx._ensure_inventory(p)
-    inv = p.get("inventory") or []
-    return [str(i) for i in inv]
+    inv = [str(i) for i in (p.get("inventory") or []) if i]
+    equipped = pstate.get_equipped_armour_id(p)
+    if equipped:
+        inv = [iid for iid in inv if iid != equipped]
+    return inv
 
 
 def find_inventory_item_by_prefix(ctx, token: str) -> Optional[str]:

--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -33,8 +33,14 @@ def _resolve_weight(inst, tpl) -> int | None:
 
 
 def inv_cmd(arg: str, ctx):
-    _, player = pstate.get_active_pair()
-    inv = list(player.get("inventory") or [])
+    state, player = pstate.get_active_pair()
+    pstate.bind_inventory_to_active_class(player)
+    inv = [str(i) for i in (player.get("inventory") or []) if i]
+    equipped = pstate.get_equipped_armour_id(state)
+    if not equipped:
+        equipped = pstate.get_equipped_armour_id(player)
+    if equipped:
+        inv = [iid for iid in inv if iid != equipped]
     cat = items_catalog.load_catalog()
     names = []
     total_weight = 0

--- a/src/mutants/services/player_reset.py
+++ b/src/mutants/services/player_reset.py
@@ -55,6 +55,9 @@ def _reset_fields_from_template(player: Dict[str, Any], template: Dict[str, Any]
         "wearing": template.get("armour_start", None),
         "armour_class": compute_ac_from_dex(dex),
     }
+    cls_name = str(player.get("class") or template.get("class") or "Thief")
+    equipment_map = player.setdefault("equipment_by_class", {})
+    equipment_map[cls_name] = {"armour": None}
     player["readied_spell"] = template.get("readied_spell_start", None)
     player["target_monster_id"] = None
     player["inventory"] = []

--- a/state/playerlivestate.json
+++ b/state/playerlivestate.json
@@ -42,7 +42,12 @@
       },
       "notes": "",
       "Ions": 30000,
-      "Riblets": 0
+      "Riblets": 0,
+      "equipment_by_class": {
+        "Thief": {
+          "armour": null
+        }
+      }
     },
     {
       "id": "player_priest",
@@ -86,7 +91,12 @@
       },
       "notes": "",
       "Ions": 30000,
-      "Riblets": 0
+      "Riblets": 0,
+      "equipment_by_class": {
+        "Priest": {
+          "armour": null
+        }
+      }
     },
     {
       "id": "player_wizard",
@@ -130,7 +140,12 @@
       },
       "notes": "",
       "Ions": 30000,
-      "Riblets": 0
+      "Riblets": 0,
+      "equipment_by_class": {
+        "Wizard": {
+          "armour": null
+        }
+      }
     },
     {
       "id": "player_warrior",
@@ -174,7 +189,12 @@
       },
       "notes": "",
       "Ions": 30000,
-      "Riblets": 0
+      "Riblets": 0,
+      "equipment_by_class": {
+        "Warrior": {
+          "armour": null
+        }
+      }
     },
     {
       "id": "player_mage",
@@ -218,7 +238,12 @@
       },
       "notes": "",
       "Ions": 30000,
-      "Riblets": 0
+      "Riblets": 0,
+      "equipment_by_class": {
+        "Mage": {
+          "armour": null
+        }
+      }
     }
   ],
   "active_id": "player_thief",
@@ -248,7 +273,15 @@
       0,
       0
     ],
-    "inventory": []
+    "inventory": [],
+    "equipment_by_class": {
+      "Thief": {
+        "armour": null
+      }
+    },
+    "armour": {
+      "wearing": null
+    }
   },
   "ions_by_class": {
     "Thief": 30000,
@@ -377,5 +410,65 @@
   "bags": {
     "Thief": []
   },
-  "inventory": []
+  "inventory": [],
+  "equipment_by_class": {
+    "Thief": {
+      "armour": null
+    },
+    "Priest": {
+      "armour": null
+    },
+    "Wizard": {
+      "armour": null
+    },
+    "Warrior": {
+      "armour": null
+    },
+    "Mage": {
+      "armour": null
+    }
+  },
+  "spells_by_class": {
+    "Thief": {
+      "known": [],
+      "prepared": []
+    },
+    "Priest": {
+      "known": [],
+      "prepared": []
+    },
+    "Wizard": {
+      "known": [],
+      "prepared": []
+    },
+    "Warrior": {
+      "known": [],
+      "prepared": []
+    },
+    "Mage": {
+      "known": [],
+      "prepared": []
+    }
+  },
+  "spell_effects_by_class": {
+    "Thief": {
+      "personal": {}
+    },
+    "Priest": {
+      "personal": {}
+    },
+    "Wizard": {
+      "personal": {}
+    },
+    "Warrior": {
+      "personal": {}
+    },
+    "Mage": {
+      "personal": {}
+    }
+  },
+  "world_tile_effects": {},
+  "armour": {
+    "wearing": null
+  }
 }


### PR DESCRIPTION
## Summary
- filter equipped armour from inventory helpers and inventory-facing commands so worn items no longer appear in look/convert/drop/use flows
- update player state normalization and convert command to respect sparse `ions_by_class` maps when only the active class is updated
- seed armour equipment slots across bootstrap/reset fixtures and keep the default save positioned at the expected look location

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cefb1edd80832babd91f5d316e0bec