### PR TITLE
Include armour class bonus from equipped armour

### DIFF
--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -5,7 +5,11 @@ from collections.abc import Mapping
 
 from mutants.registries import items_catalog, items_instances as itemsreg
 from mutants.services import player_state as pstate
-from mutants.services.combat_calc import armour_class_for_active, dex_bonus_for_active
+from mutants.services.combat_calc import (
+    armour_class_for_active,
+    armour_class_from_equipped,
+    dex_bonus_for_active,
+)
 from mutants.ui.item_display import item_label
 
 from . import inv as inv_cmd_mod
@@ -78,10 +82,12 @@ def statistics_cmd(arg: str, ctx) -> None:
     bus.push("SYSTEM/OK", f"Ions        : {ions}")
     armour_class = armour_class_for_active(state)
     dex_bonus = dex_bonus_for_active(state)
+    armour_bonus = armour_class_from_equipped(state)
     bus.push(
         "SYSTEM/OK",
         "Wearing Armor : "
-        f"{armour_status}  Armour Class: {armour_class}  (Dex bonus: +{dex_bonus})",
+        f"{armour_status}  Armour Class: {armour_class}  "
+        f"(Dex bonus: +{dex_bonus}, Armour: +{armour_bonus})",
     )
     bus.push("SYSTEM/OK", "Ready to Combat: NO ONE")
     bus.push("SYSTEM/OK", "Readied Spell  : No spell memorized.")

--- a/src/mutants/services/combat_calc.py
+++ b/src/mutants/services/combat_calc.py
@@ -1,6 +1,50 @@
 from __future__ import annotations
 
+from typing import Any, Optional
+
+from mutants.registries import items_catalog, items_instances as itemsreg
 from mutants.services import player_state as pstate
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def armour_class_from_equipped(state) -> int:
+    """Return the armour class bonus provided by the equipped armour."""
+
+    armour_iid = pstate.get_equipped_armour_id(state)
+    if not armour_iid:
+        return 0
+
+    try:
+        catalog = items_catalog.load_catalog()
+    except FileNotFoundError:
+        catalog = None
+
+    template: Optional[dict[str, Any]] = None
+    inst = itemsreg.get_instance(armour_iid)
+    if inst:
+        tpl_id: Optional[str] = None
+        for key in ("item_id", "catalog_id", "id"):
+            candidate = inst.get(key)
+            if candidate is None:
+                continue
+            tpl_id = str(candidate)
+            if tpl_id:
+                break
+        if tpl_id and catalog:
+            template = catalog.get(tpl_id)
+
+    if not template and catalog:
+        template = catalog.get(str(armour_iid))
+    if not template:
+        return 0
+
+    return max(0, _coerce_int(template.get("armour_class")))
 
 
 def dex_bonus_for_active(state) -> int:
@@ -18,4 +62,4 @@ def dex_bonus_for_active(state) -> int:
 def armour_class_for_active(state) -> int:
     """Return the active character's armour class."""
 
-    return dex_bonus_for_active(state)
+    return dex_bonus_for_active(state) + armour_class_from_equipped(state)

--- a/tests/test_combat_calc.py
+++ b/tests/test_combat_calc.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mutants.services import combat_calc
+
+
+class DummyCatalog:
+    def __init__(self, data: Dict[str, Dict[str, Any]]):
+        self._data = data
+
+    def get(self, item_id: str):
+        return self._data.get(item_id)
+
+
+def _base_state(dex: int, armour: str | None = None) -> Dict[str, Any]:
+    state: Dict[str, Any] = {
+        "players": [
+            {
+                "id": "p1",
+                "class": "Thief",
+            }
+        ],
+        "active_id": "p1",
+        "stats_by_class": {"Thief": {"dex": dex}},
+    }
+    if armour is not None:
+        state["equipment_by_class"] = {"Thief": {"armour": armour}}
+    return state
+
+
+def test_armour_class_without_armour(monkeypatch):
+    state = _base_state(dex=35)
+
+    assert combat_calc.armour_class_from_equipped(state) == 0
+    assert combat_calc.armour_class_for_active(state) == 3
+
+
+def test_armour_class_with_equipped_instance(monkeypatch):
+    state = _base_state(dex=20, armour="armour#1")
+
+    def fake_get_instance(iid: str):
+        if iid == "armour#1":
+            return {"iid": iid, "item_id": "chain_mail"}
+        return None
+
+    dummy_catalog = DummyCatalog({"chain_mail": {"armour_class": 2}})
+
+    monkeypatch.setattr(combat_calc.itemsreg, "get_instance", fake_get_instance)
+    monkeypatch.setattr(combat_calc.items_catalog, "load_catalog", lambda: dummy_catalog)
+
+    assert combat_calc.armour_class_from_equipped(state) == 2
+    assert combat_calc.armour_class_for_active(state) == 4
+
+
+def test_armour_class_from_direct_template(monkeypatch):
+    state = _base_state(dex=5, armour="leather_armour")
+
+    dummy_catalog = DummyCatalog({"leather_armour": {"armour_class": 1}})
+
+    monkeypatch.setattr(combat_calc.itemsreg, "get_instance", lambda _: None)
+    monkeypatch.setattr(combat_calc.items_catalog, "load_catalog", lambda: dummy_catalog)
+
+    assert combat_calc.armour_class_from_equipped(state) == 1
+    assert combat_calc.armour_class_for_active(state) == 1


### PR DESCRIPTION
## Summary
- compute armour class contributions from equipped armour instances or direct template references
- display the breakdown of dexterity and armour contributions in the statistics command
- add unit tests covering armour class calculations with and without equipped items

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0363eb88832bb58c054a3544acb5