### PR TITLE
Add item wear helpers and tests

### DIFF
--- a/src/mutants/services/items_wear.py
+++ b/src/mutants/services/items_wear.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mutants.registries import items_instances
+
+
+def _sanitize_wear_amount(amount: int) -> int:
+    try:
+        value = int(amount)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, value)
+
+
+def apply_wear(iid: str, amount: int) -> Dict[str, Any]:
+    """Apply *amount* of wear to the item instance ``iid``."""
+
+    inst = items_instances.get_instance(iid)
+    if inst is None:
+        raise KeyError(iid)
+
+    current_condition = items_instances.get_condition(iid)
+
+    if items_instances.is_enchanted(iid):
+        return {"cracked": False, "condition": current_condition}
+
+    if current_condition <= 0:
+        return {"cracked": False, "condition": 0}
+
+    wear_amount = _sanitize_wear_amount(amount)
+    if wear_amount <= 0:
+        return {"cracked": False, "condition": current_condition}
+
+    next_condition = max(0, current_condition - wear_amount)
+
+    if next_condition <= 0:
+        items_instances.crack_instance(iid)
+        return {"cracked": True, "condition": 0}
+
+    updated = items_instances.set_condition(iid, next_condition)
+    return {"cracked": False, "condition": updated}
+
+
+def wear_from_event(event: Any) -> int:
+    """Derive a wear value from a combat/event payload."""
+
+    return 5

--- a/tests/test_items_wear.py
+++ b/tests/test_items_wear.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from mutants.registries import items_instances
+from mutants.services import items_wear
+
+
+@pytest.fixture
+def in_memory_instances(monkeypatch):
+    data = []
+
+    def fake_cache():
+        return data
+
+    monkeypatch.setattr(items_instances, "_cache", fake_cache)
+    return data
+
+
+def test_apply_wear_enchanted_noop(in_memory_instances):
+    iid = "enchanted_sword#1"
+    in_memory_instances.append(
+        {
+            "iid": iid,
+            "item_id": "enchanted_sword",
+            "enchanted": "yes",
+            "condition": 90,
+        }
+    )
+
+    result = items_wear.apply_wear(iid, 12)
+
+    assert result == {"cracked": False, "condition": 90}
+    inst = items_instances.get_instance(iid)
+    assert inst["condition"] == 90
+    assert inst["item_id"] == "enchanted_sword"
+
+
+def test_apply_wear_cracks_and_idempotent(monkeypatch, in_memory_instances):
+    iid = "rusty_club#1"
+    in_memory_instances.append(
+        {
+            "iid": iid,
+            "item_id": "rusty_club",
+            "enchanted": "no",
+            "condition": 4,
+        }
+    )
+    monkeypatch.setattr(
+        items_instances.items_catalog,
+        "load_catalog",
+        lambda: {"rusty_club": {"name": "Rusty Club"}},
+    )
+
+    cracked = items_wear.apply_wear(iid, 5)
+
+    assert cracked == {"cracked": True, "condition": 0}
+    inst = items_instances.get_instance(iid)
+    assert inst["item_id"] == items_instances.BROKEN_WEAPON_ID
+    assert "condition" not in inst
+
+    again = items_wear.apply_wear(iid, 3)
+
+    assert again == {"cracked": False, "condition": 0}
+    assert inst["item_id"] == items_instances.BROKEN_WEAPON_ID


### PR DESCRIPTION
## Summary
- add a wear helper service that reduces condition using the registries API and cracks base items at zero
- provide a stubbed wear-from-event hook for future combat integration
- cover the new behaviour with unit tests for enchanted and breaking items

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0bb641e8832b9bec06ecef41b2e4