### PR TITLE
Add wear and remove armour commands

### DIFF
--- a/src/mutants/commands/remove.py
+++ b/src/mutants/commands/remove.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from ..registries import items_catalog as catreg
+from ..registries import items_instances as itemsreg
+from ..services import item_transfer as itx
+from ..services import player_state as pstate
+from .convert import _display_name
+
+
+def remove_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
+    bus = ctx["feedback_bus"]
+    if (arg or "").strip():
+        bus.push("SYSTEM/WARN", "Usage: remove")
+        return {"ok": False, "reason": "unexpected_argument"}
+
+    catalog = catreg.load_catalog() or {}
+    player = itx._load_player()
+    pstate.ensure_active_profile(player, ctx)
+    pstate.bind_inventory_to_active_class(player)
+    itx._ensure_inventory(player)
+
+    current = pstate.get_equipped_armour_id(player)
+    if not current:
+        bus.push("SYSTEM/WARN", "You're not wearing any armour.")
+        return {"ok": False, "reason": "no_armour"}
+
+    inventory = player.get("inventory")
+    bag_size = len(inventory) if isinstance(inventory, list) else 0
+    if bag_size >= itx.INV_CAP:
+        bus.push("SYSTEM/WARN", "You're to encumbered to do that!")
+        return {"ok": False, "reason": "bag_full"}
+
+    removed = pstate.unequip_armour()
+    if not removed:
+        bus.push("SYSTEM/WARN", "Nothing happens.")
+        return {"ok": False, "reason": "unequip_failed"}
+
+    inst = itemsreg.get_instance(removed) or {}
+    item_id = (
+        inst.get("item_id")
+        or inst.get("catalog_id")
+        or inst.get("id")
+        or removed
+    )
+    name = _display_name(str(item_id), catalog)
+
+    bus.push("SYSTEM/OK", f"You remove the {name}.")
+    return {"ok": True, "iid": removed, "item_id": item_id}
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("remove", lambda arg: remove_cmd(arg, ctx))
+    dispatch.alias("rem", "remove")
+    dispatch.alias("remo", "remove")

--- a/src/mutants/commands/wear.py
+++ b/src/mutants/commands/wear.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+from ..registries import items_catalog as catreg
+from ..registries import items_instances as itemsreg
+from ..services import player_state as pstate
+from ..services import item_transfer as itx
+from .convert import _choose_inventory_item, _display_name
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except Exception:
+        return default
+
+
+def _resolve_candidate(
+    player: Dict[str, object],
+    prefix: str,
+    catalog: Dict[str, Dict[str, object]],
+) -> Tuple[Optional[str], Optional[str]]:
+    iid, item_id = _choose_inventory_item(player, prefix, catalog)
+    if not iid or not item_id:
+        return None, None
+
+    inst = itemsreg.get_instance(iid) or {}
+    candidate_item = (
+        inst.get("item_id")
+        or inst.get("catalog_id")
+        or inst.get("id")
+        or item_id
+    )
+    return str(iid), str(candidate_item)
+
+
+def _is_armour(item_id: str, catalog: Dict[str, Dict[str, object]]) -> bool:
+    if item_id == itemsreg.BROKEN_ARMOUR_ID:
+        return True
+    template = catalog.get(item_id)
+    if not isinstance(template, dict):
+        return False
+    return bool(template.get("armour"))
+
+
+def _armour_weight(item_id: str, catalog: Dict[str, Dict[str, object]]) -> int:
+    template = catalog.get(item_id)
+    if not isinstance(template, dict):
+        return 0
+    return max(0, _coerce_int(template.get("weight"), 0))
+
+
+def wear_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
+    bus = ctx["feedback_bus"]
+    prefix = (arg or "").strip()
+    if not prefix:
+        bus.push("SYSTEM/WARN", "Usage: wear <item>")
+        return {"ok": False, "reason": "missing_argument"}
+
+    catalog = catreg.load_catalog() or {}
+    player = itx._load_player()
+    pstate.ensure_active_profile(player, ctx)
+    pstate.bind_inventory_to_active_class(player)
+    itx._ensure_inventory(player)
+
+    iid, item_id = _resolve_candidate(player, prefix, catalog)
+    if not iid or not item_id:
+        bus.push("SYSTEM/WARN", f"You're not carrying a {prefix}.")
+        return {"ok": False, "reason": "not_found"}
+
+    if not _is_armour(item_id, catalog):
+        bus.push("SYSTEM/WARN", "You can't wear that.")
+        return {"ok": False, "reason": "not_armour"}
+
+    stats_state = pstate.load_state()
+    stats = pstate.get_stats_for_active(stats_state)
+    strength = _coerce_int(stats.get("str"), 0)
+    weight = _armour_weight(item_id, catalog)
+    if strength < weight:
+        bus.push("SYSTEM/WARN", "You don't have the strength to put that on!")
+        return {"ok": False, "reason": "insufficient_strength"}
+
+    current = pstate.get_equipped_armour_id(stats_state)
+    current_name: Optional[str] = None
+    if current:
+        current_inst = itemsreg.get_instance(current) or {}
+        current_item_id = (
+            current_inst.get("item_id")
+            or current_inst.get("catalog_id")
+            or current_inst.get("id")
+            or current
+        )
+        current_name = _display_name(str(current_item_id), catalog)
+
+    try:
+        if current:
+            pstate.unequip_armour()
+        equipped = pstate.equip_armour(iid)
+    except ValueError:
+        bus.push("SYSTEM/WARN", "You can't wear that.")
+        return {"ok": False, "reason": "equip_failed"}
+
+    name = _display_name(item_id, catalog)
+    if current and current_name:
+        bus.push("SYSTEM/OK", f"You've removed the {current_name}.")
+    bus.push("SYSTEM/OK", f"You've just put on the {name}.")
+
+    result: Dict[str, object] = {"ok": True, "iid": equipped, "item_id": item_id}
+    if current:
+        result["swapped"] = current
+    return result
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("wear", lambda arg: wear_cmd(arg, ctx))
+    dispatch.alias("wea", "wear")

--- a/tests/test_commands_wear_remove.py
+++ b/tests/test_commands_wear_remove.py
@@ -1,0 +1,239 @@
+import copy
+
+import pytest
+
+from mutants.commands import remove, wear
+from mutants.registries import items_catalog, items_instances as itemsreg
+from mutants.services import combat_calc, item_transfer as itx, player_state as pstate
+
+
+class Bus:
+    def __init__(self) -> None:
+        self.msgs: list[tuple[str, str]] = []
+
+    def push(self, kind: str, msg: str) -> None:
+        self.msgs.append((kind, msg))
+
+
+def _make_state(
+    bag_items: list[str],
+    equipped: str | None,
+    stats: dict[str, int],
+) -> dict[str, object]:
+    equipment_entry = {"Thief": {"armour": equipped}}
+    base = {
+        "players": [
+            {
+                "id": "p1",
+                "class": "Thief",
+                "pos": [2000, 1, 1],
+                "inventory": list(bag_items),
+                "bags": {"Thief": list(bag_items)},
+                "equipment_by_class": copy.deepcopy(equipment_entry),
+                "armour": {"wearing": equipped},
+                "stats": dict(stats),
+            }
+        ],
+        "active_id": "p1",
+        "inventory": list(bag_items),
+        "bags": {"Thief": list(bag_items)},
+        "equipment_by_class": copy.deepcopy(equipment_entry),
+        "active": {
+            "class": "Thief",
+            "pos": [2000, 1, 1],
+            "inventory": list(bag_items),
+            "equipment_by_class": copy.deepcopy(equipment_entry),
+            "armour": {"wearing": equipped},
+            "stats": dict(stats),
+        },
+        "armour": {"wearing": equipped},
+        "stats_by_class": {"Thief": dict(stats)},
+    }
+    return base
+
+
+def _ctx(state: dict[str, object]) -> tuple[dict[str, object], Bus]:
+    bus = Bus()
+    ctx = {
+        "feedback_bus": bus,
+        "bus": bus,
+        "player_state": copy.deepcopy(state),
+        "world_loader": lambda _year: {},
+        "headers": {},
+    }
+    return ctx, bus
+
+
+@pytest.fixture
+def command_env(monkeypatch):
+    state_store: dict[str, object] = {}
+    catalog_data: dict[str, dict[str, object]] = {}
+    instances_list: list[dict[str, object]] = []
+
+    def fake_load_state() -> dict[str, object]:
+        return copy.deepcopy(state_store)
+
+    def fake_save_state(new_state: dict[str, object]) -> None:
+        state_store.clear()
+        state_store.update(copy.deepcopy(new_state))
+
+    monkeypatch.setattr(pstate, "load_state", fake_load_state)
+    monkeypatch.setattr(pstate, "save_state", fake_save_state)
+
+    monkeypatch.setattr(items_catalog, "load_catalog", lambda: catalog_data)
+
+    def fake_cache() -> list[dict[str, object]]:
+        return instances_list
+
+    monkeypatch.setattr(itemsreg, "_cache", fake_cache)
+    monkeypatch.setattr(itemsreg, "_save_instances_raw", lambda _: None)
+    monkeypatch.setattr(itemsreg, "save_instances", lambda: None)
+
+    def setup(
+        *,
+        bag_items: list[str],
+        equipped: str | None,
+        stats: dict[str, int],
+        catalog: dict[str, dict[str, object]],
+        instances: dict[str, str],
+    ) -> None:
+        state_store.clear()
+        state_store.update(_make_state(bag_items, equipped, stats))
+        catalog_data.clear()
+        catalog_data.update(copy.deepcopy(catalog))
+        instances_list.clear()
+        for iid, item_id in instances.items():
+            inst = {
+                "iid": iid,
+                "instance_id": iid,
+                "item_id": item_id,
+                "enchanted": "no",
+                "enchant_level": 0,
+                "condition": 100,
+            }
+            instances_list.append(inst)
+        itx._STATE_CACHE = None
+
+    return {"setup": setup, "state": state_store, "catalog": catalog_data, "instances": instances_list}
+
+
+def test_wear_equips_armour_and_updates_ac(command_env):
+    stats = {"str": 12, "dex": 20, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["padded_armour#bag"],
+        equipped=None,
+        stats=stats,
+        catalog={
+            "padded_armour": {"name": "Padded Armour", "armour": True, "armour_class": 2, "weight": 5},
+        },
+        instances={"padded_armour#bag": "padded_armour"},
+    )
+
+    state_before = pstate.load_state()
+    assert combat_calc.armour_class_for_active(state_before) == 2
+
+    ctx, bus = _ctx(state_before)
+    wear.wear_cmd("padd", ctx)
+
+    assert any("You've just put on the Padded Armour." in msg for _, msg in bus.msgs)
+
+    state_after = pstate.load_state()
+    assert combat_calc.armour_class_for_active(state_after) == 4
+    assert pstate.get_equipped_armour_id(state_after) == "padded_armour#bag"
+
+
+def test_wear_rejects_when_too_heavy(command_env):
+    stats = {"str": 3, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["chain_mail#bag"],
+        equipped=None,
+        stats=stats,
+        catalog={"chain_mail": {"name": "Chain Mail", "armour": True, "weight": 6}},
+        instances={"chain_mail#bag": "chain_mail"},
+    )
+
+    state = pstate.load_state()
+    ctx, bus = _ctx(state)
+    wear.wear_cmd("chain", ctx)
+
+    assert any("You don't have the strength to put that on!" in msg for _, msg in bus.msgs)
+    assert pstate.get_equipped_armour_id(pstate.load_state()) is None
+
+
+def test_remove_fails_when_bag_full(command_env):
+    bag_items = [f"junk#{idx}" for idx in range(9)] + ["padded_armour#bag"]
+    stats = {"str": 12, "dex": 15, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=bag_items,
+        equipped="chain_mail#equipped",
+        stats=stats,
+        catalog={
+            "chain_mail": {"name": "Chain Mail", "armour": True, "weight": 4},
+            "padded_armour": {"name": "Padded Armour", "armour": True, "weight": 3},
+        },
+        instances={
+            "chain_mail#equipped": "chain_mail",
+            "padded_armour#bag": "padded_armour",
+            **{item: "scrap" for item in bag_items if item.startswith("junk#")},
+        },
+    )
+
+    state = pstate.load_state()
+    ctx, bus = _ctx(state)
+    remove.remove_cmd("", ctx)
+
+    assert any("You're to encumbered to do that!" in msg for _, msg in bus.msgs)
+    assert pstate.get_equipped_armour_id(pstate.load_state()) == "chain_mail#equipped"
+
+
+def test_wear_swaps_when_already_equipped(command_env):
+    bag_items = [f"junk#{idx}" for idx in range(9)] + ["padded_armour#bag"]
+    stats = {"str": 12, "dex": 18, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=bag_items,
+        equipped="chain_mail#equipped",
+        stats=stats,
+        catalog={
+            "chain_mail": {"name": "Chain Mail", "armour": True, "weight": 4, "armour_class": 2},
+            "padded_armour": {"name": "Padded Armour", "armour": True, "weight": 3, "armour_class": 1},
+        },
+        instances={
+            "chain_mail#equipped": "chain_mail",
+            "padded_armour#bag": "padded_armour",
+            **{item: "scrap" for item in bag_items if item.startswith("junk#")},
+        },
+    )
+
+    state = pstate.load_state()
+    ctx, bus = _ctx(state)
+    wear.wear_cmd("padded", ctx)
+
+    messages = [msg for _, msg in bus.msgs]
+    assert "You've removed the Chain Mail." in messages
+    assert "You've just put on the Padded Armour." in messages
+
+    state_after = pstate.load_state()
+    bag_after = state_after["bags"]["Thief"]  # type: ignore[index]
+    assert "chain_mail#equipped" in bag_after
+    assert "padded_armour#bag" not in bag_after
+    assert len(bag_after) == 10
+
+
+def test_remove_places_armour_in_bag(command_env):
+    stats = {"str": 9, "dex": 12, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["junk#1"],
+        equipped="chain_mail#equipped",
+        stats=stats,
+        catalog={"chain_mail": {"name": "Chain Mail", "armour": True, "weight": 4}},
+        instances={"chain_mail#equipped": "chain_mail", "junk#1": "scrap"},
+    )
+
+    state = pstate.load_state()
+    ctx, bus = _ctx(state)
+    remove.remove_cmd("", ctx)
+
+    assert any("You remove the Chain Mail." in msg for _, msg in bus.msgs)
+    state_after = pstate.load_state()
+    assert pstate.get_equipped_armour_id(state_after) is None
+    assert "chain_mail#equipped" in state_after["bags"]["Thief"]  # type: ignore[index]


### PR DESCRIPTION
## Summary
- add a wear command that resolves armour by prefix, enforces strength vs weight, and swaps equipped items automatically
- add a remove command that respects bag capacity and moves armour back into the active inventory
- cover the new commands with unit tests for equip, swap, strength gating, and capacity failures

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf2ae82c38832bb1289fff5b489093