### PR TITLE
Add equip debug logging for armour commands

### DIFF
--- a/src/mutants/commands/remove.py
+++ b/src/mutants/commands/remove.py
@@ -1,17 +1,57 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
 
 from ..registries import items_catalog as catreg
 from ..registries import items_instances as itemsreg
 from ..services import item_transfer as itx
 from ..services import player_state as pstate
+from ..services.equip_debug import _edbg_enabled, _edbg_log
 from .convert import _display_name
+
+
+def _inventory_items(payload: object) -> list[str]:
+    if isinstance(payload, dict):
+        inventory = payload.get("inventory")
+        if isinstance(inventory, list):
+            return [str(item) for item in inventory if item]
+    return []
+
+
+def _bag_count(player: Optional[Dict[str, object]] = None, state: Optional[Dict[str, object]] = None) -> int:
+    if player:
+        items = _inventory_items(player)
+        if items:
+            return len(items)
+    if state and isinstance(state, dict):
+        active = state.get("active")
+        if isinstance(active, dict):
+            items = _inventory_items(active)
+            if items:
+                return len(items)
+        return len(_inventory_items(state))
+    return 0
 
 
 def remove_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
     bus = ctx["feedback_bus"]
     if (arg or "").strip():
+        if _edbg_enabled():
+            try:
+                state = pstate.load_state()
+            except Exception:
+                state = None
+            cls_name = pstate.get_active_class(state) if state else None
+            slot_iid = pstate.get_equipped_armour_id(state) if state else None
+            _edbg_log(
+                "[ equip ] reject=unexpected_argument",
+                cmd="remove",
+                **{
+                    "class": cls_name or "None",
+                    "bag_count": _bag_count(state=state),
+                    "slot_iid": slot_iid or "None",
+                },
+            )
         bus.push("SYSTEM/WARN", "Usage: remove")
         return {"ok": False, "reason": "unexpected_argument"}
 
@@ -21,19 +61,75 @@ def remove_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
     pstate.bind_inventory_to_active_class(player)
     itx._ensure_inventory(player)
 
+    try:
+        stats_state = pstate.load_state()
+    except Exception:
+        stats_state = None
+    cls_name = pstate.get_active_class(stats_state) if stats_state else None
+
     current = pstate.get_equipped_armour_id(player)
+    current_item_id: Optional[str] = None
+    if current:
+        inst = itemsreg.get_instance(current) or {}
+        current_item_id = (
+            inst.get("item_id")
+            or inst.get("catalog_id")
+            or inst.get("id")
+            or current
+        )
+    if _edbg_enabled():
+        _edbg_log(
+            "[ equip ] remove enter",
+            cmd="remove",
+            **{
+                "class": cls_name or "None",
+                "bag_count": _bag_count(player, stats_state),
+                "slot_iid": current or "None",
+                "slot_item_id": repr(str(current_item_id)) if current_item_id else "None",
+            },
+        )
+
     if not current:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=no_armour_equipped",
+                cmd="remove",
+                **{
+                    "class": cls_name or "None",
+                    "bag_count": _bag_count(player, stats_state),
+                },
+            )
         bus.push("SYSTEM/WARN", "You're not wearing any armour.")
         return {"ok": False, "reason": "no_armour"}
 
     inventory = player.get("inventory")
     bag_size = len(inventory) if isinstance(inventory, list) else 0
     if bag_size >= itx.INV_CAP:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=capacity_block_on_remove",
+                cmd="remove",
+                **{
+                    "class": cls_name or "None",
+                    "bag_count": bag_size,
+                    "capacity": itx.INV_CAP,
+                    "slot_iid": current,
+                },
+            )
         bus.push("SYSTEM/WARN", "You're to encumbered to do that!")
         return {"ok": False, "reason": "bag_full"}
 
     removed = pstate.unequip_armour()
     if not removed:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=internal_error",
+                cmd="remove",
+                **{
+                    "class": cls_name or "None",
+                    "slot_iid": current,
+                },
+            )
         bus.push("SYSTEM/WARN", "Nothing happens.")
         return {"ok": False, "reason": "unequip_failed"}
 
@@ -47,7 +143,26 @@ def remove_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
     name = _display_name(str(item_id), catalog)
 
     bus.push("SYSTEM/OK", f"You remove the {name}.")
-    return {"ok": True, "iid": removed, "item_id": item_id}
+    result = {"ok": True, "iid": removed, "item_id": item_id}
+
+    if _edbg_enabled():
+        try:
+            final_state = pstate.load_state()
+        except Exception:
+            final_state = None
+        _edbg_log(
+            "[ equip ] success=remove",
+            cmd="remove",
+            **{
+                "class": cls_name or "None",
+                "bag_count": _bag_count(state=final_state),
+                "slot_iid": "None",
+                "removed_iid": removed,
+                "removed_item_id": repr(str(item_id)),
+            },
+        )
+
+    return result
 
 
 def register(dispatch, ctx) -> None:

--- a/src/mutants/commands/wear.py
+++ b/src/mutants/commands/wear.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, Iterable, Optional, Tuple
 
 from ..registries import items_catalog as catreg
 from ..registries import items_instances as itemsreg
 from ..services import player_state as pstate
 from ..services import item_transfer as itx
+from ..services.equip_debug import _edbg_enabled, _edbg_log
 from .convert import _choose_inventory_item, _display_name
 
 
@@ -51,10 +52,91 @@ def _armour_weight(item_id: str, catalog: Dict[str, Dict[str, object]]) -> int:
     return max(0, _coerce_int(template.get("weight"), 0))
 
 
+def _inventory_items(payload: object) -> Iterable[str]:
+    if isinstance(payload, dict):
+        inventory = payload.get("inventory")
+        if isinstance(inventory, list):
+            return [str(item) for item in inventory if item]
+    return []
+
+
+def _bag_count(state: Optional[Dict[str, object]] = None, player: Optional[Dict[str, object]] = None) -> int:
+    if player:
+        items = list(_inventory_items(player))
+        if items:
+            return len(items)
+    if state:
+        active = state.get("active") if isinstance(state, dict) else None
+        if isinstance(active, dict):
+            items = list(_inventory_items(active))
+            if items:
+                return len(items)
+        return len(list(_inventory_items(state)))
+    return 0
+
+
+def _pos_repr(state: Optional[Dict[str, object]] = None, player: Optional[Dict[str, object]] = None) -> str:
+    candidate = None
+    if isinstance(state, dict):
+        active = state.get("active")
+        if isinstance(active, dict):
+            candidate = active.get("pos")
+        if candidate is None:
+            players = state.get("players")
+            if isinstance(players, list):
+                for entry in players:
+                    if not isinstance(entry, dict):
+                        continue
+                    if entry.get("is_active"):
+                        candidate = entry.get("pos")
+                        break
+                if candidate is None and players:
+                    first = players[0]
+                    if isinstance(first, dict):
+                        candidate = first.get("pos")
+        if candidate is None:
+            candidate = state.get("pos")
+    if candidate is None and isinstance(player, dict):
+        candidate = player.get("pos")
+    if isinstance(candidate, (list, tuple)):
+        return "[" + ",".join(str(v) for v in candidate) + "]"
+    if candidate is None:
+        return "None"
+    return str(candidate)
+
+
+def _catalog_template(catalog: Dict[str, Dict[str, object]], item_id: str) -> Dict[str, object]:
+    try:
+        template = catalog.get(item_id)  # type: ignore[call-arg]
+    except Exception:
+        template = None
+    if isinstance(template, dict):
+        return template
+    return {}
+
+
 def wear_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
     bus = ctx["feedback_bus"]
     prefix = (arg or "").strip()
     if not prefix:
+        if _edbg_enabled():
+            try:
+                state = pstate.load_state()
+            except Exception:
+                state = None
+            cls_name = pstate.get_active_class(state) if state else None
+            slot_iid = pstate.get_equipped_armour_id(state) if state else None
+            _edbg_log(
+                "[ equip ] reject=missing_argument",
+                cmd="wear",
+                prefix=repr(prefix),
+                **{
+                    "class": cls_name or "None",
+                    "pos": _pos_repr(state),
+                    "bag_count": _bag_count(state=state),
+                    "slot_iid": slot_iid or "None",
+                },
+            )
         bus.push("SYSTEM/WARN", "Usage: wear <item>")
         return {"ok": False, "reason": "missing_argument"}
 
@@ -64,25 +146,92 @@ def wear_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
     pstate.bind_inventory_to_active_class(player)
     itx._ensure_inventory(player)
 
+    stats_state = pstate.load_state()
+    cls_name = pstate.get_active_class(stats_state)
+    slot_iid = pstate.get_equipped_armour_id(stats_state)
+    if _edbg_enabled():
+        _edbg_log(
+            "[ equip ] enter",
+            cmd="wear",
+            prefix=repr(prefix),
+            **{
+                "class": cls_name or "None",
+                "pos": _pos_repr(stats_state, player),
+                "bag_count": _bag_count(stats_state, player),
+                "slot_iid": slot_iid or "None",
+            },
+        )
+
     iid, item_id = _resolve_candidate(player, prefix, catalog)
     if not iid or not item_id:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=not_in_bag",
+                cmd="wear",
+                prefix=repr(prefix),
+                **{
+                    "class": cls_name or "None",
+                    "bag_count": _bag_count(stats_state, player),
+                    "slot_iid": slot_iid or "None",
+                },
+            )
         bus.push("SYSTEM/WARN", f"You're not carrying a {prefix}.")
         return {"ok": False, "reason": "not_found"}
 
+    template = _catalog_template(catalog, item_id)
+    armour_flag = bool(template.get("armour"))
+    armour_class = _coerce_int(template.get("armour_class"), 0)
+    weight = _armour_weight(item_id, catalog)
+    broken = item_id == itemsreg.BROKEN_ARMOUR_ID or armour_class == 0
+    if _edbg_enabled():
+        _edbg_log(
+            "[ equip ] resolve ok",
+            cmd="wear",
+            prefix=repr(prefix),
+            **{
+                "iid": iid,
+                "item_id": repr(item_id),
+                "armour": armour_flag,
+                "weight": weight,
+                "ac": armour_class,
+                "broken": broken,
+            },
+        )
+
     if not _is_armour(item_id, catalog):
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=not_armour",
+                cmd="wear",
+                prefix=repr(prefix),
+                **{"iid": iid, "item_id": repr(item_id)},
+            )
         bus.push("SYSTEM/WARN", "You can't wear that.")
         return {"ok": False, "reason": "not_armour"}
 
-    stats_state = pstate.load_state()
     stats = pstate.get_stats_for_active(stats_state)
     strength = _coerce_int(stats.get("str"), 0)
-    weight = _armour_weight(item_id, catalog)
-    if strength < weight:
+    gate_ok = strength >= weight
+    if _edbg_enabled():
+        comp = ">=" if gate_ok else "<"
+        outcome = "pass" if gate_ok else "fail"
+        _edbg_log(
+            f"[ equip ] gate strength={strength} {comp} weight={weight} -> {outcome}",
+        )
+    if not gate_ok:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=strength_gate",
+                cmd="wear",
+                prefix=repr(prefix),
+                **{"strength": strength, "weight": weight},
+            )
         bus.push("SYSTEM/WARN", "You don't have the strength to put that on!")
         return {"ok": False, "reason": "insufficient_strength"}
 
-    current = pstate.get_equipped_armour_id(stats_state)
+    current = slot_iid
     current_name: Optional[str] = None
+    current_item_id: Optional[str] = None
     if current:
         current_inst = itemsreg.get_instance(current) or {}
         current_item_id = (
@@ -92,12 +241,36 @@ def wear_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
             or current
         )
         current_name = _display_name(str(current_item_id), catalog)
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] slot occupied -> action=swap",
+                cmd="wear",
+                prefix=repr(prefix),
+                **{
+                    "old_iid": current,
+                    "old_item_id": repr(str(current_item_id)),
+                },
+            )
+    else:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] slot empty -> action=wear",
+                cmd="wear",
+                prefix=repr(prefix),
+            )
 
     try:
         if current:
             pstate.unequip_armour()
         equipped = pstate.equip_armour(iid)
     except ValueError:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=internal_error",
+                cmd="wear",
+                prefix=repr(prefix),
+                **{"iid": iid, "item_id": repr(item_id)},
+            )
         bus.push("SYSTEM/WARN", "You can't wear that.")
         return {"ok": False, "reason": "equip_failed"}
 
@@ -109,6 +282,30 @@ def wear_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
     result: Dict[str, object] = {"ok": True, "iid": equipped, "item_id": item_id}
     if current:
         result["swapped"] = current
+
+    if _edbg_enabled():
+        try:
+            final_state = pstate.load_state()
+        except Exception:
+            final_state = None
+        prev_template = (
+            _catalog_template(catalog, str(current_item_id)) if current_item_id else {}
+        )
+        prev_ac = _coerce_int(prev_template.get("armour_class"), 0)
+        ac_delta = armour_class - prev_ac
+        payload = {
+            "cmd": "wear",
+            "prefix": repr(prefix),
+            "equipped_iid": equipped,
+            "item_id": repr(item_id),
+            "bag_count": _bag_count(state=final_state),
+            "ac_delta": f"{ac_delta:+d}",
+        }
+        if current:
+            payload["old_to_bag"] = current
+        msg = "[ equip ] success=swap" if current else "[ equip ] success=wear"
+        _edbg_log(msg, **payload)
+
     return result
 
 

--- a/src/mutants/services/equip_debug.py
+++ b/src/mutants/services/equip_debug.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+_LOGGER: Optional[logging.Logger] = None
+
+
+def _edbg_enabled() -> bool:
+    """Return True when equip-debug logging should be emitted."""
+
+    return os.environ.get("EQUIP_DEBUG") == "1" or os.environ.get("PLAYERS_DEBUG") == "1"
+
+
+def _edbg_setup_file_logging() -> logging.Logger:
+    """Initialise and return the equip-debug logger."""
+
+    global _LOGGER
+    if _LOGGER is not None:
+        return _LOGGER
+
+    os.makedirs(os.path.join("state", "logs"), exist_ok=True)
+
+    logger = logging.getLogger("mutants.equipdbg")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    if not logger.handlers:
+        handler = logging.FileHandler(os.path.join("state", "logs", "equip_debug.log"))
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+
+    _LOGGER = logger
+    return logger
+
+
+def _edbg_log(msg: str, **kv: Any) -> None:
+    """Emit a formatted equip-debug log line when enabled."""
+
+    if not _edbg_enabled():
+        return
+
+    logger = _edbg_setup_file_logging()
+
+    parts = [msg]
+    for key, value in kv.items():
+        if value is None:
+            rendered = "None"
+        elif isinstance(value, (list, tuple)):
+            rendered = "[" + ",".join(str(v) for v in value) + "]"
+        else:
+            rendered = str(value)
+        parts.append(f"{key}={rendered}")
+
+    logger.info(" ".join(parts))


### PR DESCRIPTION
## Summary
- add an equip debug logging helper that writes to state/logs/equip_debug.log when enabled
- instrument the wear command to trace prefix resolution, gating, slot decisions, and outcomes
- instrument the remove command to trace bag capacity checks and removal decisions

## Testing
- pytest tests/test_commands_wear_remove.py tests/test_items_wear.py tests/test_smoke_equipment.py

------
https://chatgpt.com/codex/tasks/task_e_68cf31f02f60832bbf0c73a4ac5d5fca