### PR TITLE
Fix stale equipment persistence during travel

### DIFF
--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -167,10 +167,7 @@ def _save_player(player: Dict[str, Any]) -> None:
                 active_profile["bags"] = {}
             active_profile["bags"][klass] = list(inv)
             active_profile["inventory"] = list(inv)
-    equipment_map = player.get("equipment_by_class")
-    if isinstance(equipment_map, dict):
-        state["equipment_by_class"] = dict(equipment_map)
-    # Mirror to legacy top-level slot so older tooling/tests stay in sync.
+    # Persist inventory and other canonical fields only; equipment is owned by pstate helpers.
     pstate.save_state(state)
     _STATE_CACHE = None
 

--- a/src/mutants/services/player_state.py
+++ b/src/mutants/services/player_state.py
@@ -768,7 +768,16 @@ def _ensure_equipment_map(
             fallback = _sanitize_equipped_iid(legacy_direct)
             if fallback:
                 break
-        normalized[key] = {"armour": fallback}
+        # Enforce invariant: equipped armour must be present in the class's bag.
+        equipped = fallback
+        try:
+            bags_map = state.get("bags_by_class") or state.get("bags") or {}
+            class_bag = list(bags_map.get(key) or [])
+        except Exception:
+            class_bag = []
+        if equipped and equipped not in class_bag:
+            equipped = None
+        normalized[key] = {"armour": equipped}
 
     state["equipment_by_class"] = normalized
     return normalized


### PR DESCRIPTION
## Summary
- keep `item_transfer._save_player` from writing stale `equipment_by_class` snapshots back into canonical state
- persist only the active player's position when travelling within the same century and refresh the cached state safely
- clear normalized armour slots that do not correspond to items in the owning class bag and update the legacy travel test expectations

## Testing
- pytest
- pytest tests_legacy/commands/test_travel_command.py::test_travel_same_century_returns_to_origin


------
https://chatgpt.com/codex/tasks/task_e_68cf4331167c832ba4b8c4dff41a17a9