### PR TITLE
Add wield command with per-class weapon tracking

### DIFF
--- a/src/mutants/bootstrap/lazyinit.py
+++ b/src/mutants/bootstrap/lazyinit.py
@@ -125,6 +125,8 @@ def make_player_from_template(t: Dict[str, Any], make_active: bool = False) -> D
             "armour_class": compute_ac_from_dex(dex),  # DEX-only at start
         },
         "equipment_by_class": {cls: {"armour": None}},
+        "wielded_by_class": {cls: None},
+        "wielded": None,
         "readied_spell": t.get("readied_spell_start", None),
         "target_monster_id": None,
 

--- a/src/mutants/commands/statistics.py
+++ b/src/mutants/commands/statistics.py
@@ -70,6 +70,17 @@ def statistics_cmd(arg: str, ctx) -> None:
             if wearing is not None:
                 armour_status = str(wearing)
 
+    weapon_iid = pstate.get_wielded_weapon_id(state)
+    weapon_status = "None"
+    if weapon_iid:
+        inst = itemsreg.get_instance(weapon_iid)
+        if inst:
+            tpl_id = inst.get("item_id") or inst.get("catalog_id") or inst.get("id")
+            tpl = cat.get(str(tpl_id)) if tpl_id and cat else {}
+            weapon_status = item_label(inst, tpl or {}, show_charges=False)
+        else:
+            weapon_status = str(weapon_iid)
+
     bus.push("SYSTEM/OK", f"Name: {name} / Mutant {cls}")
     bus.push("SYSTEM/OK", f"Exhaustion : {exhaustion}")
 
@@ -80,6 +91,7 @@ def statistics_cmd(arg: str, ctx) -> None:
     bus.push("SYSTEM/OK", f"Exp. Points : {exp_pts:<6} Level: {level}")
     bus.push("SYSTEM/OK", f"Riblets     : {riblets}")
     bus.push("SYSTEM/OK", f"Ions        : {ions}")
+    bus.push("SYSTEM/OK", f"Wielding    : {weapon_status}")
     armour_class = armour_class_for_active(state)
     dex_bonus = dex_bonus_for_active(state)
     armour_bonus = armour_class_from_equipped(state)

--- a/src/mutants/commands/wield.py
+++ b/src/mutants/commands/wield.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+from ..registries import items_catalog as catreg
+from ..registries import items_instances as itemsreg
+from ..services import item_transfer as itx
+from ..services import player_state as pstate
+from ..services.equip_debug import _edbg_enabled, _edbg_log
+from ..services.items_weight import effective_weight
+from .convert import _choose_inventory_item, _display_name
+from .wear import _bag_count, _catalog_template, _pos_repr
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except Exception:
+        return default
+
+
+def _resolve_candidate(
+    player: Dict[str, object],
+    prefix: str,
+    catalog: Dict[str, Dict[str, object]],
+) -> Tuple[Optional[str], Optional[str]]:
+    iid, item_id = _choose_inventory_item(player, prefix, catalog)
+    if not iid or not item_id:
+        return None, None
+
+    inst = itemsreg.get_instance(iid) or {}
+    candidate_item = (
+        inst.get("item_id")
+        or inst.get("catalog_id")
+        or inst.get("id")
+        or item_id
+    )
+    return str(iid), str(candidate_item)
+
+
+def wield_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
+    bus = ctx["feedback_bus"]
+    prefix = (arg or "").strip()
+    if not prefix:
+        if _edbg_enabled():
+            try:
+                state = pstate.load_state()
+            except Exception:
+                state = None
+            cls_name = pstate.get_active_class(state) if state else None
+            wield_iid = pstate.get_wielded_weapon_id(state) if state else None
+            _edbg_log(
+                "[ equip ] reject=missing_argument",
+                cmd="wield",
+                prefix=repr(prefix),
+                **{
+                    "class": cls_name or "None",
+                    "pos": _pos_repr(state),
+                    "bag_count": _bag_count(state=state),
+                    "wield_iid": wield_iid or "None",
+                },
+            )
+        bus.push("SYSTEM/WARN", "Usage: wield <item>")
+        return {"ok": False, "reason": "missing_argument"}
+
+    catalog = catreg.load_catalog() or {}
+    player = itx._load_player()
+    pstate.ensure_active_profile(player, ctx)
+    pstate.bind_inventory_to_active_class(player)
+    itx._ensure_inventory(player)
+
+    stats_state = pstate.load_state()
+    cls_name = pstate.get_active_class(stats_state)
+    current_iid = pstate.get_wielded_weapon_id(stats_state)
+    if _edbg_enabled():
+        _edbg_log(
+            "[ equip ] enter",
+            cmd="wield",
+            prefix=repr(prefix),
+            **{
+                "class": cls_name or "None",
+                "pos": _pos_repr(stats_state, player),
+                "bag_count": _bag_count(stats_state, player),
+                "wield_iid": current_iid or "None",
+            },
+        )
+
+    iid, item_id = _resolve_candidate(player, prefix, catalog)
+    if not iid or not item_id:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=not_in_bag",
+                cmd="wield",
+                prefix=repr(prefix),
+                **{
+                    "class": cls_name or "None",
+                    "bag_count": _bag_count(stats_state, player),
+                    "wield_iid": current_iid or "None",
+                },
+            )
+        bus.push("SYSTEM/WARN", f"You're not carrying a {prefix}.")
+        return {"ok": False, "reason": "not_found"}
+
+    inst = itemsreg.get_instance(iid) or {}
+    template = _catalog_template(catalog, item_id)
+    weight = max(0, effective_weight(inst, template))
+    required = weight // 5
+    name = _display_name(item_id, catalog)
+
+    if _edbg_enabled():
+        _edbg_log(
+            "[ equip ] resolve ok",
+            cmd="wield",
+            prefix=repr(prefix),
+            **{
+                "iid": iid,
+                "item_id": repr(item_id),
+                "weight": weight,
+                "required": required,
+            },
+        )
+
+    stats = pstate.get_stats_for_active(stats_state)
+    strength = _coerce_int(stats.get("str"), 0)
+    gate_ok = strength >= required
+    if _edbg_enabled():
+        comp = ">=" if gate_ok else "<"
+        outcome = "pass" if gate_ok else "fail"
+        _edbg_log(
+            f"[ equip ] gate strength={strength} {comp} required={required} weight={weight} -> {outcome}",
+            cmd="wield",
+            prefix=repr(prefix),
+        )
+    if not gate_ok:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=strength_gate",
+                cmd="wield",
+                prefix=repr(prefix),
+                **{"strength": strength, "required": required, "weight": weight},
+            )
+        bus.push("SYSTEM/WARN", "You don't have the strength to wield that!")
+        return {"ok": False, "reason": "insufficient_strength"}
+
+    try:
+        pstate.set_wielded_weapon(iid)
+    except ValueError:
+        if _edbg_enabled():
+            _edbg_log(
+                "[ equip ] reject=internal_error",
+                cmd="wield",
+                prefix=repr(prefix),
+                **{"iid": iid, "item_id": repr(item_id)},
+            )
+        bus.push("SYSTEM/WARN", "You can't wield that.")
+        return {"ok": False, "reason": "wield_failed"}
+
+    bus.push("SYSTEM/OK", f"You wield the {name}.")
+
+    result: Dict[str, object] = {
+        "ok": True,
+        "iid": iid,
+        "item_id": item_id,
+        "weight": weight,
+        "required": required,
+    }
+
+    if _edbg_enabled():
+        try:
+            final_state = pstate.load_state()
+        except Exception:
+            final_state = None
+        payload = {
+            "cmd": "wield",
+            "prefix": repr(prefix),
+            "wielded_iid": iid,
+            "item_id": repr(item_id),
+            "bag_count": _bag_count(state=final_state),
+            "weight": weight,
+            "required": required,
+        }
+        if current_iid:
+            payload["previous"] = current_iid
+        _edbg_log("[ equip ] success=wield", **payload)
+
+    return result
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("wield", lambda arg: wield_cmd(arg, ctx))
+    dispatch.alias("wie", "wield")
+    dispatch.alias("wiel", "wield")

--- a/src/mutants/services/items_weight.py
+++ b/src/mutants/services/items_weight.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+def _coerce_weight(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return max(0, int(value))
+    try:
+        return max(0, int(float(str(value))))
+    except (TypeError, ValueError):
+        return None
+
+
+def effective_weight(
+    instance: Mapping[str, Any] | None, template: Mapping[str, Any] | None
+) -> int:
+    """Return the effective weight for an item instance.
+
+    Prefers explicit effective-weight overrides, falling back to standard weight
+    metadata from the instance and catalog template.
+    """
+
+    for payload in (instance, template):
+        if not isinstance(payload, Mapping):
+            continue
+        for key in ("effective_weight", "effective_weight_lbs", "effective_lbs"):
+            weight = _coerce_weight(payload.get(key))
+            if weight is not None:
+                return weight
+
+    if isinstance(instance, Mapping):
+        weight = _coerce_weight(instance.get("weight"))
+        if weight is not None:
+            return weight
+
+    if isinstance(template, Mapping):
+        for key in ("weight", "weight_lbs", "lbs"):
+            weight = _coerce_weight(template.get(key))
+            if weight is not None:
+                return weight
+
+    return 0

--- a/src/mutants/services/player_reset.py
+++ b/src/mutants/services/player_reset.py
@@ -58,6 +58,8 @@ def _reset_fields_from_template(player: Dict[str, Any], template: Dict[str, Any]
     cls_name = str(player.get("class") or template.get("class") or "Thief")
     equipment_map = player.setdefault("equipment_by_class", {})
     equipment_map[cls_name] = {"armour": None}
+    player.setdefault("wielded_by_class", {})[cls_name] = None
+    player["wielded"] = None
     player["readied_spell"] = template.get("readied_spell_start", None)
     player["target_monster_id"] = None
     player["inventory"] = []

--- a/tests/test_commands_wield.py
+++ b/tests/test_commands_wield.py
@@ -1,0 +1,247 @@
+import copy
+
+import pytest
+
+from mutants.commands import wield
+from mutants.registries import items_catalog, items_instances as itemsreg
+from mutants.services import player_state as pstate
+
+
+class Bus:
+    def __init__(self) -> None:
+        self.msgs: list[tuple[str, str]] = []
+
+    def push(self, kind: str, msg: str) -> None:
+        self.msgs.append((kind, msg))
+
+
+def _make_state(
+    bag_items: list[str],
+    stats: dict[str, int],
+    *,
+    wielded: str | None = None,
+    extra_classes: list[tuple[str, list[str], dict[str, int]]] | None = None,
+) -> dict[str, object]:
+    equipment_entry: dict[str, dict[str, str | None]] = {"Thief": {"armour": None}}
+    wield_map: dict[str, str | None] = {"Thief": wielded}
+    bags: dict[str, list[str]] = {"Thief": list(bag_items)}
+    stats_by_class: dict[str, dict[str, int]] = {"Thief": dict(stats)}
+
+    players: list[dict[str, object]] = [
+        {
+            "id": "p1",
+            "class": "Thief",
+            "pos": [2000, 1, 1],
+            "inventory": list(bag_items),
+            "bags": {"Thief": list(bag_items)},
+            "equipment_by_class": copy.deepcopy(equipment_entry),
+            "wielded_by_class": {"Thief": wielded},
+            "armour": {"wearing": None},
+            "wielded": wielded,
+            "stats": dict(stats),
+        }
+    ]
+
+    if extra_classes:
+        for idx, (cls_name, extra_bag, extra_stats) in enumerate(extra_classes, start=2):
+            equipment_entry[cls_name] = {"armour": None}
+            wield_map[cls_name] = None
+            bags[cls_name] = list(extra_bag)
+            stats_by_class[cls_name] = dict(extra_stats)
+            players.append(
+                {
+                    "id": f"p{idx}",
+                    "class": cls_name,
+                    "pos": [2000, idx, idx],
+                    "inventory": list(extra_bag),
+                    "bags": {cls_name: list(extra_bag)},
+                    "equipment_by_class": {cls_name: {"armour": None}},
+                    "wielded_by_class": {cls_name: None},
+                    "armour": {"wearing": None},
+                    "wielded": None,
+                    "stats": dict(extra_stats),
+                }
+            )
+
+    return {
+        "players": players,
+        "active_id": "p1",
+        "inventory": list(bag_items),
+        "bags": bags,
+        "equipment_by_class": copy.deepcopy(equipment_entry),
+        "wielded_by_class": copy.deepcopy(wield_map),
+        "active": {
+            "class": "Thief",
+            "pos": [2000, 1, 1],
+            "inventory": list(bag_items),
+            "equipment_by_class": copy.deepcopy(equipment_entry),
+            "wielded_by_class": copy.deepcopy(wield_map),
+            "armour": {"wearing": None},
+            "wielded": wielded,
+            "stats": dict(stats),
+        },
+        "armour": {"wearing": None},
+        "wielded": wielded,
+        "stats_by_class": stats_by_class,
+    }
+
+
+def _ctx(state: dict[str, object]) -> tuple[dict[str, object], Bus]:
+    bus = Bus()
+    ctx = {
+        "feedback_bus": bus,
+        "bus": bus,
+        "player_state": copy.deepcopy(state),
+        "world_loader": lambda _year: {},
+        "headers": {},
+    }
+    return ctx, bus
+
+
+@pytest.fixture
+def command_env(monkeypatch):
+    state_store: dict[str, object] = {}
+    catalog_data: dict[str, dict[str, object]] = {}
+    instances_list: list[dict[str, object]] = []
+
+    def fake_load_state() -> dict[str, object]:
+        return copy.deepcopy(state_store)
+
+    def fake_save_state(new_state: dict[str, object]) -> None:
+        state_store.clear()
+        state_store.update(copy.deepcopy(new_state))
+
+    monkeypatch.setattr(pstate, "load_state", fake_load_state)
+    monkeypatch.setattr(pstate, "save_state", fake_save_state)
+
+    monkeypatch.setattr(items_catalog, "load_catalog", lambda: catalog_data)
+
+    def fake_cache() -> list[dict[str, object]]:
+        return instances_list
+
+    monkeypatch.setattr(itemsreg, "_cache", fake_cache)
+    monkeypatch.setattr(itemsreg, "_save_instances_raw", lambda _: None)
+    monkeypatch.setattr(itemsreg, "save_instances", lambda: None)
+
+    def setup(
+        *,
+        bag_items: list[str],
+        stats: dict[str, int],
+        catalog: dict[str, dict[str, object]],
+        instances: dict[str, dict[str, object]],
+        wielded: str | None = None,
+        extra_classes: list[tuple[str, list[str], dict[str, int]]] | None = None,
+    ) -> None:
+        state_store.clear()
+        state_store.update(_make_state(bag_items, stats, wielded=wielded, extra_classes=extra_classes))
+        catalog_data.clear()
+        catalog_data.update(copy.deepcopy(catalog))
+        instances_list.clear()
+        for iid, meta in instances.items():
+            inst = {
+                "iid": iid,
+                "instance_id": iid,
+                "item_id": meta.get("item_id"),
+                "enchanted": "no",
+                "enchant_level": 0,
+                "condition": 100,
+            }
+            if "weight" in meta:
+                inst["weight"] = meta["weight"]
+            instances_list.append(inst)
+        from mutants.services import item_transfer as itx
+
+        itx._STATE_CACHE = None
+
+    return {"setup": setup, "state": state_store, "catalog": catalog_data, "instances": instances_list}
+
+
+def test_wield_sets_active_weapon(command_env):
+    stats = {"str": 12, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["long_sword#bag"],
+        stats=stats,
+        catalog={"long_sword": {"name": "Long Sword", "weight": 10}},
+        instances={"long_sword#bag": {"item_id": "long_sword"}},
+    )
+
+    state_before = pstate.load_state()
+    ctx, bus = _ctx(state_before)
+    result = wield.wield_cmd("long", ctx)
+
+    assert result["ok"] is True
+    assert any("You wield the Long Sword." in msg for _, msg in bus.msgs)
+
+    state_after = pstate.load_state()
+    assert pstate.get_wielded_weapon_id(state_after) == "long_sword#bag"
+    assert "long_sword#bag" in state_after["bags"]["Thief"]  # type: ignore[index]
+    assert state_after["wielded_by_class"]["Thief"] == "long_sword#bag"  # type: ignore[index]
+
+
+def test_wield_strength_gate_failure(command_env):
+    stats = {"str": 3, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["warhammer#bag"],
+        stats=stats,
+        catalog={"warhammer": {"name": "Warhammer", "weight": 25}},
+        instances={"warhammer#bag": {"item_id": "warhammer"}},
+    )
+
+    state_before = pstate.load_state()
+    ctx, bus = _ctx(state_before)
+    result = wield.wield_cmd("war", ctx)
+
+    assert result["ok"] is False
+    assert any("You don't have the strength to wield that!" in msg for _, msg in bus.msgs)
+    assert pstate.get_wielded_weapon_id(pstate.load_state()) is None
+
+
+def test_wield_uses_prefix_resolution(command_env):
+    stats = {"str": 6, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["short_sword#bag", "long_sword#bag"],
+        stats=stats,
+        catalog={
+            "short_sword": {"name": "Short Sword", "weight": 5},
+            "long_sword": {"name": "Long Sword", "weight": 10},
+        },
+        instances={
+            "short_sword#bag": {"item_id": "short_sword"},
+            "long_sword#bag": {"item_id": "long_sword"},
+        },
+    )
+
+    state_before = pstate.load_state()
+    ctx, bus = _ctx(state_before)
+    wield.wield_cmd("lon", ctx)
+
+    state_after = pstate.load_state()
+    assert pstate.get_wielded_weapon_id(state_after) == "long_sword#bag"
+    assert any("You wield the Long Sword." in msg for _, msg in bus.msgs)
+
+
+def test_wield_persists_per_class(command_env):
+    stats = {"str": 8, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    extra = [("Wizard", ["wand#bag"], {"str": 5, "dex": 9, "int": 12, "wis": 11, "con": 8, "cha": 7})]
+    command_env["setup"](
+        bag_items=["long_sword#bag"],
+        stats=stats,
+        catalog={
+            "long_sword": {"name": "Long Sword", "weight": 10},
+            "wand": {"name": "Wizard's Wand", "weight": 2},
+        },
+        instances={
+            "long_sword#bag": {"item_id": "long_sword"},
+            "wand#bag": {"item_id": "wand"},
+        },
+        extra_classes=extra,
+    )
+
+    ctx, bus = _ctx(pstate.load_state())
+    wield.wield_cmd("long", ctx)
+    assert any("You wield the Long Sword." in msg for _, msg in bus.msgs)
+
+    state_after = pstate.load_state()
+    wield_map = state_after["wielded_by_class"]  # type: ignore[index]
+    assert wield_map["Thief"] == "long_sword#bag"  # type: ignore[index]
+    assert wield_map["Wizard"] is None  # type: ignore[index]


### PR DESCRIPTION
## Summary
- add a `wield` command that resolves inventory prefixes, enforces a strength-to-weight gate, and logs equip-debug traces
- track active weapons per class via `wielded_by_class`, including normalization, persistence helpers, and stats display updates
- introduce an effective weight helper and new tests covering wield success, failures, prefix matching, and per-class persistence

## Testing
- `pytest tests/test_commands_wield.py tests/test_commands_wear_remove.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1825567ac832b82242489baac2a7c