### PR TITLE
Implement enchant-aware weight handling for strength gates

### DIFF
--- a/src/mutants/commands/inv.py
+++ b/src/mutants/commands/inv.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from mutants.registries import items_catalog, items_instances as itemsreg
 from mutants.services import player_state as pstate
+from mutants.services.items_weight import get_effective_weight
 from ..ui.item_display import item_label, number_duplicates, with_article
 from ..ui import wrap as uwrap
 from ..ui.textutils import harden_final_display
@@ -20,16 +21,10 @@ def _coerce_weight(value):
 
 
 def _resolve_weight(inst, tpl) -> int | None:
-    """Resolve the weight for an item instance using overrides and catalog."""
+    """Resolve the effective weight for an item instance."""
 
-    raw = inst.get("weight")
-    if raw is None and tpl:
-        for key in ("weight", "weight_lbs", "lbs"):
-            if key in tpl:
-                raw = tpl.get(key)
-                if raw is not None:
-                    break
-    return _coerce_weight(raw)
+    weight = get_effective_weight(inst, tpl)
+    return _coerce_weight(weight)
 
 
 def inv_cmd(arg: str, ctx):
@@ -56,7 +51,7 @@ def inv_cmd(arg: str, ctx):
 
         weight = _resolve_weight(inst, tpl or {})
         if weight is not None:
-            total_weight += weight
+            total_weight += max(0, weight)
 
     numbered = number_duplicates(names)
     display = [harden_final_display(with_article(n)) for n in numbered]

--- a/src/mutants/commands/wield.py
+++ b/src/mutants/commands/wield.py
@@ -7,7 +7,7 @@ from ..registries import items_instances as itemsreg
 from ..services import item_transfer as itx
 from ..services import player_state as pstate
 from ..services.equip_debug import _edbg_enabled, _edbg_log
-from ..services.items_weight import effective_weight
+from ..services.items_weight import get_effective_weight
 from .convert import _choose_inventory_item, _display_name
 from .wear import _bag_count, _catalog_template, _pos_repr
 
@@ -103,7 +103,7 @@ def wield_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
 
     inst = itemsreg.get_instance(iid) or {}
     template = _catalog_template(catalog, item_id)
-    weight = max(0, effective_weight(inst, template))
+    weight = max(0, get_effective_weight(inst, template))
     required = weight // 5
     name = _display_name(item_id, catalog)
 

--- a/tests/test_item_transfer_pickup.py
+++ b/tests/test_item_transfer_pickup.py
@@ -1,0 +1,125 @@
+import copy
+
+import pytest
+
+from mutants.services import item_transfer as itx
+
+
+@pytest.fixture
+def pickup_env(monkeypatch):
+    ground: list[str] = []
+    instances: dict[str, dict[str, object]] = {}
+    catalog: dict[str, dict[str, object]] = {}
+    stats: dict[str, int] = {"str": 10}
+
+    player = {
+        "inventory": [],
+        "class": "Fighter",
+        "active": {"class": "Fighter", "inventory": [], "pos": [2000, 1, 1]},
+        "bags": {"Fighter": []},
+    }
+
+    ctx = {
+        "player_state": {
+            "active_id": "p1",
+            "players": [{"id": "p1", "pos": [2000, 1, 1]}],
+        }
+    }
+
+    def fake_load_player():
+        itx._STATE_CACHE = {"stats": copy.deepcopy(stats)}
+        return player
+
+    monkeypatch.setattr(itx, "_load_player", fake_load_player)
+    monkeypatch.setattr(itx, "_save_player", lambda _player: None)
+    monkeypatch.setattr(itx.pstate, "ensure_active_profile", lambda *args, **kwargs: None)
+    monkeypatch.setattr(itx.pstate, "bind_inventory_to_active_class", lambda *args, **kwargs: None)
+    monkeypatch.setattr(itx.pstate, "get_stats_for_active", lambda _state: dict(stats))
+    monkeypatch.setattr(itx.pstate, "load_state", lambda: {"stats": dict(stats)})
+    monkeypatch.setattr(itx.pstate, "save_state", lambda _state: None)
+
+    monkeypatch.setattr(itx.items_probe, "enabled", lambda: False)
+    monkeypatch.setattr(itx.items_probe, "probe", lambda *args, **kwargs: None)
+    monkeypatch.setattr(itx.items_probe, "setup_file_logging", lambda: None)
+    monkeypatch.setattr(itx.items_probe, "dump_tile_instances", lambda *args, **kwargs: None)
+    monkeypatch.setattr(itx.items_probe, "find_all", lambda *args, **kwargs: None)
+
+    def list_instances_at(_year: int, _x: int, _y: int):
+        return [copy.deepcopy(instances[iid]) for iid in ground if iid in instances]
+
+    def clear_position_at(iid: str, _year: int, _x: int, _y: int) -> bool:
+        try:
+            ground.remove(iid)
+            return True
+        except ValueError:
+            return False
+
+    def clear_position(iid: str) -> bool:
+        if iid in ground:
+            ground.remove(iid)
+            return True
+        return False
+
+    def set_position(iid: str, _year: int, _x: int, _y: int) -> None:
+        if iid in instances and iid not in ground:
+            ground.append(iid)
+
+    monkeypatch.setattr(itx.itemsreg, "list_instances_at", list_instances_at)
+    monkeypatch.setattr(itx.itemsreg, "clear_position_at", clear_position_at)
+    monkeypatch.setattr(itx.itemsreg, "clear_position", clear_position)
+    monkeypatch.setattr(itx.itemsreg, "set_position", set_position)
+    monkeypatch.setattr(itx.itemsreg, "save_instances", lambda: None)
+    monkeypatch.setattr(itx.itemsreg, "get_instance", lambda iid: copy.deepcopy(instances.get(iid)))
+
+    def add_ground_item(iid: str, item_id: str, *, weight: int, enchant_level: int = 0):
+        inst = {
+            "iid": iid,
+            "instance_id": iid,
+            "item_id": item_id,
+            "enchant_level": enchant_level,
+            "weight": weight,
+        }
+        instances[iid] = inst
+        if iid not in ground:
+            ground.append(iid)
+        catalog[item_id] = {"name": item_id.replace("_", " ").title(), "weight": weight}
+
+    monkeypatch.setattr(itx.catreg, "load_catalog", lambda: catalog)
+
+    def set_strength(value: int) -> None:
+        stats["str"] = value
+
+    return {
+        "ctx": ctx,
+        "player": player,
+        "add_ground_item": add_ground_item,
+        "set_strength": set_strength,
+        "catalog": catalog,
+        "ground": ground,
+        "instances": instances,
+        "stats": stats,
+    }
+
+
+def test_pickup_strength_gate_blocks_when_too_heavy(pickup_env):
+    pickup_env["add_ground_item"]("colossus#ground", "colossus", weight=160, enchant_level=0)
+    pickup_env["set_strength"](15)
+
+    result = itx.pick_from_ground(pickup_env["ctx"], "col")
+
+    assert result["ok"] is False
+    assert result["reason"] == "insufficient_strength"
+    assert result["message"] == "You don't have enough strength to pick that up!"
+    assert pickup_env["player"]["inventory"] == []
+    assert pickup_env["ground"] == ["colossus#ground"]
+
+
+def test_pickup_strength_gate_respects_enchant_reduction(pickup_env):
+    pickup_env["add_ground_item"]("warhammer#ground", "warhammer", weight=40, enchant_level=2)
+    pickup_env["set_strength"](2)
+
+    result = itx.pick_from_ground(pickup_env["ctx"], "war")
+
+    assert result["ok"] is True
+    assert pickup_env["player"]["inventory"] == ["warhammer#ground"]
+    assert pickup_env["ground"] == []

--- a/tests/test_items_weight.py
+++ b/tests/test_items_weight.py
@@ -1,0 +1,29 @@
+from mutants.services.items_weight import get_effective_weight
+
+
+def test_get_effective_weight_uses_template_weight():
+    inst = {"item_id": "test", "enchant_level": 0}
+    template = {"weight": 30}
+
+    assert get_effective_weight(inst, template) == 30
+
+
+def test_get_effective_weight_reduces_weight_with_enchants():
+    inst = {"item_id": "test", "enchant_level": 2}
+    template = {"weight": 40}
+
+    assert get_effective_weight(inst, template) == 20
+
+
+def test_get_effective_weight_respects_minimum_floor():
+    inst = {"item_id": "test", "enchant_level": 4}
+    template = {"weight": 40}
+
+    assert get_effective_weight(inst, template) == 10
+
+
+def test_get_effective_weight_leaves_light_items_unmodified():
+    inst = {"item_id": "test", "enchant_level": 3}
+    template = {"weight": 8}
+
+    assert get_effective_weight(inst, template) == 8


### PR DESCRIPTION
## Summary
- introduce `get_effective_weight` to compute enchant-aware item weight with a 10 lb floor
- use effective weights when enforcing wear, wield, and pickup strength gates and when summing inventory totals
- add focused tests covering enchanted equipment handling, pickup gating, and inventory totals

## Testing
- pytest tests/test_item_transfer_pickup.py
- pytest tests/test_commands_wear_remove.py tests/test_commands_wield.py tests/test_items_weight.py tests_legacy/commands/test_inv_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d18b194924832b864eeafa125d1824