### PR TITLE
Implement enchantment item bonuses and registry updates

### DIFF
--- a/src/mutants/commands/convert.py
+++ b/src/mutants/commands/convert.py
@@ -67,6 +67,27 @@ def _convert_value(item_id: str, catalog: Any) -> int:
     return 0
 
 
+def _enchant_convert_bonus(level: int) -> int:
+    try:
+        normalized = int(level)
+    except (TypeError, ValueError):
+        normalized = 0
+    if normalized <= 0:
+        return 0
+    return 10100 * normalized
+
+
+def _convert_payout(iid: str, item_id: str, catalog: Any) -> int:
+    base_value = _convert_value(item_id, catalog)
+    if not iid:
+        return base_value
+    try:
+        level = itemsreg.get_enchant_level(iid)
+    except Exception:
+        level = 0
+    return base_value + _enchant_convert_bonus(level)
+
+
 def _choose_inventory_item(
     player: Dict[str, object],
     prefix: str,
@@ -127,7 +148,7 @@ def convert_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
         bus.push("SYSTEM/WARN", f"You're not carrying a {prefix}.")
         return {"ok": False, "reason": "not_found"}
 
-    value = _convert_value(item_id, catalog)
+    value = _convert_payout(iid, item_id, catalog)
 
     before = _legacy_ions(player)
     klass = pstate.get_active_class(player)

--- a/src/mutants/services/combat_calc.py
+++ b/src/mutants/services/combat_calc.py
@@ -44,7 +44,9 @@ def armour_class_from_equipped(state) -> int:
     if not template:
         return 0
 
-    return max(0, _coerce_int(template.get("armour_class")))
+    enchant_level = itemsreg.get_enchant_level(armour_iid)
+    base_ac = max(0, _coerce_int(template.get("armour_class")))
+    return base_ac + max(0, enchant_level)
 
 
 def dex_bonus_for_active(state) -> int:

--- a/tests/test_combat_calc.py
+++ b/tests/test_combat_calc.py
@@ -48,6 +48,7 @@ def test_armour_class_with_equipped_instance(monkeypatch):
 
     monkeypatch.setattr(combat_calc.itemsreg, "get_instance", fake_get_instance)
     monkeypatch.setattr(combat_calc.items_catalog, "load_catalog", lambda: dummy_catalog)
+    monkeypatch.setattr(combat_calc.itemsreg, "get_enchant_level", lambda _: 0)
 
     assert combat_calc.armour_class_from_equipped(state) == 2
     assert combat_calc.armour_class_for_active(state) == 4
@@ -63,3 +64,21 @@ def test_armour_class_from_direct_template(monkeypatch):
 
     assert combat_calc.armour_class_from_equipped(state) == 1
     assert combat_calc.armour_class_for_active(state) == 1
+
+
+def test_armour_class_adds_enchant_bonus(monkeypatch):
+    state = _base_state(dex=10, armour="armour#2")
+
+    def fake_get_instance(iid: str):
+        if iid == "armour#2":
+            return {"iid": iid, "item_id": "chain_mail"}
+        return None
+
+    dummy_catalog = DummyCatalog({"chain_mail": {"armour_class": 3}})
+
+    monkeypatch.setattr(combat_calc.itemsreg, "get_instance", fake_get_instance)
+    monkeypatch.setattr(combat_calc.items_catalog, "load_catalog", lambda: dummy_catalog)
+    monkeypatch.setattr(combat_calc.itemsreg, "get_enchant_level", lambda iid: 3 if iid == "armour#2" else 0)
+
+    assert combat_calc.armour_class_from_equipped(state) == 6
+    assert combat_calc.armour_class_for_active(state) == 7

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict
+
+from mutants.commands import convert
+
+
+def _catalog(meta: Dict[str, Dict[str, Any]]):
+    class DummyCatalog:
+        def __init__(self, data: Dict[str, Dict[str, Any]]):
+            self._data = data
+
+        def get(self, item_id: str):
+            return self._data.get(item_id)
+
+    return DummyCatalog(meta)
+
+
+def test_convert_payout_uses_enchant_bonus(monkeypatch):
+    monkeypatch.setattr(convert.itemsreg, "get_enchant_level", lambda iid: 2 if iid == "knife#1" else 0)
+
+    catalog = _catalog({"knife": {"convert_ions": 14000}})
+
+    payout = convert._convert_payout("knife#1", "knife", catalog)
+
+    assert payout == 14000 + 2 * 10100
+
+
+def test_convert_payout_handles_missing_instance(monkeypatch):
+    monkeypatch.setattr(convert.itemsreg, "get_enchant_level", lambda _: 0)
+
+    catalog = _catalog({"knife": {"convert_ions": 14000}})
+
+    payout = convert._convert_payout("", "knife", catalog)
+
+    assert payout == 14000

--- a/tests/test_items_instances.py
+++ b/tests/test_items_instances.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from mutants.registries import items_instances
+
+
+class DummyCatalog:
+    def __init__(self, data: Dict[str, Dict[str, Any]]):
+        self._data = data
+
+    def get(self, item_id: str):
+        return self._data.get(item_id)
+
+
+def test_create_instance_copies_god_tier_flag(tmp_path):
+    registry = items_instances.ItemsInstances(str(tmp_path / "instances.json"), [])
+    inst = registry.create_instance({"item_id": "holy_blade", "god_tier": True})
+
+    assert inst["god_tier"] is True
+    stored = registry.get(inst["instance_id"])
+    assert stored is not None
+    assert stored["god_tier"] is True
+
+
+def test_normalize_instance_defaults_god_tier(tmp_path):
+    inst_data = [
+        {"instance_id": "axe#1", "item_id": "axe", "god_tier": "no"},
+        {"instance_id": "mace#1", "item_id": "mace"},
+    ]
+
+    registry = items_instances.ItemsInstances(str(tmp_path / "instances.json"), inst_data)
+
+    first = registry.get("axe#1")
+    second = registry.get("mace#1")
+
+    assert first is not None and first["god_tier"] is False
+    assert second is not None and second["god_tier"] is False
+
+
+@pytest.fixture
+def _memory_instances(monkeypatch) -> List[Dict[str, Any]]:
+    data: List[Dict[str, Any]] = []
+
+    def fake_cache() -> List[Dict[str, Any]]:
+        return data
+
+    monkeypatch.setattr(items_instances, "_cache", fake_cache)
+    monkeypatch.setattr(items_instances, "_save_instances_raw", lambda _: None)
+
+    return data
+
+
+def test_enchant_blockers_detect_condition_and_level(monkeypatch, _memory_instances):
+    _memory_instances.append(
+        {
+            "iid": "knife#1",
+            "instance_id": "knife#1",
+            "item_id": "knife",
+            "condition": 75,
+            "enchant_level": 150,
+        }
+    )
+
+    monkeypatch.setattr(
+        items_instances.items_catalog,
+        "load_catalog",
+        lambda: DummyCatalog({"knife": {"item_id": "knife"}}),
+    )
+
+    blockers = items_instances.enchant_blockers_for("knife#1")
+
+    assert "condition" in blockers
+    assert "max_enchant" in blockers
+    assert not items_instances.is_enchantable("knife#1")
+
+
+def test_enchant_blockers_detect_catalog_flags(monkeypatch, _memory_instances):
+    _memory_instances.append(
+        {
+            "iid": "wand#1",
+            "instance_id": "wand#1",
+            "item_id": "wand",
+            "condition": 100,
+            "enchant_level": 0,
+        }
+    )
+
+    template = {
+        "item_id": "wand",
+        "ranged": True,
+        "potion": True,
+        "spawnable": True,
+        "spell_component": True,
+    }
+
+    monkeypatch.setattr(
+        items_instances.items_catalog, "load_catalog", lambda: DummyCatalog({"wand": template})
+    )
+
+    blockers = items_instances.enchant_blockers_for("wand#1")
+
+    for reason in ("ranged", "potion", "spawnable", "spell_component"):
+        assert reason in blockers
+
+
+def test_enchant_blockers_detect_broken(monkeypatch, _memory_instances):
+    _memory_instances.append(
+        {
+            "iid": "broke#1",
+            "instance_id": "broke#1",
+            "item_id": items_instances.BROKEN_WEAPON_ID,
+        }
+    )
+
+    monkeypatch.setattr(
+        items_instances.items_catalog, "load_catalog", lambda: DummyCatalog({})
+    )
+
+    blockers = items_instances.enchant_blockers_for("broke#1")
+
+    assert "broken" in blockers
+    assert "condition" not in blockers


### PR DESCRIPTION
## Summary
- add armour enchantment bonuses to AC and include enchant-level payouts when converting items
- codify not-enchantable item categories, track the god_tier flag, and expose helpers for future spell checks
- cover the new behaviour with dedicated unit tests for conversions, enchantment blockers, and armour bonuses

## Testing
- pytest
- pytest tests/test_combat_calc.py

------
https://chatgpt.com/codex/tasks/task_e_68d1942b8d20832bbd6aeb5490645374