### PR TITLE
Adjust convert payouts for enchant levels

### DIFF
--- a/src/mutants/commands/convert.py
+++ b/src/mutants/commands/convert.py
@@ -54,17 +54,30 @@ def _display_name(item_id: str, catalog: Any) -> str:
     return str(meta.get("display") or meta.get("name") or item_id)
 
 
-def _convert_value(item_id: str, catalog: Any) -> int:
+def _convert_value(item_id: str, catalog: Any, iid: Optional[str] = None) -> int:
     meta = _resolve_meta(catalog, item_id)
     if not meta:
         return 0
     for key in ("convert_ions", "ion_value", "value"):
         if key in meta:
             try:
-                return int(meta[key])
+                base_value = int(meta[key])
             except Exception:
                 return 0
-    return 0
+            else:
+                break
+    else:
+        return 0
+
+    if not iid:
+        return base_value
+
+    try:
+        level = itemsreg.get_enchant_level(iid)
+    except Exception:
+        level = 0
+
+    return base_value + _enchant_convert_bonus(level)
 
 
 def _enchant_convert_bonus(level: int) -> int:
@@ -78,14 +91,7 @@ def _enchant_convert_bonus(level: int) -> int:
 
 
 def _convert_payout(iid: str, item_id: str, catalog: Any) -> int:
-    base_value = _convert_value(item_id, catalog)
-    if not iid:
-        return base_value
-    try:
-        level = itemsreg.get_enchant_level(iid)
-    except Exception:
-        level = 0
-    return base_value + _enchant_convert_bonus(level)
+    return _convert_value(item_id, catalog, iid if iid else None)
 
 
 def _choose_inventory_item(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -14,14 +14,14 @@ def _catalog(meta: Dict[str, Dict[str, Any]]):
     return DummyCatalog(meta)
 
 
-def test_convert_payout_uses_enchant_bonus(monkeypatch):
-    monkeypatch.setattr(convert.itemsreg, "get_enchant_level", lambda iid: 2 if iid == "knife#1" else 0)
+def test_convert_value_uses_enchant_bonus(monkeypatch):
+    levels = {"knife#2": 2, "knife#3": 3}
+    monkeypatch.setattr(convert.itemsreg, "get_enchant_level", lambda iid: levels.get(iid, 0))
 
     catalog = _catalog({"knife": {"convert_ions": 14000}})
 
-    payout = convert._convert_payout("knife#1", "knife", catalog)
-
-    assert payout == 14000 + 2 * 10100
+    assert convert._convert_value("knife", catalog, "knife#2") == 34200
+    assert convert._convert_value("knife", catalog, "knife#3") == 44300
 
 
 def test_convert_payout_handles_missing_instance(monkeypatch):
@@ -32,3 +32,13 @@ def test_convert_payout_handles_missing_instance(monkeypatch):
     payout = convert._convert_payout("", "knife", catalog)
 
     assert payout == 14000
+
+
+def test_convert_payout_handles_mixed_enchant_levels(monkeypatch):
+    levels = {"knife_plain": 0, "knife_plus3": 3}
+    monkeypatch.setattr(convert.itemsreg, "get_enchant_level", lambda iid: levels.get(iid, 0))
+
+    catalog = _catalog({"knife": {"convert_ions": 14000}})
+
+    assert convert._convert_payout("knife_plain", "knife", catalog) == 14000
+    assert convert._convert_payout("knife_plus3", "knife", catalog) == 44300


### PR DESCRIPTION
## Summary
- make convert value instance-aware so enchantment levels add 10,100 ions each
- extend convert tests to cover mixed enchant payouts and updated value helper

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d19c245c54832b9d40e9751730f7e8