### PR TITLE
Add monster import CLI and validation

### DIFF
--- a/scripts/import_monsters.py
+++ b/scripts/import_monsters.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Bulk import monsters from a generator JSON payload."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from mutants.services import monsters_state
+from mutants.services.monsters_importer import (
+    MonsterImportError,
+    print_report,
+    run_import,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Import monsters into the game state.")
+    parser.add_argument("input_path", help="Path to the generator JSON file (array of monsters).")
+    parser.add_argument(
+        "--state-path",
+        default=str(monsters_state.DEFAULT_MONSTERS_PATH),
+        help="Target monsters state path (defaults to state/monsters/instances.json).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and show the summary without writing any changes.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    input_path = Path(args.input_path)
+    state_path = Path(args.state_path)
+
+    try:
+        report = run_import(input_path, dry_run=args.dry_run, state_path=state_path)
+    except MonsterImportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print_report(report, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mutants/services/monsters_importer.py
+++ b/src/mutants/services/monsters_importer.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set, TextIO
+
+from mutants.io.atomic import atomic_write_json
+from mutants.services import monsters_state
+
+
+@dataclass
+class RecordResult:
+    index: int
+    label: str
+    status: str = "OK"
+    messages: List[str] = field(default_factory=list)
+    source_id: Optional[str] = None
+    final_id: Optional[str] = None
+    pinned_years: List[int] = field(default_factory=list)
+    minted_iids: int = 0
+
+
+@dataclass
+class ImportReport:
+    records: List[RecordResult]
+    normalized_new: List[Dict[str, Any]]
+    combined_payload: List[Dict[str, Any]]
+    per_year: Dict[int, int]
+    minted_iids: int
+
+    @property
+    def imported_count(self) -> int:
+        return sum(1 for r in self.records if r.status == "OK")
+
+    @property
+    def rejected_count(self) -> int:
+        return sum(1 for r in self.records if r.status != "OK")
+
+
+class MonsterImportError(Exception):
+    """Raised when the import payload is malformed."""
+
+
+def _load_input(path: Path) -> List[Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:  # pragma: no cover - explicit signal to caller
+        raise MonsterImportError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - explicit signal to caller
+        raise MonsterImportError(f"Invalid JSON in {path}: {exc}") from exc
+
+    if isinstance(raw, Mapping) and "monsters" in raw:
+        candidates = raw.get("monsters")
+    else:
+        candidates = raw
+
+    if not isinstance(candidates, list):
+        raise MonsterImportError("Monster import payload must be a JSON array.")
+
+    return list(candidates)
+
+
+def _extract_item_id(item: Mapping[str, Any]) -> str:
+    for key in ("item_id", "id", "catalog_id"):
+        raw = item.get(key)
+        if isinstance(raw, str) and raw:
+            return raw
+    return ""
+
+
+def _collect_item_iids(record: Mapping[str, Any]) -> Set[str]:
+    iids: Set[str] = set()
+    bag = record.get("bag")
+    if isinstance(bag, Iterable):
+        for item in bag:
+            if not isinstance(item, Mapping):
+                continue
+            iid = item.get("iid") or item.get("instance_id")
+            if isinstance(iid, str) and iid:
+                iids.add(iid)
+    armour = record.get("armour_slot")
+    if isinstance(armour, Mapping):
+        iid = armour.get("iid") or armour.get("instance_id")
+        if isinstance(iid, str) and iid:
+            iids.add(iid)
+    return iids
+
+
+def _normalize_label(payload: Mapping[str, Any], idx: int) -> str:
+    label = (
+        payload.get("name")
+        or payload.get("monster_id")
+        or payload.get("id")
+        or f"record#{idx}"
+    )
+    return str(label)
+
+
+def _validate_record(
+    payload: Any,
+    *,
+    idx: int,
+    existing_ids: Set[str],
+    file_ids: Set[str],
+) -> tuple[Optional[Dict[str, Any]], RecordResult, Set[str]]:
+    result = RecordResult(index=idx, label=_normalize_label(payload if isinstance(payload, Mapping) else {}, idx))
+
+    if not isinstance(payload, Mapping):
+        result.status = "ERROR"
+        result.messages.append("Entry must be an object.")
+        return None, result, set()
+
+    record: Dict[str, Any] = dict(payload)
+    bag_raw = record.get("bag")
+    errors: List[str] = []
+    notes: List[str] = []
+
+    pinned_years_raw = record.get("pinned_years")
+    normalized_years: List[int] = []
+    has_any_years = isinstance(pinned_years_raw, list) and bool(pinned_years_raw)
+    if has_any_years:
+        for entry in pinned_years_raw:
+            coerced = _coerce_int(entry)
+            if coerced is None:
+                notes.append(f"ignored pinned_year value: {entry}")
+                continue
+            normalized_years.append(coerced)
+
+    if not normalized_years:
+        if has_any_years:
+            errors.append("no valid pinned_years")
+        else:
+            errors.append("pinned_years missing or empty")
+
+    record["pinned_years"] = normalized_years
+    result.pinned_years = list(normalized_years)
+
+    bag_items: List[Dict[str, Any]] = []
+    if bag_raw is None:
+        record["bag"] = []
+    elif not isinstance(bag_raw, list):
+        errors.append("bag must be an array")
+    else:
+        for pos, item in enumerate(bag_raw):
+            if not isinstance(item, Mapping):
+                errors.append(f"bag[{pos}] must be an object")
+                continue
+            item_dict = dict(item)
+            if not _extract_item_id(item_dict):
+                errors.append(f"bag[{pos}] missing item_id")
+                continue
+            bag_items.append(item_dict)
+        record["bag"] = bag_items
+
+    armour_raw = record.get("armour_slot")
+    armour_item: Optional[Dict[str, Any]] = None
+    if armour_raw is None or armour_raw is False:
+        record["armour_slot"] = None
+    elif not isinstance(armour_raw, Mapping):
+        errors.append("armour_slot must be an object or null")
+        record["armour_slot"] = None
+    else:
+        armour_item = dict(armour_raw)
+        if not _extract_item_id(armour_item):
+            errors.append("armour_slot missing item_id")
+            armour_item = None
+        record["armour_slot"] = armour_item
+
+    if armour_item and bag_items:
+        armour_key = armour_item.get("iid") or armour_item.get("item_id")
+        if isinstance(armour_key, str) and armour_key:
+            filtered: List[Dict[str, Any]] = []
+            removed = False
+            for item in bag_items:
+                key = item.get("iid") or item.get("item_id")
+                if key == armour_key:
+                    removed = True
+                    continue
+                filtered.append(item)
+            if removed:
+                notes.append("removed armour_slot item from bag")
+                record["bag"] = filtered
+                bag_items = filtered
+
+    valid_iids = {item.get("iid") for item in bag_items if isinstance(item, Mapping) and isinstance(item.get("iid"), str) and item.get("iid")}
+    valid_item_ids = {_extract_item_id(item) for item in bag_items if isinstance(item, Mapping)}
+
+    wielded_raw = record.get("wielded")
+    if wielded_raw is None or wielded_raw == "":
+        record["wielded"] = None
+    elif isinstance(wielded_raw, str):
+        if wielded_raw in valid_iids or wielded_raw in valid_item_ids:
+            record["wielded"] = wielded_raw
+        else:
+            record["wielded"] = None
+            notes.append(f"wielded cleared (not in bag: {wielded_raw})")
+    else:
+        record["wielded"] = None
+        notes.append("wielded cleared (invalid type)")
+
+    raw_id = record.get("id")
+    if isinstance(raw_id, str) and raw_id:
+        candidate_id = raw_id
+        if candidate_id in existing_ids:
+            errors.append(f"duplicate id (existing): {candidate_id}")
+        elif candidate_id in file_ids:
+            errors.append(f"duplicate id: {candidate_id}")
+        else:
+            file_ids.add(candidate_id)
+            result.source_id = candidate_id
+    elif raw_id is not None:
+        # Normalize non-string ids by coercing to string for downstream normalization.
+        candidate_id = str(raw_id)
+        if candidate_id in existing_ids or candidate_id in file_ids:
+            errors.append(f"duplicate id: {candidate_id}")
+        else:
+            file_ids.add(candidate_id)
+            result.source_id = candidate_id
+            record["id"] = candidate_id
+    else:
+        record.pop("id", None)
+
+    if errors:
+        result.status = "ERROR"
+        result.messages = errors
+        return None, result, set()
+
+    if notes:
+        result.messages.extend(notes)
+
+    return record, result, _collect_item_iids(record)
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _count_minted_iids(original: Set[str], normalized: Mapping[str, Any]) -> int:
+    new = _collect_item_iids(normalized)
+    return len(new - original)
+
+
+def run_import(
+    input_path: Path,
+    *,
+    dry_run: bool,
+    state_path: Path | None = None,
+) -> ImportReport:
+    entries = _load_input(input_path)
+
+    target_path = Path(state_path) if state_path is not None else monsters_state.DEFAULT_MONSTERS_PATH
+    state = monsters_state.load_state(target_path)
+    existing_monsters = [dict(m) for m in state.list_all()]
+    existing_ids: Set[str] = {
+        str(m["id"])
+        for m in existing_monsters
+        if isinstance(m, Mapping) and m.get("id")
+    }
+
+    file_ids: Set[str] = set()
+    records: List[RecordResult] = []
+    valid_records: List[Dict[str, Any]] = []
+    valid_results: List[RecordResult] = []
+    original_iids: List[Set[str]] = []
+
+    for idx, payload in enumerate(entries):
+        record, result, orig_iids = _validate_record(
+            payload,
+            idx=idx,
+            existing_ids=existing_ids,
+            file_ids=file_ids,
+        )
+        records.append(result)
+        if record is None:
+            continue
+        valid_records.append(record)
+        valid_results.append(result)
+        original_iids.append(orig_iids)
+
+    try:
+        catalog = monsters_state.items_catalog.load_catalog()
+    except FileNotFoundError:
+        catalog = {}
+
+    combined = existing_monsters + valid_records
+    normalized_all = monsters_state.normalize_records(combined, catalog=catalog)
+    normalized_new = normalized_all[len(existing_monsters) :]
+
+    minted_total = 0
+    for idx, normalized in enumerate(normalized_new):
+        result = valid_results[idx]
+        result.final_id = str(normalized.get("id") or "") or None
+        result.pinned_years = list(normalized.get("pinned_years") or [])
+        minted = _count_minted_iids(original_iids[idx], normalized)
+        result.minted_iids = minted
+        minted_total += minted
+        if result.status == "OK":
+            if result.source_id and result.final_id and result.source_id != result.final_id:
+                result.messages.append(f"id normalized to {result.final_id}")
+            if not result.source_id and result.final_id:
+                result.messages.append(f"id minted as {result.final_id}")
+            if minted:
+                suffix = "iid" if minted == 1 else "iids"
+                result.messages.append(f"minted {minted} {suffix}")
+
+    per_year_counter: Dict[int, int] = defaultdict(int)
+    for normalized in normalized_new:
+        years = normalized.get("pinned_years")
+        if isinstance(years, Iterable):
+            for year in years:
+                coerced = _coerce_int(year)
+                if coerced is not None:
+                    per_year_counter[coerced] += 1
+
+    per_year = dict(sorted(per_year_counter.items()))
+
+    report = ImportReport(
+        records=records,
+        normalized_new=normalized_new,
+        combined_payload=normalized_all,
+        per_year=per_year,
+        minted_iids=minted_total,
+    )
+
+    if not dry_run:
+        payload = {"monsters": report.combined_payload}
+        atomic_write_json(target_path, payload)
+        monsters_state.invalidate_cache()
+
+    return report
+
+
+def format_report_table(records: List[RecordResult]) -> str:
+    headers = ["#", "Monster", "Status", "ID", "Notes"]
+    rows: List[List[str]] = []
+    for rec in records:
+        ident = rec.final_id or rec.source_id or ""
+        notes = "; ".join(rec.messages)
+        rows.append([
+            str(rec.index),
+            rec.label,
+            rec.status,
+            ident,
+            notes,
+        ])
+
+    widths = [len(col) for col in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    header_line = " | ".join(headers[idx].ljust(widths[idx]) for idx in range(len(headers)))
+    separator = "-+-".join("-" * widths[idx] for idx in range(len(headers)))
+    data_lines = [
+        " | ".join(row[idx].ljust(widths[idx]) for idx in range(len(headers)))
+        for row in rows
+    ]
+
+    if rows:
+        return "\n".join([header_line, separator, *data_lines])
+    return header_line
+
+
+def print_report(report: ImportReport, *, dry_run: bool, out: TextIO = sys.stdout) -> None:
+    table = format_report_table(report.records)
+    print(table, file=out)
+    print(file=out)
+
+    if report.imported_count:
+        print(f"Imported {report.imported_count} monster(s).", file=out)
+        if report.per_year:
+            print("Per year:", file=out)
+            for year, count in report.per_year.items():
+                print(f"  {year}: {count}", file=out)
+        print(f"Minted {report.minted_iids} item IID(s).", file=out)
+
+    if report.rejected_count:
+        print(f"Rejected {report.rejected_count} monster(s).", file=out)
+
+    if dry_run:
+        print("Dry-run: no changes were written.", file=out)

--- a/src/mutants/services/monsters_state.py
+++ b/src/mutants/services/monsters_state.py
@@ -448,3 +448,33 @@ def invalidate_cache() -> None:
     _CACHE = None
     _CACHE_PATH = None
     _CACHE_MTIME = None
+
+
+def normalize_records(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    catalog: Mapping[str, Any] | None = None,
+) -> List[Dict[str, Any]]:
+    """Normalize raw monster records using the same rules as ``load_state``.
+
+    Parameters
+    ----------
+    records:
+        Iterable of raw monster records (dict-like objects).
+    catalog:
+        Optional item catalog mapping used to derive armour/weapon payloads.
+        If omitted the catalog will be loaded via ``items_catalog``.
+
+    Returns
+    -------
+    list of dict
+        Normalized monsters ready for persistence.
+    """
+
+    if catalog is None:
+        try:
+            catalog = items_catalog.load_catalog()
+        except FileNotFoundError:
+            catalog = {}
+
+    return _normalize_monsters([dict(m) for m in records], catalog=catalog)

--- a/tests/test_monsters_importer.py
+++ b/tests/test_monsters_importer.py
@@ -1,0 +1,146 @@
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from mutants.services import monsters_state
+from mutants.services import monsters_importer
+
+
+@pytest.fixture(autouse=True)
+def _clear_monsters_cache():
+    monsters_state.invalidate_cache()
+    yield
+    monsters_state.invalidate_cache()
+
+
+def _write_state(path: Path, monsters: list[dict]) -> None:
+    payload = {"monsters": monsters}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_import_monsters_dry_run_reports_summary(tmp_path, monkeypatch):
+    catalog = {
+        "club": {"item_id": "club", "base_power": 3, "weight": 10},
+        "cloak": {"item_id": "cloak", "armour": True, "armour_class": 1, "weight": 5},
+    }
+    monkeypatch.setattr(monsters_state.items_catalog, "load_catalog", lambda: catalog)
+
+    payload = [
+        {
+            "name": "Bandit",
+            "bag": [{"item_id": "club", "enchant_level": 0}],
+            "armour_slot": {"item_id": "cloak"},
+            "wielded": "club",
+            "hp": {"current": 5, "max": 5},
+            "stats": {"str": 12, "dex": 9},
+            "pinned_years": ["2000"],
+        },
+        {
+            "name": "Broken",
+            "hp": {"current": 1, "max": 1},
+            "stats": {"str": 5},
+            "bag": [],
+        },
+    ]
+
+    input_path = tmp_path / "monsters.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    state_path = tmp_path / "instances.json"
+
+    report = monsters_importer.run_import(input_path, dry_run=True, state_path=state_path)
+
+    assert report.imported_count == 1
+    assert report.rejected_count == 1
+    assert report.per_year == {2000: 1}
+    assert report.minted_iids >= 1
+    assert not state_path.exists()
+
+    rendered = io.StringIO()
+    monsters_importer.print_report(report, dry_run=True, out=rendered)
+    text = rendered.getvalue()
+    assert "Dry-run" in text
+    assert "minted" in text
+    assert "missing" in text or "no valid" in text
+
+
+def test_import_monsters_real_run_persists_and_normalizes(tmp_path, monkeypatch):
+    catalog = {
+        "club": {"item_id": "club", "base_power": 3, "weight": 10},
+    }
+    monkeypatch.setattr(monsters_state.items_catalog, "load_catalog", lambda: catalog)
+
+    payload = [
+        {
+            "id": "bandit#1",
+            "name": "Bandit",
+            "bag": [{"item_id": "club"}],
+            "wielded": "missing",
+            "hp": {"current": 4, "max": 4},
+            "stats": {"str": 11, "dex": 8},
+            "pinned_years": [2001],
+        }
+    ]
+
+    input_path = tmp_path / "monsters.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    state_path = tmp_path / "instances.json"
+
+    report = monsters_importer.run_import(input_path, dry_run=False, state_path=state_path)
+
+    assert state_path.exists()
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    monsters = saved["monsters"]
+    assert len(monsters) == 1
+    monster = monsters[0]
+    assert monster["id"] == "bandit#1"
+    bag_iid = monster["bag"][0]["iid"]
+    assert bag_iid
+    assert monster["wielded"] == bag_iid
+    assert report.imported_count == 1
+    assert report.minted_iids >= 1
+    assert any("wielded cleared" in msg for msg in report.records[0].messages)
+
+
+def test_import_monsters_rejects_duplicate_id(tmp_path, monkeypatch):
+    catalog = {"club": {"item_id": "club", "base_power": 3, "weight": 10}}
+    monkeypatch.setattr(monsters_state.items_catalog, "load_catalog", lambda: catalog)
+
+    existing = [
+        {
+            "id": "bandit#1",
+            "name": "Bandit",
+            "bag": [],
+            "hp": {"current": 5, "max": 5},
+            "stats": {"str": 10},
+            "pinned_years": [1999],
+        }
+    ]
+    state_path = tmp_path / "instances.json"
+    _write_state(state_path, existing)
+
+    payload = [
+        {
+            "id": "bandit#1",
+            "name": "Duplicate",
+            "bag": [],
+            "hp": {"current": 5, "max": 5},
+            "stats": {"str": 10},
+            "pinned_years": [2005],
+        }
+    ]
+
+    input_path = tmp_path / "monsters.json"
+    input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = monsters_importer.run_import(input_path, dry_run=True, state_path=state_path)
+
+    assert report.imported_count == 0
+    assert report.rejected_count == 1
+    assert any("duplicate" in msg for msg in report.records[0].messages)
+
+    saved_after = json.loads(state_path.read_text(encoding="utf-8"))
+    assert len(saved_after["monsters"]) == 1


### PR DESCRIPTION
## Summary
- add a CLI script to import generator monster payloads with --dry-run support and reporting
- build a monsters_importer service that validates records, clears bad wielded values, mints IDs, normalizes via monsters_state, and persists when not a dry run
- expose a normalize_records helper on monsters_state and cover the importer with targeted pytest cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2a52adca4832b88f23a3e5c503e13