### PR TITLE
Add kill-based monster leveling and tests

### DIFF
--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -16,7 +16,7 @@ from mutants.ui.logsink import LogSink
 from mutants.ui.themes import Theme, load_theme
 from mutants.ui import styles as st
 from ..registries import items_instances as itemsreg
-from mutants.services import monsters_state
+from mutants.services import monster_leveling, monsters_state
 from mutants.engine import session
 
 LOG = logging.getLogger(__name__)
@@ -80,12 +80,14 @@ def build_context() -> Dict[str, Any]:
     st.reload_colors_map()
     st.set_ansi_enabled(theme.ansi_enabled)
     sink = LogSink()
+    monsters = monsters_state.load_state()
     bus.subscribe(sink.handle)
+    monster_leveling.attach(bus, monsters)
     ctx: Dict[str, Any] = {
         "player_state": state,
         # Multi-year aware loader: exact year if present, otherwise closest available.
         "world_loader": load_nearest_year,
-        "monsters": monsters_state.load_state(),
+        "monsters": monsters,
         "items": itemsreg,
         "headers": ROOM_HEADERS,
         "feedback_bus": bus,

--- a/src/mutants/services/monster_leveling.py
+++ b/src/mutants/services/monster_leveling.py
@@ -1,0 +1,51 @@
+"""Monster progression triggered by combat kill events."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, TYPE_CHECKING
+
+from .monsters_state import MonstersState
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from mutants.ui.feedback import FeedbackBus
+
+
+KILL_EVENT_KIND = "COMBAT/KILL"
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _handle_kill_event(state: MonstersState, event: Mapping[str, Any]) -> None:
+    if event.get("kind") != KILL_EVENT_KIND:
+        return
+
+    monster_id = _as_str(event.get("killer_id"))
+    if not monster_id:
+        return
+
+    if not state.level_up_monster(monster_id):
+        return
+
+    try:
+        state.save()
+    except Exception:
+        # Persistence issues should not break the game loop; ignore failures.
+        pass
+
+
+def attach(bus: "FeedbackBus", state: MonstersState) -> None:
+    """Attach kill-based leveling to the provided feedback ``bus``."""
+
+    def _listener(event: MutableMapping[str, Any]) -> None:
+        _handle_kill_event(state, event)
+
+    bus.subscribe(_listener)

--- a/tests/test_monster_leveling.py
+++ b/tests/test_monster_leveling.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mutants.services import monster_leveling, monsters_state
+from mutants.ui.feedback import FeedbackBus
+
+
+def _build_state(tmp_path: Path) -> monsters_state.MonstersState:
+    raw = [
+        {
+            "id": "ogre#1",
+            "level": 1,
+            "stats": {"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 10, "cha": 10},
+            "hp": {"current": 5, "max": 5},
+        }
+    ]
+    normalized = monsters_state.normalize_records(raw, catalog={})
+    return monsters_state.MonstersState(tmp_path / "instances.json", normalized)
+
+
+def test_monster_levels_on_kill(tmp_path: Path) -> None:
+    state = _build_state(tmp_path)
+    monster = state.get("ogre#1")
+    assert monster is not None
+
+    initial_weapon_damage = monster["derived"]["weapon_damage"]
+
+    bus = FeedbackBus()
+    monster_leveling.attach(bus, state)
+
+    bus.push("COMBAT/KILL", "ogre crushes foe", killer_id="ogre#1", victim_id="hero#1")
+
+    assert monster["level"] == 2
+    for stat in ("str", "dex", "con", "int", "wis", "cha"):
+        assert monster["stats"][stat] == 20
+
+    assert monster["hp"] == {"current": 15, "max": 15}
+
+    derived = monster["derived"]
+    assert derived["weapon_damage"] == initial_weapon_damage + 1
+    assert derived["dex_bonus"] == 2
+    assert derived["armour_class"] == 2
+
+
+def test_ignores_non_monster_kills(tmp_path: Path) -> None:
+    state = _build_state(tmp_path)
+    monster = state.get("ogre#1")
+    assert monster is not None
+
+    bus = FeedbackBus()
+    monster_leveling.attach(bus, state)
+
+    bus.push("COMBAT/KILL", "player victory", killer_id="player#1", victim_id="ogre#1")
+
+    assert monster["level"] == 1


### PR DESCRIPTION
## Summary
- add a monster leveling handler that listens for COMBAT/KILL events and levels the killer monster
- extend monster state management to apply standardized stat, HP, and derived updates on level-up
- wire the handler into the application context and cover the new behaviour with targeted tests

## Testing
- pytest tests/test_monster_leveling.py tests/test_monsters_state.py

------
https://chatgpt.com/codex/tasks/task_e_68d2af13a15c832b815e36d86e1f0c6c