### PR TITLE
Align monster combat math and drops

### DIFF
--- a/src/mutants/services/combat_calc.py
+++ b/src/mutants/services/combat_calc.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from mutants.registries import items_catalog, items_instances as itemsreg
 from mutants.services import player_state as pstate
@@ -13,8 +13,43 @@ def _coerce_int(value: Any) -> int:
         return 0
 
 
+def _armour_class_from_payload(payload: Any) -> Optional[int]:
+    if not isinstance(payload, Mapping):
+        return None
+
+    derived = payload.get("derived")
+    if isinstance(derived, Mapping) and derived.get("armour_class") is not None:
+        return max(0, _coerce_int(derived.get("armour_class")))
+
+    base_value = payload.get("armour_class")
+    enchant_level = payload.get("enchant_level")
+
+    if base_value is None:
+        item_id = payload.get("item_id")
+        template: Optional[Mapping[str, Any]] = None
+        if item_id:
+            try:
+                catalog = items_catalog.load_catalog()
+            except FileNotFoundError:
+                catalog = None
+            if catalog:
+                template = catalog.get(str(item_id))
+        if template and template.get("armour_class") is not None:
+            base_value = template.get("armour_class")
+
+    base_ac = max(0, _coerce_int(base_value))
+    enchant_bonus = max(0, _coerce_int(enchant_level))
+    return base_ac + enchant_bonus
+
+
 def armour_class_from_equipped(state) -> int:
     """Return the armour class bonus provided by the equipped armour."""
+
+    if isinstance(state, Mapping):
+        armour_payload = state.get("armour_slot")
+        bonus = _armour_class_from_payload(armour_payload)
+        if bonus is not None:
+            return bonus
 
     armour_iid = pstate.get_equipped_armour_id(state)
     if not armour_iid:
@@ -51,6 +86,19 @@ def armour_class_from_equipped(state) -> int:
 
 def dex_bonus_for_active(state) -> int:
     """Return the derived dexterity bonus for the active character."""
+
+    if isinstance(state, Mapping):
+        derived = state.get("derived")
+        if isinstance(derived, Mapping) and derived.get("dex_bonus") is not None:
+            return max(0, _coerce_int(derived.get("dex_bonus")))
+
+        stats = state.get("stats")
+        if isinstance(stats, Mapping) and stats.get("dex") is not None:
+            try:
+                dex_value = int(stats.get("dex", 0))
+            except (TypeError, ValueError):
+                dex_value = 0
+            return max(0, dex_value // 10)
 
     stats = pstate.get_stats_for_active(state)
     dex = stats.get("dex", 0)

--- a/src/mutants/services/damage_engine.py
+++ b/src/mutants/services/damage_engine.py
@@ -96,6 +96,16 @@ def _resolve_item_payload(item: Any) -> MutableMapping[str, Any]:
 
 
 def _resolve_attacker_strength(attacker_state: Any) -> int:
+    if isinstance(attacker_state, Mapping):
+        derived = attacker_state.get("derived") if isinstance(attacker_state.get("derived"), Mapping) else None
+        if isinstance(derived, Mapping) and derived.get("str_bonus") is not None:
+            return max(0, _coerce_int(derived.get("str_bonus"), 0))
+
+        stats_block = attacker_state.get("stats") if isinstance(attacker_state.get("stats"), Mapping) else None
+        if isinstance(stats_block, Mapping) and stats_block.get("str") is not None:
+            strength = _coerce_int(stats_block.get("str"), 0)
+            return max(0, strength // 10)
+
     stats = pstate.get_stats_for_active(attacker_state)
     strength = _coerce_int(stats.get("str"), 0)
     return max(0, strength // 10)

--- a/tests/test_damage_engine.py
+++ b/tests/test_damage_engine.py
@@ -74,3 +74,19 @@ def test_compute_base_damage_uses_helpers(monkeypatch):
 
     assert damage_engine.compute_base_damage({}, {}, {}) == 27
 
+
+def test_get_attacker_power_handles_monster_state():
+    monster = {"stats": {"str": 47}}
+    weapon = {"base_power": 5, "enchant_level": 15}
+
+    # strength bonus = floor(47/10) = 4; enchant bonus = 60
+    assert damage_engine.get_attacker_power(weapon, monster) == 5 + 60 + 4
+
+
+def test_get_total_ac_handles_monster_state():
+    armour = {"item_id": "leather", "enchant_level": 3, "derived": {"armour_class": 6}}
+    monster = {"stats": {"dex": 28}, "armour_slot": armour}
+
+    # dex bonus = 2, armour = 6 (base 3 + enchant 3)
+    assert damage_engine.get_total_ac(monster) == 8
+

--- a/tests/test_monsters_state.py
+++ b/tests/test_monsters_state.py
@@ -121,3 +121,53 @@ def test_wielded_invalid_defaults_to_first_item(tmp_path, monkeypatch):
     assert monster["pinned_years"] == [1999, 2005]
     assert monster["derived"]["weapon_damage"] == bag[0]["derived"]["base_damage"] + 1  # str bonus 1
 
+
+def test_kill_monster_drops_items_and_clears_record(tmp_path):
+    catalog = {
+        "club": {"item_id": "club", "base_power": 5, "weight": 20},
+        "leather": {"item_id": "leather", "armour": True, "armour_class": 3, "weight": 15},
+    }
+
+    raw = {
+        "id": "ogre#1",
+        "name": "Ogre",
+        "stats": {"str": 30, "dex": 24},
+        "hp": {"current": 10, "max": 10},
+        "bag": [
+            {"item_id": "club", "iid": "ogre#club", "enchant_level": 15, "condition": 42},
+        ],
+        "armour_slot": {"item_id": "leather", "iid": "ogre#leather", "enchant_level": 2, "condition": 55},
+        "wielded": "ogre#club",
+        "pos": [1999, 2, 3],
+    }
+
+    normalized = monsters_state.normalize_records([raw], catalog=catalog)
+    state = monsters_state.MonstersState(tmp_path / "instances.json", normalized)
+
+    monster = state.get("ogre#1")
+    assert monster is not None
+    weapon = monster["bag"][0]
+    armour = monster["armour_slot"]
+    weapon["condition"] = 17
+    armour["condition"] = 12
+
+    summary = state.kill_monster("ogre#1")
+
+    assert summary["monster"]["id"] == "ogre#1"
+    assert summary["drops"] == [weapon, armour]
+    assert summary["pos"] == [1999, 2, 3]
+    assert summary["monster"]["bag"] == []
+    assert summary["monster"]["armour_slot"] is None
+    assert summary["monster"]["wielded"] is None
+    assert summary["monster"]["hp"]["current"] == 0
+    assert summary["monster"]["derived"]["armour_class"] == summary["monster"]["derived"]["dex_bonus"]
+    assert weapon["condition"] == 17
+    assert armour["condition"] == 12
+    assert state.get("ogre#1") is None
+    assert not state.list_all()
+
+
+def test_kill_monster_missing_returns_empty(tmp_path):
+    state = monsters_state.MonstersState(tmp_path / "instances.json", [])
+    assert state.kill_monster("missing") == {"monster": None, "drops": [], "pos": None}
+


### PR DESCRIPTION
## Summary
- allow combat_calc and damage_engine helpers to consume monster records so they share the same armour/strength math as players
- add MonstersState.kill_monster so monsters drop their carried armour and bag items on death while clearing their record
- cover the shared combat math and death handling with new unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2b1f1f614832b92adb8736c1e4c8d