### PR TITLE
Allow monsters to bypass strength gates

### DIFF
--- a/src/mutants/commands/wear.py
+++ b/src/mutants/commands/wear.py
@@ -209,6 +209,7 @@ def wear_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
 
     stats = pstate.get_stats_for_active(stats_state)
     strength = _coerce_int(stats.get("str"), 0)
+    monster_actor = itx.actor_is_monster(ctx)
     gate_ok = strength >= required
     if _edbg_enabled():
         comp = ">=" if gate_ok else "<"
@@ -216,7 +217,14 @@ def wear_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
         _edbg_log(
             f"[ equip ] gate strength={strength} {comp} required={required} weight={weight} -> {outcome}",
         )
-    if not gate_ok:
+        if not gate_ok and monster_actor:
+            _edbg_log(
+                "[ equip ] gate bypass=monster",
+                cmd="wear",
+                prefix=repr(prefix),
+                **{"strength": strength, "required": required, "weight": weight},
+            )
+    if not gate_ok and not monster_actor:
         if _edbg_enabled():
             _edbg_log(
                 "[ equip ] reject=strength_gate",

--- a/src/mutants/commands/wield.py
+++ b/src/mutants/commands/wield.py
@@ -122,6 +122,7 @@ def wield_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
 
     stats = pstate.get_stats_for_active(stats_state)
     strength = _coerce_int(stats.get("str"), 0)
+    monster_actor = itx.actor_is_monster(ctx)
     gate_ok = strength >= required
     if _edbg_enabled():
         comp = ">=" if gate_ok else "<"
@@ -131,7 +132,14 @@ def wield_cmd(arg: str, ctx: Dict[str, object]) -> Dict[str, object]:
             cmd="wield",
             prefix=repr(prefix),
         )
-    if not gate_ok:
+        if not gate_ok and monster_actor:
+            _edbg_log(
+                "[ equip ] gate bypass=monster",
+                cmd="wield",
+                prefix=repr(prefix),
+                **{"strength": strength, "required": required, "weight": weight},
+            )
+    if not gate_ok and not monster_actor:
         if _edbg_enabled():
             _edbg_log(
                 "[ equip ] reject=strength_gate",

--- a/tests/test_commands_wear_remove.py
+++ b/tests/test_commands_wear_remove.py
@@ -167,6 +167,27 @@ def test_wear_rejects_when_too_heavy(command_env):
     assert pstate.get_equipped_armour_id(pstate.load_state()) is None
 
 
+def test_monster_wear_bypasses_strength_gate(command_env):
+    stats = {"str": 1, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["chain_mail#bag"],
+        equipped=None,
+        stats=stats,
+        catalog={"chain_mail": {"name": "Chain Mail", "armour": True, "weight": 40}},
+        instances={"chain_mail#bag": "chain_mail"},
+    )
+
+    state = pstate.load_state()
+    ctx, bus = _ctx(state)
+    ctx["actor_kind"] = "monster"
+
+    result = wear.wear_cmd("chain", ctx)
+
+    assert result["ok"] is True
+    assert not any("You don't have the strength to put that on!" in msg for _, msg in bus.msgs)
+    assert pstate.get_equipped_armour_id(pstate.load_state()) == "chain_mail#bag"
+
+
 def test_wear_requires_strength_for_150_lb_armour(command_env):
     stats = {"str": 14, "dex": 8, "int": 0, "wis": 0, "con": 0, "cha": 0}
     command_env["setup"](

--- a/tests/test_commands_wield.py
+++ b/tests/test_commands_wield.py
@@ -198,6 +198,26 @@ def test_wield_strength_gate_failure(command_env):
     assert pstate.get_wielded_weapon_id(pstate.load_state()) is None
 
 
+def test_monster_wield_bypasses_strength_gate(command_env):
+    stats = {"str": 1, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
+    command_env["setup"](
+        bag_items=["warhammer#bag"],
+        stats=stats,
+        catalog={"warhammer": {"name": "Warhammer", "weight": 25}},
+        instances={"warhammer#bag": {"item_id": "warhammer"}},
+    )
+
+    state_before = pstate.load_state()
+    ctx, bus = _ctx(state_before)
+    ctx["actor_kind"] = "monster"
+
+    result = wield.wield_cmd("war", ctx)
+
+    assert result["ok"] is True
+    assert not any("You don't have the strength to wield that!" in msg for _, msg in bus.msgs)
+    assert pstate.get_wielded_weapon_id(pstate.load_state()) == "warhammer#bag"
+
+
 def test_wield_allows_enchanted_weapon_with_reduced_weight(command_env):
     stats = {"str": 4, "dex": 10, "int": 0, "wis": 0, "con": 0, "cha": 0}
     command_env["setup"](

--- a/tests/test_item_transfer_pickup.py
+++ b/tests/test_item_transfer_pickup.py
@@ -123,3 +123,17 @@ def test_pickup_strength_gate_respects_enchant_reduction(pickup_env):
     assert result["ok"] is True
     assert pickup_env["player"]["inventory"] == ["warhammer#ground"]
     assert pickup_env["ground"] == []
+
+
+def test_monster_pickup_bypasses_strength_gate(pickup_env):
+    pickup_env["add_ground_item"]("colossus#ground", "colossus", weight=160, enchant_level=0)
+    pickup_env["set_strength"](1)
+
+    monster_ctx = dict(pickup_env["ctx"])
+    monster_ctx["actor_kind"] = "monster"
+
+    result = itx.pick_from_ground(monster_ctx, "col")
+
+    assert result["ok"] is True
+    assert pickup_env["player"]["inventory"] == ["colossus#ground"]
+    assert pickup_env["ground"] == []


### PR DESCRIPTION
## Summary
- add an `actor_is_monster` helper so monster contexts bypass pickup strength checks while still logging the comparison
- teach the wear and wield commands to honour monster contexts and skip strength gates with explicit debug logs
- extend the pickup, wear, and wield test suites with monster-specific coverage to prove the bypass while retaining player gates

## Testing
- pytest tests/test_item_transfer_pickup.py tests/test_commands_wear_remove.py tests/test_commands_wield.py

------
https://chatgpt.com/codex/tasks/task_e_68d2b6e481a8832bbda1db062675417f