### PR TITLE
Add monster debug command and playersdbg logging

### DIFF
--- a/src/mutants/commands/mon.py
+++ b/src/mutants/commands/mon.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Iterable as IterableABC
+from typing import Any, Dict, Iterable, Mapping, Tuple
+
+
+_MON_STAT_KEYS: Tuple[str, ...] = ("str", "dex", "con", "int", "wis", "cha")
+
+
+def _normalize_monster_lookup(monsters: Any, token: str) -> Tuple[Mapping[str, Any] | None, Iterable[str]]:
+    if monsters is None or not token:
+        return None, []
+
+    lookup = getattr(monsters, "get", None)
+    if callable(lookup):
+        monster = lookup(token)
+        if isinstance(monster, Mapping):
+            return monster, []
+
+    matches: list[str] = []
+    candidates = getattr(monsters, "list_all", None)
+    if callable(candidates):
+        try:
+            for entry in candidates():
+                if not isinstance(entry, Mapping):
+                    continue
+                mid = str(entry.get("id") or "")
+                name = str(entry.get("name") or "")
+                token_lower = token.lower()
+                if mid == token:
+                    return entry, []
+                if mid.startswith(token) or name.lower().startswith(token_lower):
+                    matches.append(mid)
+        except Exception:
+            return None, []
+    return None, matches
+
+
+def _format_stats(stats: Mapping[str, Any] | None) -> str:
+    if not isinstance(stats, Mapping):
+        return "-"
+    parts = []
+    for key in _MON_STAT_KEYS:
+        value = stats.get(key)
+        try:
+            value_int = int(value)
+        except (TypeError, ValueError):
+            continue
+        parts.append(f"{key}:{value_int}")
+    return ",".join(parts) if parts else "-"
+
+
+def _format_hp(hp: Mapping[str, Any] | None) -> str:
+    if not isinstance(hp, Mapping):
+        return "?/?"
+    cur = hp.get("current")
+    cap = hp.get("max")
+    return f"{cur}/{cap}"
+
+
+def _format_armour(armour: Mapping[str, Any] | None) -> str:
+    if not isinstance(armour, Mapping):
+        return "-"
+    item_id = armour.get("item_id") or armour.get("iid")
+    return str(item_id) if item_id else "-"
+
+
+def _bag_count(bag: Any) -> int:
+    if not isinstance(bag, list):
+        return 0
+    count = 0
+    for entry in bag:
+        if isinstance(entry, Mapping):
+            count += 1
+    return count
+
+
+def _summarize_monster(monster: Mapping[str, Any]) -> str:
+    monster_id = monster.get("id") or "?"
+    name = monster.get("name") or "?"
+    level = monster.get("level")
+    stats_text = _format_stats(monster.get("stats"))
+    hp_text = _format_hp(monster.get("hp"))
+    pinned = monster.get("pinned_years")
+    if isinstance(pinned, IterableABC) and not isinstance(pinned, (str, bytes)):
+        pinned_text = ",".join(str(year) for year in pinned) or "-"
+    else:
+        pinned_text = "-"
+    wielded = monster.get("wielded") or "-"
+    armour_text = _format_armour(monster.get("armour_slot"))
+    bag_items = _bag_count(monster.get("bag"))
+    return (
+        f"MON id={monster_id} name={name} level={level} hp={hp_text} stats={stats_text} "
+        f"pinned={pinned_text or '-'} wielded={wielded} armour={armour_text} bag={bag_items}"
+    )
+
+
+def mon_cmd(arg: str, ctx: Dict[str, Any]) -> None:
+    parts = shlex.split((arg or "").strip())
+    bus = ctx["feedback_bus"]
+    if not parts:
+        bus.push("SYSTEM/INFO", "Usage: mon debug <monster_id>")
+        return
+
+    if parts[0].lower() in {"debug", "info", "show"}:
+        parts = parts[1:]
+        if not parts:
+            bus.push("SYSTEM/INFO", "Usage: mon debug <monster_id>")
+            return
+
+    token = parts[0]
+    monster_state = ctx.get("monsters")
+    monster, matches = _normalize_monster_lookup(monster_state, token)
+    if matches:
+        preview = ", ".join(sorted(matches)[:5])
+        bus.push("SYSTEM/WARN", f'Ambiguous monster "{token}" (matches: {preview})')
+        return
+    if not monster:
+        bus.push("SYSTEM/WARN", f"Unknown monster '{token}'.")
+        return
+
+    summary = _summarize_monster(monster)
+    bus.push("DEBUG", summary)
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("mon", lambda arg: mon_cmd(arg, ctx))

--- a/tests/test_commands_mon.py
+++ b/tests/test_commands_mon.py
@@ -1,0 +1,67 @@
+import pytest
+
+from mutants.commands import mon
+from mutants.ui.feedback import FeedbackBus
+
+
+class _DummyMonsters:
+    def __init__(self, monster):
+        self._monster = monster
+
+    def get(self, monster_id):
+        return self._monster if monster_id == self._monster["id"] else None
+
+    def list_all(self):
+        return [self._monster]
+
+
+@pytest.fixture
+def monster_record():
+    return {
+        "id": "ogre#1",
+        "name": "Ogre",
+        "level": 5,
+        "hp": {"current": 10, "max": 20},
+        "stats": {"str": 30, "dex": 12, "con": 18, "int": 4, "wis": 6, "cha": 3},
+        "pinned_years": [2000, 2100],
+        "wielded": "ogre#club",
+        "armour_slot": {"item_id": "leather_mail", "iid": "ogre#mail"},
+        "bag": [{"item_id": "club"}, {"item_id": "potion"}],
+    }
+
+
+def test_mon_debug_outputs_expected_fields(monster_record):
+    monsters = _DummyMonsters(monster_record)
+    bus = FeedbackBus()
+    ctx = {"monsters": monsters, "feedback_bus": bus}
+
+    mon.mon_cmd("debug ogre#1", ctx)
+
+    events = bus.drain()
+    assert events
+    event = events[-1]
+    assert event["kind"] == "DEBUG"
+    text = event["text"]
+    assert "id=ogre#1" in text
+    assert "name=Ogre" in text
+    assert "level=5" in text
+    assert "hp=10/20" in text
+    assert "stats=str:30" in text
+    assert "pinned=2000,2100" in text
+    assert "wielded=ogre#club" in text
+    assert "armour=leather_mail" in text
+    assert "bag=2" in text
+
+
+def test_mon_unknown_monster(monster_record):
+    monsters = _DummyMonsters(monster_record)
+    bus = FeedbackBus()
+    ctx = {"monsters": monsters, "feedback_bus": bus}
+
+    mon.mon_cmd("debug missing", ctx)
+
+    events = bus.drain()
+    assert events
+    event = events[-1]
+    assert event["kind"] == "SYSTEM/WARN"
+    assert "Unknown monster" in event["text"]

--- a/tests/test_monster_playersdbg.py
+++ b/tests/test_monster_playersdbg.py
@@ -1,0 +1,114 @@
+import logging
+import random
+from pathlib import Path
+
+import pytest
+
+from mutants.registries import monsters_instances
+from mutants.services import monster_spawner, monsters_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_monster_cache():
+    monsters_state.invalidate_cache()
+    yield
+    monsters_state.invalidate_cache()
+
+
+def _build_state(tmp_path: Path):
+    raw = [
+        {
+            "id": "ogre#1",
+            "name": "Ogre",
+            "level": 1,
+            "stats": {"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 10, "cha": 10},
+            "hp": {"current": 5, "max": 5},
+            "bag": [{"item_id": "club", "iid": "ogre#club"}],
+            "armour_slot": {"item_id": "leather", "iid": "ogre#leather"},
+        }
+    ]
+    normalized = monsters_state.normalize_records(raw, catalog={})
+    return monsters_state.MonstersState(tmp_path / "instances.json", normalized)
+
+
+def test_level_up_logs_playersdbg(monkeypatch, tmp_path, caplog):
+    state = _build_state(tmp_path)
+    monkeypatch.setattr(monsters_state.pstate, "_pdbg_enabled", lambda: True)
+    monkeypatch.setattr(monsters_state.pstate, "_pdbg_setup_file_logging", lambda: None)
+
+    with caplog.at_level(logging.INFO, logger="mutants.playersdbg"):
+        assert state.level_up_monster("ogre#1")
+
+    messages = [record.message for record in caplog.records if "MON-LVL" in record.message]
+    assert messages, "expected MON-LVL log record"
+    message = messages[-1]
+    assert "id=ogre#1" in message
+    assert "lvl=2" in message
+    assert "Δlvl=+1" in message
+    assert "stats=str:+10" in message
+    assert "hp=+10" in message
+
+
+def test_kill_logs_playersdbg(monkeypatch, tmp_path, caplog):
+    state = _build_state(tmp_path)
+    monkeypatch.setattr(monsters_state.pstate, "_pdbg_enabled", lambda: True)
+    monkeypatch.setattr(monsters_state.pstate, "_pdbg_setup_file_logging", lambda: None)
+
+    with caplog.at_level(logging.INFO, logger="mutants.playersdbg"):
+        summary = state.kill_monster("ogre#1")
+
+    assert summary["monster"]["hp"]["current"] == 0
+    messages = [record.message for record in caplog.records if "MON-KILL" in record.message]
+    assert messages, "expected MON-KILL log record"
+    message = messages[-1]
+    assert "id=ogre#1" in message
+    assert "drops=2" in message
+    assert "bag=1" in message
+    assert "armour=yes" in message
+
+
+class _DummyWorld:
+    def __init__(self, year: int):
+        self._year = year
+
+    def iter_tiles(self):
+        yield {"pos": [self._year, 1, 2]}
+
+
+def test_spawn_logs_playersdbg(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(monster_spawner.pstate, "_pdbg_enabled", lambda: True)
+    monkeypatch.setattr(monster_spawner.pstate, "_pdbg_setup_file_logging", lambda: None)
+
+    template = {
+        "id": "ogre",
+        "name": "Ogre",
+        "pinned_years": [2000],
+        "hp": {"max": 5},
+        "armour_class": 3,
+        "level": 2,
+        "bag": [{"item_id": "club"}],
+        "innate_attack": {"name": "Smash", "power_base": 1, "power_per_level": 1},
+    }
+    instances = monsters_instances.MonstersInstances(str(tmp_path / "instances.json"), [])
+
+    controller = monster_spawner.MonsterSpawnerController(
+        templates=[template],
+        instances=instances,
+        world_loader=lambda year: _DummyWorld(year),
+        rng=random.Random(0),
+        time_func=lambda: 10.0,
+        floor_per_year=1,
+        spawn_interval=1.0,
+        spawn_jitter=0.0,
+    )
+
+    with caplog.at_level(logging.INFO, logger="mutants.playersdbg"):
+        controller.tick()
+
+    messages = [record.message for record in caplog.records if "MON-SPAWN" in record.message]
+    assert messages, "expected MON-SPAWN log record"
+    message = messages[-1]
+    assert "kind=ogre" in message
+    assert "pos=[2000, 1, 2]" in message
+    assert "lvl=2" in message
+    assert "hp=" in message


### PR DESCRIPTION
## Summary
- add a `mon` debug command that prints monster summaries including level, hp, stats, pins, equipment, and bag counts
- emit `mutants.playersdbg` log lines for monster spawns, kills, and level ups with concise deltas
- add regression coverage for the new command and logging hooks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2bcd0f0f8832b8d37dd6f15ecfeef