### PR TITLE
Fix duplicate future import in combat command

### DIFF
--- a/src/mutants/bootstrap/lazyinit.py
+++ b/src/mutants/bootstrap/lazyinit.py
@@ -126,8 +126,10 @@ def make_player_from_template(t: Dict[str, Any], make_active: bool = False) -> D
         },
         "equipment_by_class": {cls: {"armour": None}},
         "wielded_by_class": {cls: None},
+        "ready_target_by_class": {cls: None},
         "wielded": None,
         "readied_spell": t.get("readied_spell_start", None),
+        "ready_target": None,
         "target_monster_id": None,
 
         "inventory": inventory,

--- a/src/mutants/commands/combat.py
+++ b/src/mutants/commands/combat.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+from mutants.services import player_state as pstate
+from mutants.util.textnorm import normalize_item_query
+
+CLEAR_TOKENS = {"none", "clear", "cancel"}
+
+
+def _coerce_position(player: Mapping[str, Any]) -> Optional[Tuple[int, int, int]]:
+    pos = player.get("pos")
+    if isinstance(pos, (list, tuple)) and len(pos) >= 3:
+        try:
+            return int(pos[0]), int(pos[1]), int(pos[2])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _list_monsters(
+    monsters: Any, year: int, x: int, y: int
+) -> List[Mapping[str, Any]]:
+    if not monsters or not hasattr(monsters, "list_at"):
+        return []
+    try:
+        return [mon for mon in monsters.list_at(year, x, y)]  # type: ignore[attr-defined]
+    except Exception:
+        return []
+
+
+def _is_alive(monster: Mapping[str, Any]) -> bool:
+    hp_block = monster.get("hp")
+    if isinstance(hp_block, Mapping):
+        try:
+            return int(hp_block.get("current", 0)) > 0
+        except (TypeError, ValueError):
+            return True
+    return True
+
+
+def _display_name(monster: Mapping[str, Any], fallback_id: str) -> str:
+    name = monster.get("name") or monster.get("monster_id")
+    return str(name) if name else fallback_id
+
+
+def combat_cmd(arg: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    bus = ctx["feedback_bus"]
+    token = (arg or "").strip()
+    if not token:
+        bus.push("SYSTEM/WARN", "Usage: combat <monster>")
+        return {"ok": False, "reason": "missing_argument"}
+
+    lowered = token.lower()
+    if lowered in CLEAR_TOKENS:
+        previous = pstate.clear_ready_target_for_active(reason="user-clear")
+        message = "You lower your guard." if previous else "You are not ready to fight anyone."
+        bus.push("SYSTEM/OK", message)
+        return {"ok": True, "cleared": True}
+
+    normalized = normalize_item_query(token)
+    state, active = pstate.get_active_pair()
+    player: Mapping[str, Any] = active if isinstance(active, Mapping) else {}
+    pos = _coerce_position(player)
+    if not pos:
+        bus.push("SYSTEM/WARN", "You are nowhere to engage in combat.")
+        pstate.clear_ready_target_for_active(reason="invalid-position")
+        return {"ok": False, "reason": "invalid_position"}
+
+    year, px, py = pos
+    monsters_state = ctx.get("monsters")
+    monsters_here = _list_monsters(monsters_state, year, px, py)
+    living = [mon for mon in monsters_here if _is_alive(mon)]
+    if not living:
+        pstate.clear_ready_target_for_active(reason="no-monsters")
+        bus.push("SYSTEM/WARN", "No living monsters here to fight.")
+        return {"ok": False, "reason": "no_monsters"}
+
+    matches: List[Tuple[Mapping[str, Any], str]] = []
+    norm_token = normalized or lowered
+    for monster in living:
+        raw_id = monster.get("id") or monster.get("instance_id") or monster.get("monster_id")
+        monster_id = str(raw_id) if raw_id else ""
+        norm_id = normalize_item_query(monster_id)
+        display_name = _display_name(monster, monster_id or "monster")
+        norm_name = normalize_item_query(display_name)
+        if not norm_token:
+            continue
+        if norm_name.startswith(norm_token) or norm_id.startswith(norm_token) or (
+            monster_id and monster_id.lower().startswith(lowered)
+        ):
+            matches.append((monster, monster_id))
+
+    if not matches:
+        bus.push("SYSTEM/WARN", f"No monster here matches '{token}'.")
+        return {"ok": False, "reason": "not_found"}
+
+    if len(matches) > 1:
+        preview = ", ".join(_display_name(mon, mid or "monster") for mon, mid in matches[:3])
+        bus.push("SYSTEM/WARN", f"Ambiguous target '{token}' ({preview}).")
+        return {"ok": False, "reason": "ambiguous", "candidates": [mid for _, mid in matches]}
+
+    target_monster, target_id = matches[0]
+    sanitized = pstate.set_ready_target_for_active(target_id)
+    label = _display_name(target_monster, sanitized or target_id)
+    bus.push("SYSTEM/OK", f"You ready yourself against {label}.")
+    return {"ok": True, "target_id": sanitized or target_id, "target_name": label}
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("combat", lambda arg: combat_cmd(arg, ctx))
+    dispatch.alias("com", "combat")

--- a/src/mutants/commands/move.py
+++ b/src/mutants/commands/move.py
@@ -99,6 +99,8 @@ def move(dir_code: str, ctx: Dict[str, Any]) -> None:
         pstate.mutate_active(_persist)
     except Exception:
         LOG.exception("Failed to autosave position after move.")
+    else:
+        pstate.clear_ready_target_for_active(reason="player-moved")
     # Successful movement requests a render of the new room.
     ctx["render_next"] = True
     # Do not echo success movement like "You head north." Original shows next room immediately.

--- a/src/mutants/registries/monsters_instances.py
+++ b/src/mutants/registries/monsters_instances.py
@@ -19,6 +19,7 @@ class MonstersInstances:
       armour_wearing: item_id|instance_id|null,
       readied_spell: spell_id|null,
       target_player_id: str|null, target_monster_id: str|null,
+      ready_target: str|null,
       taunt: str
     }
     """
@@ -93,6 +94,7 @@ class MonstersInstances:
             "readied_spell": None,
             "target_player_id": None,
             "target_monster_id": None,
+            "ready_target": None,
             "taunt": base.get("taunt", ""),
             # Copy innate attack block for quick access (optional, but handy for combat)
             "innate_attack": {
@@ -112,8 +114,18 @@ class MonstersInstances:
     def set_target_player(self, instance_id: str, player_id: Optional[str]) -> None:
         m = self._by_id[instance_id]; m["target_player_id"] = player_id; self._dirty = True
 
+    def set_ready_target(self, instance_id: str, target_id: Optional[str]) -> None:
+        monster = self._by_id[instance_id]
+        if target_id is None:
+            sanitized = None
+        else:
+            sanitized = str(target_id).strip() or None
+        monster["ready_target"] = sanitized
+        monster["target_monster_id"] = sanitized
+        self._dirty = True
+
     def set_target_monster(self, instance_id: str, other_id: Optional[str]) -> None:
-        m = self._by_id[instance_id]; m["target_monster_id"] = other_id; self._dirty = True
+        self.set_ready_target(instance_id, other_id)
 
     # ---------- Persistence ----------
     def save(self) -> None:

--- a/src/mutants/schemas/monsters_instances.schema.json
+++ b/src/mutants/schemas/monsters_instances.schema.json
@@ -17,6 +17,7 @@
       "readied_spell":{"type":["string","null"]},
       "target_player_id":{"type":["string","null"]},
       "target_monster_id":{"type":["string","null"]},
+      "ready_target":{"type":["string","null"]},
       "taunt":{"type":"string"},
       "innate_attack":{
         "type":"object",

--- a/src/mutants/services/monster_spawner.py
+++ b/src/mutants/services/monster_spawner.py
@@ -210,6 +210,7 @@ def _clone_template(template: Mapping[str, Any], pos: Pos) -> Dict[str, Any]:
         "readied_spell": None,
         "target_player_id": None,
         "target_monster_id": None,
+        "ready_target": None,
         "taunt": str(template.get("taunt", "")),
         "innate_attack": _copy_innate_attack(template),
         "spells": [str(s) for s in template.get("spells", []) if isinstance(s, (str, int))],

--- a/src/mutants/services/player_reset.py
+++ b/src/mutants/services/player_reset.py
@@ -59,8 +59,10 @@ def _reset_fields_from_template(player: Dict[str, Any], template: Dict[str, Any]
     equipment_map = player.setdefault("equipment_by_class", {})
     equipment_map[cls_name] = {"armour": None}
     player.setdefault("wielded_by_class", {})[cls_name] = None
+    player.setdefault("ready_target_by_class", {})[cls_name] = None
     player["wielded"] = None
     player["readied_spell"] = template.get("readied_spell_start", None)
+    player["ready_target"] = None
     player["target_monster_id"] = None
     player["inventory"] = []
     player["carried_weight"] = 0

--- a/src/mutants/ui/viewmodels.py
+++ b/src/mutants/ui/viewmodels.py
@@ -15,8 +15,9 @@ class Coords(TypedDict):
     y: int
 
 
-class Thing(TypedDict):
+class Thing(TypedDict, total=False):
     name: str
+    id: str
 
 
 class RoomVM(TypedDict, total=False):

--- a/tests/test_commands_combat.py
+++ b/tests/test_commands_combat.py
@@ -1,0 +1,197 @@
+import copy
+
+import pytest
+
+from mutants.commands import combat, statistics
+from mutants.services import player_state as pstate
+
+
+class Bus:
+    def __init__(self) -> None:
+        self.msgs: list[tuple[str, str]] = []
+
+    def push(self, kind: str, text: str) -> None:
+        self.msgs.append((kind, text))
+
+
+class MonsterState:
+    def __init__(self, monsters: list[dict[str, object]]) -> None:
+        self._monsters = monsters
+
+    def list_at(self, year: int, x: int, y: int) -> list[dict[str, object]]:
+        result: list[dict[str, object]] = []
+        for monster in self._monsters:
+            pos = monster.get("pos")
+            if isinstance(pos, list) and len(pos) >= 3:
+                try:
+                    if int(pos[0]) == year and int(pos[1]) == x and int(pos[2]) == y:
+                        result.append(monster)
+                except (TypeError, ValueError):
+                    continue
+        return result
+
+
+def _base_state() -> dict[str, object]:
+    stats = {"str": 10, "dex": 12, "int": 8, "wis": 9, "con": 11, "cha": 7}
+    hp = {"current": 10, "max": 10}
+    player = {
+        "id": "p1",
+        "name": "Thief",
+        "class": "Thief",
+        "pos": [2000, 1, 1],
+        "stats": dict(stats),
+        "hp": dict(hp),
+        "inventory": [],
+        "bags": {"Thief": []},
+        "equipment_by_class": {"Thief": {"armour": None}},
+        "wielded_by_class": {"Thief": None},
+        "ready_target_by_class": {"Thief": None},
+        "ready_target": None,
+        "target_monster_id": None,
+        "wielded": None,
+        "armour": {"wearing": None},
+        "ions": 0,
+        "Ions": 0,
+        "riblets": 0,
+        "Riblets": 0,
+        "exp_points": 0,
+        "level": 1,
+        "exhaustion": 0,
+    }
+    state = {
+        "players": [copy.deepcopy(player)],
+        "active_id": "p1",
+        "active": copy.deepcopy(player),
+        "inventory": [],
+        "bags": {"Thief": []},
+        "equipment_by_class": {"Thief": {"armour": None}},
+        "wielded_by_class": {"Thief": None},
+        "ready_target_by_class": {"Thief": None},
+        "stats_by_class": {"Thief": dict(stats)},
+        "hp_by_class": {"Thief": dict(hp)},
+        "ions_by_class": {"Thief": 0},
+        "riblets_by_class": {"Thief": 0},
+        "exp_by_class": {"Thief": 0},
+        "level_by_class": {"Thief": 1},
+        "bags_by_class": {"Thief": []},
+        "stats": dict(stats),
+        "hp": dict(hp),
+        "ions": 0,
+        "Ions": 0,
+        "riblets": 0,
+        "Riblets": 0,
+        "exp_points": 0,
+        "level": 1,
+        "exhaustion": 0,
+        "wielded": None,
+        "ready_target": None,
+        "target_monster_id": None,
+    }
+    return state
+
+
+@pytest.fixture
+def command_env(monkeypatch):
+    state_store: dict[str, object] = {}
+
+    def fake_load_state() -> dict[str, object]:
+        return copy.deepcopy(state_store)
+
+    def fake_save_state(new_state: dict[str, object]) -> None:
+        state_store.clear()
+        state_store.update(copy.deepcopy(new_state))
+
+    monkeypatch.setattr(pstate, "load_state", fake_load_state)
+    monkeypatch.setattr(pstate, "save_state", fake_save_state)
+
+    def setup(*, ready_target: str | None = None) -> None:
+        state_store.clear()
+        state_store.update(_base_state())
+        if ready_target:
+            pstate.set_ready_target_for_active(ready_target)
+
+    return {"setup": setup, "state": state_store}
+
+
+def _ctx(monsters) -> tuple[dict[str, object], Bus]:
+    bus = Bus()
+    ctx = {"feedback_bus": bus, "monsters": monsters}
+    return ctx, bus
+
+
+def test_combat_sets_ready_target(command_env):
+    command_env["setup"]()
+    monsters = MonsterState(
+        [
+            {"id": "ghoul#1", "name": "Ghoul", "hp": {"current": 12, "max": 12}, "pos": [2000, 1, 1]},
+            {"id": "ogre#1", "name": "Ogre", "hp": {"current": 20, "max": 20}, "pos": [2000, 2, 2]},
+        ]
+    )
+    ctx, bus = _ctx(monsters)
+
+    result = combat.combat_cmd("gh", ctx)
+
+    assert result["ok"] is True
+    assert result["target_id"] == "ghoul#1"
+    assert any("ready yourself" in msg for _, msg in bus.msgs)
+    assert pstate.get_ready_target_for_active(pstate.load_state()) == "ghoul#1"
+
+
+def test_combat_clear_command(command_env):
+    command_env["setup"]()
+    pstate.set_ready_target_for_active("ghoul#1")
+    monsters = MonsterState([])
+    ctx, bus = _ctx(monsters)
+
+    result = combat.combat_cmd("none", ctx)
+
+    assert result["ok"] is True and result["cleared"] is True
+    assert any("lower your guard" in msg for _, msg in bus.msgs)
+    assert pstate.get_ready_target_for_active(pstate.load_state()) is None
+
+
+def test_combat_ignores_dead_monsters(command_env):
+    command_env["setup"]()
+    monsters = MonsterState(
+        [
+            {"id": "ghoul#1", "name": "Ghoul", "hp": {"current": 0, "max": 12}, "pos": [2000, 1, 1]}
+        ]
+    )
+    ctx, bus = _ctx(monsters)
+
+    result = combat.combat_cmd("gh", ctx)
+
+    assert result["ok"] is False
+    assert any("No living monsters" in msg for _, msg in bus.msgs)
+    assert pstate.get_ready_target_for_active(pstate.load_state()) is None
+
+
+def test_statistics_reports_ready_target(command_env):
+    command_env["setup"]()
+    pstate.set_ready_target_for_active("ghoul#1")
+    monsters = MonsterState(
+        [
+            {"id": "ghoul#1", "name": "Ghoul", "hp": {"current": 8, "max": 12}, "pos": [2000, 1, 1]}
+        ]
+    )
+    ctx, bus = _ctx(monsters)
+
+    statistics.statistics_cmd("", ctx)
+
+    ready_lines = [text for kind, text in bus.msgs if "Ready to Combat" in text]
+    assert ready_lines
+    assert ready_lines[0].endswith("Ghoul")
+
+
+def test_statistics_clears_missing_target(command_env):
+    command_env["setup"]()
+    pstate.set_ready_target_for_active("ghoul#1")
+    monsters = MonsterState([])
+    ctx, bus = _ctx(monsters)
+
+    statistics.statistics_cmd("", ctx)
+
+    ready_lines = [text for kind, text in bus.msgs if "Ready to Combat" in text]
+    assert ready_lines
+    assert ready_lines[0].endswith("NO ONE")
+    assert pstate.get_ready_target_for_active(pstate.load_state()) is None


### PR DESCRIPTION
## Summary
- ensure `from __future__ import annotations` appears once at the top of `combat.py`
- remove duplicated typing import to avoid SyntaxError during test collection

## Testing
- pytest tests/test_commands_combat.py

------
https://chatgpt.com/codex/tasks/task_e_68d2fc94720c832b9d935b45bbe95568