### PR TITLE
Add strike command for player melee attacks

### DIFF
--- a/src/mutants/commands/strike.py
+++ b/src/mutants/commands/strike.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from mutants.registries import items_catalog, items_instances as itemsreg
+from mutants.services import damage_engine, items_wear, monsters_state, player_state as pstate
+from mutants.ui.item_display import item_label
+
+MIN_INNATE_DAMAGE = 6
+
+
+def _load_monsters(ctx: Mapping[str, Any]) -> Any:
+    monsters = ctx.get("monsters")
+    if monsters is not None:
+        return monsters
+    try:
+        state = monsters_state.load_state()
+    except Exception:
+        return None
+    if isinstance(ctx, MutableMapping):
+        ctx["monsters"] = state  # type: ignore[index]
+    return state
+
+
+def _monster_display_name(monster: Mapping[str, Any], fallback: str) -> str:
+    name = monster.get("name") or monster.get("monster_id")
+    return str(name) if name else fallback
+
+
+def _sanitize_hp(monster: Mapping[str, Any]) -> tuple[int, int]:
+    hp_block = monster.get("hp")
+    if isinstance(hp_block, Mapping):
+        try:
+            current = int(hp_block.get("current", 0))
+        except (TypeError, ValueError):
+            current = 0
+        try:
+            maximum = int(hp_block.get("max", current))
+        except (TypeError, ValueError):
+            maximum = current
+        return max(0, current), max(0, maximum)
+    return 0, 0
+
+
+def _is_alive(monster: Mapping[str, Any]) -> bool:
+    current, _ = _sanitize_hp(monster)
+    return current > 0
+
+
+def _resolve_target_armour(monster: Mapping[str, Any]) -> Optional[MutableMapping[str, Any]]:
+    armour = monster.get("armour_slot")
+    if isinstance(armour, MutableMapping):
+        return armour
+    return None
+
+
+def _apply_weapon_wear(
+    weapon_iid: Optional[str],
+    wear_amount: int,
+    catalog: Mapping[str, Mapping[str, Any]],
+    bus: Any,
+) -> Optional[Dict[str, Any]]:
+    if not weapon_iid or wear_amount <= 0:
+        return None
+    try:
+        result = items_wear.apply_wear(weapon_iid, wear_amount)
+    except KeyError:
+        return None
+    if not isinstance(result, Mapping):
+        return None
+    if not result.get("cracked"):
+        return result  # wear applied but no crack to announce
+    inst = itemsreg.get_instance(weapon_iid) or {"item_id": weapon_iid}
+    tpl = catalog.get(str(inst.get("item_id"))) or {}
+    name = item_label(inst, tpl, show_charges=False)
+    bus.push("COMBAT/INFO", f"Your {name} cracks!")
+    return dict(result)
+
+
+def _sync_monster_armour_view(
+    monster: MutableMapping[str, Any],
+    armour: MutableMapping[str, Any],
+    result: Mapping[str, Any],
+) -> None:
+    derived = dict(monster.get("derived") or {})
+    armour_payload = dict(armour.get("derived") or {})
+    if result.get("cracked"):
+        armour["item_id"] = itemsreg.BROKEN_ARMOUR_ID
+        armour["enchant_level"] = 0
+        armour["enchanted"] = "no"
+        armour["condition"] = 0
+        armour_payload["armour_class"] = 0
+    else:
+        condition = result.get("condition")
+        if isinstance(condition, int):
+            armour["condition"] = condition
+    armour["derived"] = armour_payload
+    dex_bonus = derived.get("dex_bonus", 0)
+    armour_bonus = armour_payload.get("armour_class", 0)
+    derived["armour_class"] = dex_bonus + armour_bonus
+    monster["derived"] = derived
+
+
+def _apply_armour_local(
+    monster: MutableMapping[str, Any],
+    armour: MutableMapping[str, Any],
+    wear_amount: int,
+) -> Optional[Dict[str, Any]]:
+    if wear_amount <= 0:
+        return None
+    try:
+        current = int(armour.get("condition", 0))
+    except (TypeError, ValueError):
+        current = 0
+    enchanted_flag = str(armour.get("enchanted", "")).lower()
+    enchant_level = armour.get("enchant_level", 0)
+    if enchanted_flag == "yes" or (isinstance(enchant_level, int) and enchant_level > 0):
+        return {"cracked": False, "condition": current}
+    if current <= 0:
+        _sync_monster_armour_view(monster, armour, {"cracked": False, "condition": 0})
+        return {"cracked": False, "condition": 0}
+    next_condition = max(0, current - wear_amount)
+    payload: Dict[str, Any] = {"cracked": next_condition <= 0, "condition": next_condition}
+    _sync_monster_armour_view(monster, armour, payload)
+    return payload
+
+
+def _apply_armour_wear(
+    monster: MutableMapping[str, Any],
+    wear_amount: int,
+    catalog: Mapping[str, Mapping[str, Any]],
+    bus: Any,
+) -> Optional[Dict[str, Any]]:
+    armour = _resolve_target_armour(monster)
+    if armour is None or wear_amount <= 0:
+        return None
+    iid = armour.get("iid") or armour.get("instance_id")
+    iid_str = str(iid) if iid else None
+    result: Optional[Dict[str, Any]] = None
+    if iid_str:
+        try:
+            result = items_wear.apply_wear(iid_str, wear_amount)
+        except KeyError:
+            result = None
+    if result is None:
+        result = _apply_armour_local(monster, armour, wear_amount)
+    else:
+        _sync_monster_armour_view(monster, armour, result)
+    if not result:
+        return None
+    if result.get("cracked"):
+        inst: Mapping[str, Any] | None = None
+        if iid_str:
+            inst = itemsreg.get_instance(iid_str)
+        if not inst:
+            inst = {"item_id": armour.get("item_id"), "iid": iid_str}
+        tpl = catalog.get(str(inst.get("item_id"))) or {}
+        target_name = _monster_display_name(monster, str(monster.get("id") or "target"))
+        suffix = "'" if target_name.endswith("s") else "'s"
+        name = item_label(inst, tpl, show_charges=False)
+        bus.push("COMBAT/INFO", f"{target_name}{suffix} {name} cracks!")
+    return result
+
+
+def _clamp_melee_damage(monster: Mapping[str, Any], damage: int) -> int:
+    if damage <= 0:
+        return 0
+    current, maximum = _sanitize_hp(monster)
+    if maximum <= 0:
+        return damage
+    if current != maximum or current <= 1:
+        return damage
+    if damage >= current:
+        return max(0, current - 1)
+    return damage
+
+
+def _coerce_iid(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, Mapping):
+        for key in ("wielded", "iid", "instance_id", "weapon"):
+            candidate = _coerce_iid(value.get(key))
+            if candidate:
+                return candidate
+    return None
+
+
+def _extract_wielded_iid(payload: Any, cls: Optional[str]) -> Optional[str]:
+    if not isinstance(payload, Mapping):
+        return None
+    direct = _coerce_iid(payload.get("wielded"))
+    if direct:
+        return direct
+    if cls:
+        wield_map = payload.get("wielded_by_class")
+        if isinstance(wield_map, Mapping):
+            entry = wield_map.get(cls)
+            candidate = _coerce_iid(entry)
+            if candidate:
+                return candidate
+    return None
+
+
+def strike_cmd(arg: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    bus = ctx.get("feedback_bus")
+    if bus is None:
+        raise ValueError("strike command requires feedback_bus in context")
+
+    monsters = _load_monsters(ctx)
+    if monsters is None:
+        bus.push("SYSTEM/WARN", "No monsters are available to strike.")
+        return {"ok": False, "reason": "no_monsters"}
+
+    state, active = pstate.get_active_pair()
+    target_id = pstate.get_ready_target_for_active(state)
+    if not target_id:
+        bus.push("SYSTEM/WARN", "You're not ready to combat anyone!")
+        return {"ok": False, "reason": "no_target"}
+
+    target = None
+    getter = getattr(monsters, "get", None)
+    if callable(getter):
+        target = getter(target_id)
+    if target is None:
+        bus.push("SYSTEM/WARN", "Your target is nowhere to be found.")
+        pstate.clear_ready_target_for_active(reason="target-missing")
+        return {"ok": False, "reason": "target_missing"}
+
+    if not isinstance(target, MutableMapping):
+        bus.push("SYSTEM/WARN", "You cannot strike that target.")
+        return {"ok": False, "reason": "invalid_target"}
+
+    if not _is_alive(target):
+        bus.push("SYSTEM/WARN", "Your target is already dead.")
+        pstate.clear_ready_target_for_active(reason="target-dead")
+        return {"ok": False, "reason": "target_dead"}
+
+    catalog = {}  # type: Dict[str, Mapping[str, Any]]
+    try:
+        catalog = items_catalog.load_catalog() or {}
+    except FileNotFoundError:
+        catalog = {}
+
+    cls_name = pstate.get_active_class(state)
+    weapon_iid = pstate.get_wielded_weapon_id(state)
+    if not weapon_iid:
+        weapon_iid = pstate.get_wielded_weapon_id(active)
+    if not weapon_iid:
+        weapon_iid = _extract_wielded_iid(state, cls_name)
+    if not weapon_iid:
+        weapon_iid = _extract_wielded_iid(active, cls_name)
+    if not weapon_iid:
+        weapon_iid = pstate.get_wielded_weapon_id(pstate.load_state())
+    if not weapon_iid:
+        weapon_iid = _extract_wielded_iid(pstate.load_state(), cls_name)
+    damage_item = weapon_iid if weapon_iid else {}
+    raw_damage = damage_engine.compute_base_damage(damage_item, active, target)
+    final_damage = max(0, int(raw_damage))
+    if not weapon_iid:
+        final_damage = max(MIN_INNATE_DAMAGE, final_damage)
+
+    final_damage = _clamp_melee_damage(target, final_damage)
+
+    wear_amount = items_wear.wear_from_event({"kind": "strike", "damage": final_damage})
+
+    if final_damage > 0:
+        _apply_weapon_wear(weapon_iid, wear_amount, catalog, bus)
+        if isinstance(target, MutableMapping):
+            _apply_armour_wear(target, wear_amount, catalog, bus)
+
+    current_hp, max_hp = _sanitize_hp(target)
+    new_hp = max(0, current_hp - final_damage)
+    hp_block = target.setdefault("hp", {})
+    if isinstance(hp_block, MutableMapping):
+        hp_block["current"] = new_hp
+        if "max" not in hp_block:
+            hp_block["max"] = max_hp
+
+    result: Dict[str, Any] = {
+        "ok": True,
+        "damage": final_damage,
+        "target_id": target_id,
+        "remaining_hp": new_hp,
+    }
+
+    label = _monster_display_name(target, target_id)
+    bus.push("COMBAT/HIT", f"You strike {label} for {final_damage} damage.")
+
+    killed = final_damage > 0 and new_hp <= 0
+    if killed:
+        killer_id = str(active.get("id") or state.get("active_id") or "player")
+        killer_label = pstate.get_active_class(state)
+        killer_meta = {"killer_id": killer_id, "killer_class": killer_label, "victim_id": target_id}
+        finisher = getattr(monsters, "kill_monster", None)
+        if callable(finisher):
+            try:
+                finisher(target_id)
+            except Exception:
+                pass
+        pstate.clear_ready_target_for_active(reason="monster-dead")
+        bus.push("COMBAT/KILL", f"You slay {label}!", **killer_meta)
+        result["killed"] = True
+    else:
+        marker = getattr(monsters, "mark_dirty", None)
+        if callable(marker):
+            try:
+                marker()
+            except Exception:
+                pass
+    return result
+
+
+def register(dispatch, ctx) -> None:
+    dispatch.register("strike", lambda arg: strike_cmd(arg, ctx))
+    dispatch.alias("str", "strike")
+    dispatch.alias("hit", "strike")
+    dispatch.alias("att", "strike")

--- a/tests/test_commands_strike.py
+++ b/tests/test_commands_strike.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List
+
+import pytest
+
+from mutants.commands import strike
+from mutants.registries import items_catalog, items_instances as itemsreg
+from mutants.services import damage_engine, player_state as pstate
+
+
+class Bus:
+    def __init__(self) -> None:
+        self.msgs: List[tuple[str, str, Dict[str, Any]]] = []
+
+    def push(self, kind: str, text: str, **meta: Any) -> None:
+        self.msgs.append((kind, text, dict(meta)))
+
+
+class DummyMonsters:
+    def __init__(self, monsters: List[Dict[str, Any]]) -> None:
+        self._monsters = {monster["id"]: monster for monster in monsters}
+        self.killed: List[str] = []
+        self.dirty_calls = 0
+
+    def get(self, monster_id: str) -> Dict[str, Any] | None:
+        return self._monsters.get(monster_id)
+
+    def mark_dirty(self) -> None:
+        self.dirty_calls += 1
+
+    def kill_monster(self, monster_id: str) -> Dict[str, Any]:
+        monster = self._monsters.pop(monster_id, None)
+        if monster is None:
+            return {"monster": None, "drops": [], "pos": None}
+        hp = monster.setdefault("hp", {})
+        if isinstance(hp, dict):
+            hp["current"] = 0
+        self.killed.append(monster_id)
+        return {"monster": monster, "drops": [], "pos": monster.get("pos")}
+
+
+def _base_state() -> Dict[str, Any]:
+    stats = {"str": 10, "dex": 12, "int": 8, "wis": 9, "con": 11, "cha": 7}
+    hp = {"current": 30, "max": 30}
+    player = {
+        "id": "p1",
+        "name": "Thief",
+        "class": "Thief",
+        "pos": [2000, 1, 1],
+        "stats": dict(stats),
+        "hp": dict(hp),
+        "inventory": [],
+        "bags": {"Thief": []},
+        "bags_by_class": {"Thief": []},
+        "equipment_by_class": {"Thief": {"armour": None}},
+        "wielded_by_class": {"Thief": None},
+        "ready_target_by_class": {"Thief": None},
+        "ready_target": None,
+        "target_monster_id": None,
+        "wielded": None,
+        "armour": {"wearing": None},
+        "ions": 0,
+        "Ions": 0,
+        "riblets": 0,
+        "Riblets": 0,
+        "exp_points": 0,
+        "level": 1,
+        "exhaustion": 0,
+    }
+    state = {
+        "players": [copy.deepcopy(player)],
+        "active_id": "p1",
+        "active": copy.deepcopy(player),
+        "inventory": [],
+        "bags": {"Thief": []},
+        "bags_by_class": {"Thief": []},
+        "equipment_by_class": {"Thief": {"armour": None}},
+        "wielded_by_class": {"Thief": None},
+        "ready_target_by_class": {"Thief": None},
+        "stats_by_class": {"Thief": dict(stats)},
+        "hp_by_class": {"Thief": dict(hp)},
+        "ions_by_class": {"Thief": 0},
+        "riblets_by_class": {"Thief": 0},
+        "exp_by_class": {"Thief": 0},
+        "level_by_class": {"Thief": 1},
+        "stats": dict(stats),
+        "hp": dict(hp),
+        "ions": 0,
+        "Ions": 0,
+        "riblets": 0,
+        "Riblets": 0,
+        "exp_points": 0,
+        "level": 1,
+        "exhaustion": 0,
+        "wielded": None,
+        "ready_target": None,
+        "target_monster_id": None,
+    }
+    return state
+
+
+def _make_monster(
+    *,
+    monster_id: str = "ogre#1",
+    name: str = "Ogre",
+    hp: int = 40,
+    max_hp: int | None = None,
+    ac: int = 10,
+    armour_iid: str | None = None,
+    armour_item: str = "chain_mail",
+    armour_condition: int = 100,
+    armour_enchant: int = 0,
+) -> Dict[str, Any]:
+    maximum = max_hp if max_hp is not None else hp
+    monster = {
+        "id": monster_id,
+        "name": name,
+        "hp": {"current": hp, "max": maximum},
+        "stats": {"dex": 10},
+        "derived": {"dex_bonus": 0, "armour_class": ac},
+        "armour_slot": None,
+    }
+    if armour_iid is not None:
+        monster["armour_slot"] = {
+            "iid": armour_iid,
+            "item_id": armour_item,
+            "condition": armour_condition,
+            "enchanted": "yes" if armour_enchant else "no",
+            "enchant_level": armour_enchant,
+            "derived": {"armour_class": ac},
+        }
+    return monster
+
+
+@pytest.fixture
+def in_memory_instances(monkeypatch):
+    data: List[Dict[str, Any]] = []
+
+    def fake_cache() -> List[Dict[str, Any]]:
+        return data
+
+    monkeypatch.setattr(itemsreg, "_cache", fake_cache)
+    return data
+
+
+@pytest.fixture
+def strike_env(monkeypatch, in_memory_instances):
+    state_store: Dict[str, Any] = {}
+
+    def fake_load_state() -> Dict[str, Any]:
+        return copy.deepcopy(state_store)
+
+    def fake_save_state(new_state: Dict[str, Any]) -> None:
+        state_store.clear()
+        state_store.update(copy.deepcopy(new_state))
+
+    monkeypatch.setattr(pstate, "load_state", fake_load_state)
+    monkeypatch.setattr(pstate, "save_state", fake_save_state)
+
+    catalog: Dict[str, Dict[str, Any]] = {}
+    monkeypatch.setattr(items_catalog, "load_catalog", lambda: catalog)
+
+    def setup(
+        *,
+        stats: Dict[str, int] | None = None,
+        weapon: Dict[str, Any] | None = None,
+        ready_target: str | None = None,
+    ) -> None:
+        base = _base_state()
+        catalog.clear()
+        catalog.update(
+            {
+                itemsreg.BROKEN_WEAPON_ID: {"name": "Broken Weapon", "base_power": 0},
+                itemsreg.BROKEN_ARMOUR_ID: {"name": "Broken Armour", "armour": True, "armour_class": 0},
+            }
+        )
+        in_memory_instances.clear()
+        if stats:
+            for key, value in stats.items():
+                base["stats"][key] = value
+                base["players"][0]["stats"][key] = value
+                base["active"]["stats"][key] = value
+                base["stats_by_class"]["Thief"][key] = value
+        if weapon:
+            iid = weapon["iid"]
+            base["bags"]["Thief"].append(iid)
+            base["inventory"].append(iid)
+            base["players"][0]["bags"]["Thief"].append(iid)
+            base["players"][0]["inventory"].append(iid)
+            base["active"]["bags"]["Thief"].append(iid)
+            base["active"]["inventory"].append(iid)
+            base["wielded_by_class"]["Thief"] = {"wielded": iid}
+            base["wielded"] = iid
+            base["players"][0]["wielded_by_class"]["Thief"] = {"wielded": iid}
+            base["players"][0]["wielded"] = iid
+            base["active"]["wielded_by_class"]["Thief"] = {"wielded": iid}
+            base["active"]["wielded"] = iid
+            inst = {
+                "iid": iid,
+                "instance_id": iid,
+                "item_id": weapon["item_id"],
+                "enchanted": weapon.get("enchanted", "no"),
+                "enchant_level": weapon.get("enchant_level", 0),
+                "condition": weapon.get("condition", 100),
+            }
+            inst.update(weapon.get("extra", {}))
+            in_memory_instances.append(inst)
+            catalog[weapon["item_id"]] = {
+                "name": weapon.get("name", weapon["item_id"].replace("_", " ").title()),
+                "base_power": weapon.get("base_power", 0),
+            }
+        state_store.clear()
+        state_store.update(copy.deepcopy(base))
+        pstate.save_state(copy.deepcopy(base))
+        if ready_target:
+            pstate.set_ready_target_for_active(ready_target)
+
+    return {
+        "setup": setup,
+        "state": state_store,
+        "catalog": catalog,
+        "instances": in_memory_instances,
+    }
+
+
+def test_strike_requires_ready_target(strike_env):
+    strike_env["setup"]()
+    bus = Bus()
+    monsters = DummyMonsters([])
+    ctx = {"feedback_bus": bus, "monsters": monsters}
+
+    result = strike.strike_cmd("", ctx)
+
+    assert result["ok"] is False
+    assert result["reason"] == "no_target"
+    assert any("not ready" in msg for _, msg, _ in bus.msgs)
+
+
+def test_strike_weapon_damage_formula(strike_env, monkeypatch):
+    strike_env["setup"](
+        stats={"str": 500},
+        weapon={
+            "iid": "blade#1",
+            "item_id": "ion_blade",
+            "base_power": 10,
+            "enchant_level": 3,
+            "enchanted": "yes",
+            "condition": 100,
+            "name": "Ion Blade",
+        },
+        ready_target="ogre#1",
+    )
+    strike_env["catalog"].update({"plate": {"name": "Plate", "armour": True, "armour_class": 20}})
+    monster = _make_monster(hp=200, max_hp=200, ac=20, armour_iid="ogre_armour", armour_item="plate")
+    monsters = DummyMonsters([monster])
+    bus = Bus()
+    ctx = {"feedback_bus": bus, "monsters": monsters}
+    state, active = pstate.get_active_pair()
+    assert pstate.get_active_class(state) == "Thief"
+    assert damage_engine.get_attacker_power("blade#1", active) == 72
+    assert damage_engine.get_total_ac(monster) == 20
+    assert damage_engine.compute_base_damage("blade#1", active, monster) == 52
+
+    monkeypatch.setattr(pstate, "get_wielded_weapon_id", lambda payload=None: "blade#1")
+
+    recorded: Dict[str, Any] = {}
+
+    original_compute = strike.damage_engine.compute_base_damage
+
+    def _recording_compute(item: Any, attacker: Any, defender: Any) -> int:
+        value = original_compute(item, attacker, defender)
+        recorded["raw"] = value
+        recorded["item"] = item
+        recorded["attacker"] = attacker
+        recorded["defender"] = defender
+        recorded["power"] = damage_engine.get_attacker_power(item, attacker)
+        recorded["ac"] = damage_engine.get_total_ac(defender)
+        return value
+
+    monkeypatch.setattr(strike.damage_engine, "compute_base_damage", _recording_compute)
+
+    result = strike.strike_cmd("", ctx)
+
+    assert result["ok"] is True
+    assert recorded["attacker"]["stats"]["str"] == 500
+    assert damage_engine.get_attacker_power("blade#1", recorded["attacker"]) == 72
+    assert damage_engine.get_total_ac(recorded["defender"]) == 20
+    assert recorded.get("raw") == 52
+    assert result["damage"] == 52
+    assert monster["hp"]["current"] == 148
+    assert any("You strike" in text and "52" in text for _, text, _ in bus.msgs)
+
+
+def test_strike_innate_has_minimum_damage(strike_env):
+    strike_env["setup"](stats={"str": 10}, ready_target="ogre#1")
+    monster = _make_monster(ac=30)
+    monsters = DummyMonsters([monster])
+    bus = Bus()
+    ctx = {"feedback_bus": bus, "monsters": monsters}
+
+    result = strike.strike_cmd("", ctx)
+
+    assert result["damage"] == 6
+    assert monster["hp"]["current"] == monster["hp"]["max"] - 6
+    assert any("6 damage" in text for _, text, _ in bus.msgs)
+
+
+def test_strike_applies_wear_and_cracks_items(strike_env, monkeypatch):
+    strike_env["setup"](
+        stats={"str": 120},
+        weapon={
+            "iid": "rusty#1",
+            "item_id": "rusty_blade",
+            "base_power": 20,
+            "enchant_level": 0,
+            "enchanted": "no",
+            "condition": 4,
+            "name": "Rusty Blade",
+        },
+        ready_target="ogre#1",
+    )
+    strike_env["catalog"].update(
+        {
+            "rusty_blade": {"name": "Rusty Blade", "base_power": 20},
+            "chain_mail": {"name": "Chain Mail", "armour": True, "armour_class": 10},
+        }
+    )
+    strike_env["instances"].append(
+        {
+            "iid": "ogre_armour",
+            "instance_id": "ogre_armour",
+            "item_id": "chain_mail",
+            "enchanted": "no",
+            "enchant_level": 0,
+            "condition": 3,
+        }
+    )
+    monster = _make_monster(
+        ac=10,
+        armour_iid="ogre_armour",
+        armour_item="chain_mail",
+        armour_condition=3,
+    )
+    monsters = DummyMonsters([monster])
+    bus = Bus()
+    ctx = {"feedback_bus": bus, "monsters": monsters}
+    monkeypatch.setattr(pstate, "get_wielded_weapon_id", lambda payload=None: "rusty#1")
+
+    result = strike.strike_cmd("", ctx)
+
+    assert result["damage"] > 0
+    weapon_inst = itemsreg.get_instance("rusty#1")
+    assert weapon_inst["item_id"] == itemsreg.BROKEN_WEAPON_ID
+    armour_inst = itemsreg.get_instance("ogre_armour")
+    assert armour_inst["item_id"] == itemsreg.BROKEN_ARMOUR_ID
+    armour = monster["armour_slot"]
+    assert armour["item_id"] == itemsreg.BROKEN_ARMOUR_ID
+    assert armour["condition"] == 0
+    assert monster["derived"]["armour_class"] == monster["derived"].get("dex_bonus", 0)
+    crack_msgs = "\n".join(text for _, text, _ in bus.msgs)
+    assert "Broken-Weapon" in crack_msgs
+    assert "Broken-Armour" in crack_msgs or "Broken Armour" in crack_msgs
+
+
+def test_strike_clamps_fatal_full_hp_blow(strike_env, monkeypatch):
+    strike_env["setup"](
+        stats={"str": 200},
+        weapon={
+            "iid": "greatsword#1",
+            "item_id": "greatsword",
+            "base_power": 80,
+            "enchant_level": 0,
+            "condition": 100,
+            "name": "Greatsword",
+        },
+        ready_target="ogre#1",
+    )
+    strike_env["catalog"]["greatsword"] = {"name": "Greatsword", "base_power": 80}
+    monster = _make_monster(hp=40, max_hp=40, ac=10)
+    monsters = DummyMonsters([monster])
+    bus = Bus()
+    ctx = {"feedback_bus": bus, "monsters": monsters}
+
+    monkeypatch.setattr(pstate, "get_wielded_weapon_id", lambda payload=None: "greatsword#1")
+
+    result = strike.strike_cmd("", ctx)
+
+    assert result["damage"] == 39
+    assert monster["hp"]["current"] == 1
+    assert all(kind != "COMBAT/KILL" for kind, _, _ in bus.msgs)
+
+
+def test_strike_can_kill_when_target_weakened(strike_env, monkeypatch):
+    strike_env["setup"](
+        stats={"str": 160},
+        weapon={
+            "iid": "warhammer#1",
+            "item_id": "warhammer",
+            "base_power": 60,
+            "enchant_level": 0,
+            "condition": 100,
+            "name": "Warhammer",
+        },
+        ready_target="ogre#1",
+    )
+    strike_env["catalog"]["warhammer"] = {"name": "Warhammer", "base_power": 60}
+    monster = _make_monster(hp=20, max_hp=50, ac=5)
+    monsters = DummyMonsters([monster])
+    bus = Bus()
+    ctx = {"feedback_bus": bus, "monsters": monsters}
+
+    monkeypatch.setattr(pstate, "get_wielded_weapon_id", lambda payload=None: "warhammer#1")
+
+    result = strike.strike_cmd("", ctx)
+
+    assert result.get("killed") is True
+    assert monsters.killed == ["ogre#1"]
+    assert any(kind == "COMBAT/KILL" for kind, _, _ in bus.msgs)
+    assert pstate.get_ready_target_for_active(pstate.load_state()) is None


### PR DESCRIPTION
## Summary
- add a player `strike` command that validates targets, applies damage with full-HP melee clamp, and triggers wear/cracking messages
- integrate innate minimum damage and item wear handling into the strike flow
- cover strike command behaviour with a comprehensive pytest suite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d303bc6d90832bae52225aae324c34