### PR TITLE
Add monster turn tick hook after player commands

### DIFF
--- a/src/mutants/services/monster_actions.py
+++ b/src/mutants/services/monster_actions.py
@@ -1,0 +1,20 @@
+"""Placeholder monster action helpers.
+
+These routines will be fleshed out by subsequent tasks. The AI tick hook only
+needs an entry point it can call for now, so the implementation is a no-op.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def execute_random_action(monster: Any, ctx: Any, *, rng: Any | None = None) -> None:
+    """Execute a placeholder action for *monster*.
+
+    The implementation intentionally does nothing; it exists so the AI turn
+    hook can invoke a stable API that later tasks will replace with concrete
+    behaviour.
+    """
+
+    return None
+

--- a/src/mutants/services/monster_ai.py
+++ b/src/mutants/services/monster_ai.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+from mutants.services import player_state as pstate
+
+from . import monster_actions
+
+LOG = logging.getLogger(__name__)
+
+# Default weights for the number of action credits (0..3) a monster may earn on
+# a tick. The distribution favours zero or one action while still allowing
+# occasional bursts, matching the "sometimes nothing, sometimes bursty" brief.
+DEFAULT_CREDIT_WEIGHTS: tuple[float, float, float, float] = (
+    0.5,
+    0.3,
+    0.15,
+    0.05,
+)
+
+
+def _pull(ctx: Any, key: str) -> Any:
+    if isinstance(ctx, Mapping):
+        return ctx.get(key)
+    return getattr(ctx, key, None)
+
+
+def _normalize_id(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        token = value.strip()
+        return token or None
+    try:
+        token = str(value).strip()
+    except Exception:
+        return None
+    return token or None
+
+
+def _normalize_pos(value: Any) -> tuple[int, int, int] | None:
+    coords: Iterable[Any]
+    if isinstance(value, Mapping):
+        coords = (value.get("year"), value.get("x"), value.get("y"))
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        coords = value
+    else:
+        return None
+
+    raw = list(coords)
+    if len(raw) != 3:
+        return None
+    try:
+        year, x, y = (int(raw[0]), int(raw[1]), int(raw[2]))
+    except (TypeError, ValueError):
+        return None
+    return year, x, y
+
+
+def _is_alive(monster: Mapping[str, Any]) -> bool:
+    hp_block = monster.get("hp")
+    if isinstance(hp_block, Mapping):
+        try:
+            return int(hp_block.get("current", 0)) > 0
+        except (TypeError, ValueError):
+            return True
+    return True
+
+
+def _monster_id(monster: Mapping[str, Any]) -> str:
+    for key in ("id", "instance_id", "monster_id"):
+        mid = _normalize_id(monster.get(key))
+        if mid:
+            return mid
+    return "?"
+
+
+def _resolve_rng(ctx: Any) -> random.Random:
+    candidate = _pull(ctx, "monster_ai_rng")
+    if candidate and hasattr(candidate, "random"):
+        return candidate  # type: ignore[return-value]
+    rng = getattr(_resolve_rng, "_rng", None)
+    if not isinstance(rng, random.Random):
+        rng = random.Random()
+        setattr(_resolve_rng, "_rng", rng)
+    return rng
+
+
+def _sanitize_weights(weights: Any) -> tuple[float, float, float, float] | None:
+    if isinstance(weights, Sequence) and not isinstance(weights, (str, bytes)):
+        sanitized: list[float] = []
+        for value in list(weights)[:4]:
+            try:
+                weight = float(value)
+            except (TypeError, ValueError):
+                return None
+            sanitized.append(max(0.0, weight))
+        while len(sanitized) < 4:
+            sanitized.append(0.0)
+        if any(sanitized):
+            return tuple(sanitized)  # type: ignore[return-value]
+    return None
+
+
+def _resolve_weights(ctx: Any) -> tuple[float, float, float, float]:
+    custom = _pull(ctx, "monster_ai_credit_weights")
+    sanitized = _sanitize_weights(custom)
+    if sanitized is not None:
+        return sanitized
+    return DEFAULT_CREDIT_WEIGHTS
+
+
+def _roll_credits(rng: Any, weights: Sequence[float]) -> int:
+    total = float(sum(weights))
+    if total <= 0:
+        return 0
+    roll = float(getattr(rng, "random")()) * total
+    cumulative = 0.0
+    for idx, weight in enumerate(weights):
+        cumulative += float(weight)
+        if roll < cumulative:
+            return idx
+    return len(weights) - 1
+
+
+def _log_tick(ctx: Any, monster: Mapping[str, Any], credits: int) -> None:
+    mid = _monster_id(monster)
+    message = f"mon={mid} credits={credits}"
+    logsink = _pull(ctx, "logsink")
+    if logsink and hasattr(logsink, "handle"):
+        try:
+            logsink.handle({"ts": "", "kind": "AI/TICK", "text": message})
+        except Exception:  # pragma: no cover - defensive
+            LOG.exception("Failed to log monster tick to sink")
+    LOG.info("AI/TICK %s", message)
+
+
+def _iter_aggro_monsters(monsters: Any, *, year: int, x: int, y: int) -> Iterable[Mapping[str, Any]]:
+    if monsters is None:
+        return []
+    list_at = getattr(monsters, "list_at", None)
+    if not callable(list_at):
+        return []
+    try:
+        entries = list_at(year, x, y)
+    except Exception:
+        return []
+    result: list[Mapping[str, Any]] = []
+    for entry in entries:
+        if isinstance(entry, Mapping):
+            result.append(entry)
+    return result
+
+
+def on_player_command(ctx: Any, *, token: str, resolved: str | None) -> None:
+    """Advance monster turns after a player command."""
+
+    monsters = _pull(ctx, "monsters")
+    if monsters is None:
+        return
+
+    player_state = _pull(ctx, "player_state")
+    if isinstance(player_state, Mapping):
+        try:
+            state, active = pstate.get_active_pair(player_state)
+        except Exception:
+            state, active = pstate.get_active_pair()
+    else:
+        state, active = pstate.get_active_pair()
+
+    player_id = _normalize_id(active.get("id") if isinstance(active, Mapping) else None)
+    if not player_id:
+        player_id = _normalize_id(state.get("active_id") if isinstance(state, Mapping) else None)
+    if not player_id:
+        return
+
+    pos = None
+    if isinstance(active, Mapping):
+        pos = _normalize_pos(active.get("pos"))
+    if pos is None and isinstance(state, Mapping):
+        pos = _normalize_pos(state.get("pos"))
+    if pos is None:
+        return
+    year, x, y = pos
+
+    rng = _resolve_rng(ctx)
+    weights = _resolve_weights(ctx)
+
+    for monster in _iter_aggro_monsters(monsters, year=year, x=x, y=y):
+        if _normalize_id(monster.get("target_player_id")) != player_id:
+            continue
+        if not _is_alive(monster):
+            continue
+        mon_pos = _normalize_pos(monster.get("pos"))
+        if mon_pos != pos:
+            continue
+
+        credits = _roll_credits(rng, weights)
+        _log_tick(ctx, monster, credits)
+        if credits <= 0:
+            continue
+
+        for _ in range(credits):
+            try:
+                monster_actions.execute_random_action(monster, ctx, rng=rng)
+            except Exception:  # pragma: no cover - defensive
+                LOG.exception("Monster action execution failed", extra={"monster": _monster_id(monster)})
+                break
+

--- a/tests/test_monster_ai_tick.py
+++ b/tests/test_monster_ai_tick.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+
+import pytest
+
+from mutants.repl.dispatch import Dispatch
+from mutants.services import monster_ai
+from mutants.ui.feedback import FeedbackBus
+
+
+class _DummyMonsters:
+    def __init__(self, monsters: Iterable[Mapping[str, Any]]):
+        self._monsters = list(monsters)
+
+    def list_at(self, year: int, x: int, y: int) -> List[Mapping[str, Any]]:
+        return [
+            m
+            for m in self._monsters
+            if m.get("pos") == [int(year), int(x), int(y)]
+        ]
+
+
+class _DummySink:
+    def __init__(self) -> None:
+        self.events: List[Dict[str, str]] = []
+
+    def handle(self, event: Dict[str, str]) -> None:
+        self.events.append(event)
+
+
+class _FixedRng:
+    def __init__(self, values: Iterable[float]):
+        self._values = list(values)
+        if not self._values:
+            self._values = [0.0]
+        self._idx = 0
+
+    def random(self) -> float:
+        value = self._values[min(self._idx, len(self._values) - 1)]
+        self._idx += 1
+        return value
+
+
+@pytest.fixture
+def ctx_base() -> Dict[str, Any]:
+    state = {
+        "active_id": "player-1",
+        "players": [
+            {"id": "player-1", "pos": [2000, 3, 4]},
+        ],
+    }
+    bus = FeedbackBus()
+    sink = _DummySink()
+    return {
+        "player_state": state,
+        "feedback_bus": bus,
+        "logsink": sink,
+    }
+
+
+def _build_dispatch(ctx: Dict[str, Any]) -> Dispatch:
+    dispatch = Dispatch()
+    dispatch.set_feedback_bus(ctx["feedback_bus"])
+    dispatch.set_context(ctx)
+    return dispatch
+
+
+def test_monster_tick_executes_actions(monkeypatch: pytest.MonkeyPatch, ctx_base: Dict[str, Any]) -> None:
+    ctx = dict(ctx_base)
+    monster = {
+        "id": "monster-1",
+        "pos": [2000, 3, 4],
+        "target_player_id": "player-1",
+        "hp": {"current": 5, "max": 5},
+    }
+    ctx["monsters"] = _DummyMonsters([monster])
+    ctx["monster_ai_rng"] = _FixedRng([0.1])
+    ctx["monster_ai_credit_weights"] = [0.0, 0.0, 1.0, 0.0]
+
+    calls: List[str] = []
+
+    def fake_action(mon: Mapping[str, Any], action_ctx: Mapping[str, Any], *, rng: Any | None = None) -> None:
+        calls.append(mon.get("id"))
+
+    monkeypatch.setattr(monster_ai.monster_actions, "execute_random_action", fake_action)
+
+    dispatch = _build_dispatch(ctx)
+    dispatch.register("noop", lambda arg: None)
+
+    dispatch.call("noop", "")
+
+    assert calls == ["monster-1", "monster-1"]
+    assert ctx["logsink"].events
+    kinds = {event["kind"] for event in ctx["logsink"].events}
+    assert kinds == {"AI/TICK"}
+    texts = [event["text"] for event in ctx["logsink"].events]
+    assert any(text.endswith("credits=2") for text in texts)
+
+
+def test_monster_tick_skips_non_aggro(monkeypatch: pytest.MonkeyPatch, ctx_base: Dict[str, Any]) -> None:
+    ctx = dict(ctx_base)
+    monsters = [
+        {
+            "id": "monster-1",
+            "pos": [2000, 3, 4],
+            "target_player_id": "someone-else",
+            "hp": {"current": 5, "max": 5},
+        },
+        {
+            "id": "monster-2",
+            "pos": [2000, 3, 4],
+            "target_player_id": "player-1",
+            "hp": {"current": 0, "max": 5},
+        },
+        {
+            "id": "monster-3",
+            "pos": [2000, 2, 4],
+            "target_player_id": "player-1",
+            "hp": {"current": 5, "max": 5},
+        },
+        {
+            "id": "monster-4",
+            "pos": [2000, 3, 4],
+            "target_player_id": "player-1",
+            "hp": {"current": 5, "max": 5},
+        },
+    ]
+    ctx["monsters"] = _DummyMonsters(monsters)
+    ctx["monster_ai_rng"] = _FixedRng([0.9])
+    ctx["monster_ai_credit_weights"] = [1.0, 0.0, 0.0, 0.0]
+
+    def fail_action(*_: Any, **__: Any) -> None:
+        raise AssertionError("action should not run")
+
+    monkeypatch.setattr(monster_ai.monster_actions, "execute_random_action", fail_action)
+
+    dispatch = _build_dispatch(ctx)
+
+    dispatch.call("unknown", "")  # unresolved command still advances the turn
+
+    events = [event for event in ctx["logsink"].events if event["kind"] == "AI/TICK"]
+    assert events == [{"ts": "", "kind": "AI/TICK", "text": "mon=monster-4 credits=0"}]


### PR DESCRIPTION
## Summary
- call the monster AI tick hook after every player command
- add a service to roll action credits and log AI ticks for targeted monsters
- cover the new behaviour with deterministic tests and provide a placeholder monster action executor

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d30e974628832b99397a4b5d386a86