### PR TITLE
Implement basic monster actions

### DIFF
--- a/src/mutants/services/monster_actions.py
+++ b/src/mutants/services/monster_actions.py
@@ -1,20 +1,517 @@
-"""Placeholder monster action helpers.
+"""Monster action helpers implementing basic deterministic behaviours."""
 
-These routines will be fleshed out by subsequent tasks. The AI tick hook only
-needs an entry point it can call for now, so the implementation is a no-op.
-"""
 from __future__ import annotations
 
-from typing import Any
+import logging
+import random
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional
+
+from mutants.commands import convert as convert_cmd
+from mutants.commands import strike
+from mutants.registries import items_catalog, items_instances as itemsreg
+from mutants.services import damage_engine, items_wear, monsters_state, player_state as pstate
+from mutants.ui import item_display
+
+LOG = logging.getLogger(__name__)
+
+
+MIN_INNATE_DAMAGE = strike.MIN_INNATE_DAMAGE
+
+
+ActionFn = Callable[[MutableMapping[str, Any], MutableMapping[str, Any], random.Random], bool]
+
+
+def _monster_display_name(monster: Mapping[str, Any]) -> str:
+    name = monster.get("name") or monster.get("monster_id")
+    if isinstance(name, str) and name:
+        return name
+    ident = monster.get("id") or monster.get("instance_id")
+    if isinstance(ident, str) and ident:
+        return ident
+    return "The monster"
+
+
+def _feedback_bus(ctx: MutableMapping[str, Any]) -> Any:
+    bus = ctx.get("feedback_bus")
+    return bus
+
+
+def _monsters_state(ctx: MutableMapping[str, Any]) -> Optional[Any]:
+    monsters = ctx.get("monsters")
+    return monsters
+
+
+def _mark_monsters_dirty(ctx: MutableMapping[str, Any]) -> None:
+    monsters = _monsters_state(ctx)
+    marker = getattr(monsters, "mark_dirty", None)
+    if callable(marker):
+        try:
+            marker()
+        except Exception:  # pragma: no cover - defensive
+            LOG.exception("Failed to mark monsters state dirty")
+
+
+def _sanitize_hp_block(payload: Any) -> tuple[int, int]:
+    if isinstance(payload, Mapping):
+        try:
+            current = int(payload.get("current", 0))
+        except (TypeError, ValueError):
+            current = 0
+        try:
+            maximum = int(payload.get("max", current))
+        except (TypeError, ValueError):
+            maximum = current
+        return max(0, current), max(0, maximum)
+    return 0, 0
+
+
+def _ai_state(monster: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    payload = monster.get("_ai_state")
+    if not isinstance(payload, MutableMapping):
+        payload = {}
+        monster["_ai_state"] = payload
+    pickups = payload.get("picked_up")
+    if not isinstance(pickups, list):
+        payload["picked_up"] = []
+    return payload
+
+
+def _picked_up_iids(monster: MutableMapping[str, Any]) -> list[str]:
+    state = _ai_state(monster)
+    pickups = state.get("picked_up")
+    if isinstance(pickups, list):
+        return [str(iid) for iid in pickups if isinstance(iid, str)]
+    return []
+
+
+def _add_picked_up(monster: MutableMapping[str, Any], iid: str) -> None:
+    state = _ai_state(monster)
+    pickups = state.get("picked_up")
+    if not isinstance(pickups, list):
+        pickups = []
+        state["picked_up"] = pickups
+    if iid not in pickups:
+        pickups.append(iid)
+
+
+def _remove_picked_up(monster: MutableMapping[str, Any], iid: str) -> None:
+    state = _ai_state(monster)
+    pickups = state.get("picked_up")
+    if isinstance(pickups, list):
+        try:
+            pickups.remove(iid)
+        except ValueError:
+            pass
+
+
+def _load_catalog() -> Mapping[str, Mapping[str, Any]]:
+    try:
+        catalog = items_catalog.load_catalog()
+    except FileNotFoundError:
+        catalog = None
+    if isinstance(catalog, Mapping):
+        return catalog
+    return {}
+
+
+def _resolve_item_id(inst: Mapping[str, Any]) -> str:
+    for key in ("item_id", "catalog_id", "id"):
+        value = inst.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if value:
+            return str(value)
+    iid = inst.get("iid") or inst.get("instance_id")
+    return str(iid) if iid else ""
+
+
+def _convert_value(catalog: Mapping[str, Any], iid: str, item_id: str) -> int:
+    try:
+        return convert_cmd._convert_value(item_id, catalog, iid)
+    except Exception:
+        return 0
+
+
+def _score_pickup_candidate(
+    inst: Mapping[str, Any],
+    catalog: Mapping[str, Mapping[str, Any]],
+) -> int:
+    item_id = _resolve_item_id(inst)
+    tpl = catalog.get(item_id) if item_id else None
+    base_power = 0
+    if isinstance(tpl, Mapping):
+        try:
+            base_power = int(tpl.get("base_power", 0))
+        except (TypeError, ValueError):
+            base_power = 0
+    enchant = 0
+    try:
+        enchant = int(inst.get("enchant_level", 0))
+    except (TypeError, ValueError):
+        enchant = 0
+    base_damage = max(0, base_power) + (4 * max(0, enchant))
+    convert_val = _convert_value(catalog, str(inst.get("iid")), item_id)
+    return (base_damage * 1000) + max(0, convert_val)
+
+
+def _bag_list(monster: MutableMapping[str, Any]) -> list[MutableMapping[str, Any]]:
+    bag = monster.get("bag")
+    if isinstance(bag, list):
+        cleaned: list[MutableMapping[str, Any]] = []
+        for entry in bag:
+            if isinstance(entry, MutableMapping):
+                cleaned.append(entry)
+        if cleaned is not bag:
+            monster["bag"] = cleaned
+        return cleaned
+    monster["bag"] = []
+    return monster["bag"]  # type: ignore[return-value]
+
+
+def _build_bag_entry(
+    monster: MutableMapping[str, Any],
+    inst: Mapping[str, Any],
+    catalog: Mapping[str, Mapping[str, Any]],
+) -> MutableMapping[str, Any]:
+    iid = inst.get("iid") or inst.get("instance_id")
+    entry: MutableMapping[str, Any] = {"iid": str(iid) if iid else ""}
+    entry["item_id"] = _resolve_item_id(inst)
+    enchant = 0
+    try:
+        enchant = int(inst.get("enchant_level", 0))
+    except (TypeError, ValueError):
+        enchant = 0
+    entry["enchant_level"] = max(0, enchant)
+    condition = inst.get("condition")
+    try:
+        entry["condition"] = max(0, int(condition))
+    except (TypeError, ValueError):
+        if condition is not None:
+            entry["condition"] = 0
+    tpl = catalog.get(entry["item_id"])
+    derived: dict[str, int] = {}
+    if isinstance(tpl, Mapping) and tpl.get("armour"):
+        try:
+            armour_base = int(tpl.get("armour_class", 0))
+        except (TypeError, ValueError):
+            armour_base = 0
+        derived["armour_class"] = max(0, armour_base) + entry["enchant_level"]
+    if isinstance(tpl, Mapping) and tpl.get("base_power") is not None:
+        try:
+            base_power = int(tpl.get("base_power", 0))
+        except (TypeError, ValueError):
+            base_power = 0
+        derived["base_damage"] = max(0, base_power) + (4 * entry["enchant_level"])
+    if derived:
+        entry["derived"] = derived
+    return entry
+
+
+def _refresh_monster(monster: MutableMapping[str, Any]) -> None:
+    try:
+        monsters_state._refresh_monster_derived(monster)
+    except Exception:  # pragma: no cover - defensive
+        LOG.exception("Failed to refresh monster derived stats")
+
+
+def _apply_weapon_wear(
+    monster: MutableMapping[str, Any],
+    weapon_iid: Optional[str],
+    wear_amount: int,
+    catalog: Mapping[str, Mapping[str, Any]],
+    bus: Any,
+) -> None:
+    if not weapon_iid or wear_amount <= 0:
+        return
+    try:
+        result = items_wear.apply_wear(weapon_iid, wear_amount)
+    except KeyError:
+        return
+    if not isinstance(result, Mapping):
+        return
+    bag = _bag_list(monster)
+    for entry in bag:
+        if entry.get("iid") == weapon_iid:
+            inst = itemsreg.get_instance(weapon_iid)
+            if inst:
+                entry["item_id"] = _resolve_item_id(inst)
+                if inst.get("condition") is not None:
+                    try:
+                        entry["condition"] = max(0, int(inst.get("condition", 0)))
+                    except (TypeError, ValueError):
+                        entry["condition"] = 0
+                else:
+                    entry.pop("condition", None)
+                entry["enchant_level"] = max(0, int(inst.get("enchant_level", 0) or 0))
+            break
+    if result.get("cracked"):
+        inst = itemsreg.get_instance(weapon_iid) or {"item_id": weapon_iid}
+        tpl = catalog.get(str(inst.get("item_id"))) or {}
+        name = item_display.item_label(inst, tpl, show_charges=False)
+        if bus is not None and hasattr(bus, "push"):
+            bus.push("COMBAT/INFO", f"{_monster_display_name(monster)}'s {name} cracks!")
+    _refresh_monster(monster)
+
+
+def _apply_player_damage(
+    monster: MutableMapping[str, Any],
+    ctx: MutableMapping[str, Any],
+    rng: random.Random,
+) -> bool:
+    bus = _feedback_bus(ctx)
+    state_hint = ctx.get("player_state") if isinstance(ctx.get("player_state"), Mapping) else None
+    try:
+        state, active = pstate.get_active_pair(state_hint)
+    except Exception:
+        state, active = pstate.get_active_pair()
+    if not isinstance(active, Mapping) or not active:
+        return False
+    hp_block = active.get("hp") if isinstance(active.get("hp"), Mapping) else pstate.get_hp_for_active(state)
+    current, maximum = _sanitize_hp_block(hp_block)
+    if maximum <= 0:
+        maximum = max(current, 1)
+    weapon_iid = monster.get("wielded")
+    damage_item: Any
+    if weapon_iid:
+        damage_item = weapon_iid
+    else:
+        damage_item = {}
+    raw_damage = damage_engine.compute_base_damage(damage_item, monster, active)
+    try:
+        final_damage = max(0, int(raw_damage))
+    except (TypeError, ValueError):
+        final_damage = 0
+    if not weapon_iid:
+        final_damage = max(MIN_INNATE_DAMAGE, final_damage)
+    final_damage = strike._clamp_melee_damage(active, final_damage)
+    if final_damage > 0:
+        wear_amount = items_wear.wear_from_event({"kind": "monster-attack", "damage": final_damage})
+        catalog = _load_catalog()
+        bus_obj = bus if hasattr(bus, "push") else None
+        _apply_weapon_wear(monster, str(weapon_iid) if weapon_iid else None, wear_amount, catalog, bus_obj)
+        if weapon_iid:
+            _mark_monsters_dirty(ctx)
+    new_hp = max(0, current - final_damage)
+    try:
+        pstate.set_hp_for_active(state, {"current": new_hp, "max": maximum})
+    except Exception:  # pragma: no cover - defensive
+        LOG.exception("Failed to persist player HP after monster attack")
+    label = _monster_display_name(monster)
+    if hasattr(bus, "push"):
+        bus.push("COMBAT/INFO", f"{label} strikes you for {final_damage} damage.")
+    return True
+
+
+def _pickup_from_ground(
+    monster: MutableMapping[str, Any],
+    ctx: MutableMapping[str, Any],
+    rng: random.Random,
+) -> bool:
+    pos = monster.get("pos")
+    if not isinstance(pos, Iterable):
+        return False
+    coords = list(pos)
+    if len(coords) != 3:
+        return False
+    try:
+        year, x, y = int(coords[0]), int(coords[1]), int(coords[2])
+    except (TypeError, ValueError):
+        return False
+    ground = itemsreg.list_instances_at(year, x, y)
+    if not ground:
+        return False
+    catalog = _load_catalog()
+    best_inst: Optional[Mapping[str, Any]] = None
+    best_score = -1
+    for inst in ground:
+        if not isinstance(inst, Mapping):
+            continue
+        score = _score_pickup_candidate(inst, catalog)
+        if score > best_score:
+            best_score = score
+            best_inst = inst
+    if not best_inst or best_score <= 0:
+        return False
+    iid = best_inst.get("iid") or best_inst.get("instance_id")
+    if not iid:
+        return False
+    iid_str = str(iid)
+    if not itemsreg.clear_position_at(iid_str, year, x, y):
+        return False
+    entry = _build_bag_entry(monster, best_inst, catalog)
+    bag = _bag_list(monster)
+    bag.append(entry)
+    _add_picked_up(monster, iid_str)
+    _refresh_monster(monster)
+    _mark_monsters_dirty(ctx)
+    bus = _feedback_bus(ctx)
+    if hasattr(bus, "push"):
+        tpl = catalog.get(entry.get("item_id", "")) or {}
+        inst = {"item_id": entry.get("item_id"), "iid": iid_str}
+        name = item_display.item_label(inst, tpl, show_charges=False)
+        bus.push("COMBAT/INFO", f"{_monster_display_name(monster)} picks up {name}.")
+    return True
+
+
+def _convert_item(
+    monster: MutableMapping[str, Any],
+    ctx: MutableMapping[str, Any],
+    rng: random.Random,
+) -> bool:
+    bag = _bag_list(monster)
+    if not bag:
+        return False
+    tracked = set(_picked_up_iids(monster))
+    if not tracked:
+        return False
+    catalog = _load_catalog()
+    best_entry: Optional[MutableMapping[str, Any]] = None
+    best_value = 0
+    for entry in bag:
+        iid = entry.get("iid")
+        if not isinstance(iid, str) or iid not in tracked:
+            continue
+        item_id = entry.get("item_id")
+        if not isinstance(item_id, str) or not item_id:
+            continue
+        value = _convert_value(catalog, iid, item_id)
+        if value > best_value:
+            best_value = value
+            best_entry = entry
+    if not best_entry or best_value <= 0:
+        return False
+    iid = str(best_entry.get("iid"))
+    if best_entry in bag:
+        bag.remove(best_entry)
+    _remove_picked_up(monster, iid)
+    if monster.get("wielded") == iid:
+        monster["wielded"] = None
+    itemsreg.delete_instance(iid)
+    monster["ions"] = max(0, int(monster.get("ions", 0))) + best_value
+    _refresh_monster(monster)
+    _mark_monsters_dirty(ctx)
+    bus = _feedback_bus(ctx)
+    if hasattr(bus, "push"):
+        label = _monster_display_name(monster)
+        bus.push("COMBAT/INFO", f"A blinding white flash erupts around {label}!")
+        bus.push(
+            "COMBAT/INFO",
+            f"{label} converts loot worth {best_value} ions.",
+        )
+    return True
+
+
+def _remove_broken_armour(
+    monster: MutableMapping[str, Any],
+    ctx: MutableMapping[str, Any],
+    rng: random.Random,
+) -> bool:
+    armour = monster.get("armour_slot")
+    if not isinstance(armour, MutableMapping):
+        return False
+    item_id = armour.get("item_id")
+    if str(item_id) != itemsreg.BROKEN_ARMOUR_ID:
+        return False
+    monster["armour_slot"] = None
+    _refresh_monster(monster)
+    _mark_monsters_dirty(ctx)
+    bus = _feedback_bus(ctx)
+    if hasattr(bus, "push"):
+        bus.push("COMBAT/INFO", f"{_monster_display_name(monster)} discards broken armour.")
+    return True
+
+
+def _heal_stub(
+    monster: MutableMapping[str, Any],
+    ctx: MutableMapping[str, Any],
+    rng: random.Random,
+) -> bool:
+    bus = _feedback_bus(ctx)
+    if hasattr(bus, "push"):
+        bus.push("COMBAT/INFO", f"{_monster_display_name(monster)}'s body is glowing.")
+    return True
+
+
+_ACTION_TABLE: dict[str, ActionFn] = {
+    "attack": _apply_player_damage,
+    "pickup": _pickup_from_ground,
+    "convert": _convert_item,
+    "remove_armour": _remove_broken_armour,
+    "heal": _heal_stub,
+}
+
+
+def _action_weights(
+    monster: MutableMapping[str, Any],
+    ctx: MutableMapping[str, Any],
+) -> list[tuple[str, float]]:
+    current, maximum = _sanitize_hp_block(monster.get("hp"))
+    hp_ratio = 1.0
+    if maximum > 0:
+        hp_ratio = current / maximum if maximum else 1.0
+    bag = _bag_list(monster)
+    tracked = _picked_up_iids(monster)
+    weights: list[tuple[str, float]] = [("attack", 6.0)]
+    pickup_weight = 1.5 if hp_ratio < 0.5 else 1.0
+    convert_weight = 1.0 if tracked else 0.0
+    if hp_ratio < 0.5 and convert_weight:
+        convert_weight *= 1.5
+    armour = monster.get("armour_slot")
+    remove_weight = 1.0 if isinstance(armour, Mapping) and str(armour.get("item_id")) == itemsreg.BROKEN_ARMOUR_ID else 0.0
+    if itemsreg.BROKEN_ARMOUR_ID in {str(entry.get("item_id")) for entry in bag}:
+        pickup_weight *= 1.1
+    heal_enabled = bool(ctx.get("monster_ai_allow_heal"))
+    heal_weight = 0.0
+    if heal_enabled and hp_ratio < 0.9:
+        ions = 0
+        try:
+            ions = int(monster.get("ions", 0))
+        except (TypeError, ValueError):
+            ions = 0
+        if ions > 0:
+            heal_weight = 0.5
+    weights.append(("pickup", pickup_weight if pickup_weight > 0 and ctx.get("allow_pickup", True) else 0.0))
+    weights.append(("convert", convert_weight))
+    weights.append(("remove_armour", remove_weight))
+    weights.append(("heal", heal_weight))
+    return weights
+
+
+def _select_action(
+    monster: MutableMapping[str, Any],
+    ctx: MutableMapping[str, Any],
+    rng: random.Random,
+) -> Optional[str]:
+    weighted = [(name, weight) for name, weight in _action_weights(monster, ctx) if weight > 0]
+    if not weighted:
+        return None
+    total = sum(weight for _, weight in weighted)
+    if total <= 0:
+        return None
+    roll = rng.random() * total
+    cumulative = 0.0
+    for name, weight in weighted:
+        cumulative += weight
+        if roll < cumulative:
+            return name
+    return weighted[-1][0]
 
 
 def execute_random_action(monster: Any, ctx: Any, *, rng: Any | None = None) -> None:
-    """Execute a placeholder action for *monster*.
-
-    The implementation intentionally does nothing; it exists so the AI turn
-    hook can invoke a stable API that later tasks will replace with concrete
-    behaviour.
-    """
-
+    if not isinstance(monster, MutableMapping):
+        return None
+    if not isinstance(ctx, MutableMapping):
+        return None
+    random_obj = rng if isinstance(rng, random.Random) else random.Random()
+    action_name = _select_action(monster, ctx, random_obj)
+    if not action_name:
+        return None
+    action = _ACTION_TABLE.get(action_name)
+    if not action:
+        return None
+    try:
+        action(monster, ctx, random_obj)
+    except Exception:  # pragma: no cover - defensive guard
+        LOG.exception("Monster action %s failed", action_name)
     return None
 

--- a/tests/test_monster_actions.py
+++ b/tests/test_monster_actions.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping
+
+import pytest
+
+from mutants.services import monster_actions
+
+
+class _DummyBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def push(self, kind: str, text: str, **_: Any) -> None:
+        self.events.append((kind, text))
+
+
+class _FixedRng:
+    def __init__(self, values: Iterable[float]) -> None:
+        self._values = list(values)
+        if not self._values:
+            self._values = [0.0]
+        self._idx = 0
+
+    def random(self) -> float:
+        value = self._values[min(self._idx, len(self._values) - 1)]
+        self._idx += 1
+        return value
+
+
+@pytest.fixture(autouse=True)
+def _reset_ai_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(monster_actions, "_mark_monsters_dirty", lambda ctx: ctx.setdefault("_dirty", True))
+
+
+def _force_action(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    monkeypatch.setattr(monster_actions, "_select_action", lambda m, c, r: name)
+
+
+def test_attack_uses_innate_floor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monster = {"id": "ogre#1", "hp": {"current": 10, "max": 10}, "wielded": None}
+    bus = _DummyBus()
+    ctx: Dict[str, Any] = {"feedback_bus": bus}
+
+    state = {"hp_by_class": {"fighter": {"current": 30, "max": 30}}, "active_id": "player"}
+    active = {"hp": {"current": 30, "max": 30}, "stats": {"dex": 10}}
+
+    monkeypatch.setattr(monster_actions.pstate, "get_active_pair", lambda hint=None: (state, active))
+
+    recorded: Dict[str, int] = {}
+
+    def _fake_set_hp(st: Mapping[str, Any], hp: Mapping[str, Any]) -> Mapping[str, Any]:
+        recorded.update(hp)  # type: ignore[arg-type]
+        return dict(hp)
+
+    monkeypatch.setattr(monster_actions.pstate, "set_hp_for_active", _fake_set_hp)
+    monkeypatch.setattr(monster_actions.damage_engine, "compute_base_damage", lambda *args, **kwargs: -5)
+    monkeypatch.setattr(monster_actions.items_wear, "wear_from_event", lambda payload: 0)
+    monkeypatch.setattr(monster_actions, "_apply_weapon_wear", lambda *args, **kwargs: None)
+
+    _force_action(monkeypatch, "attack")
+
+    monster_actions.execute_random_action(monster, ctx, rng=_FixedRng([0.0]))
+
+    assert recorded["current"] == 24 and recorded["max"] == 30
+    assert any("6 damage" in text for _, text in bus.events)
+
+
+def test_pickup_prefers_stronger_item(monkeypatch: pytest.MonkeyPatch) -> None:
+    monster = {"id": "ghoul#1", "hp": {"current": 10, "max": 10}, "pos": [2000, 1, 2], "bag": []}
+    bus = _DummyBus()
+    ctx: Dict[str, Any] = {"feedback_bus": bus}
+
+    ground_items = [
+        {"iid": "weak", "item_id": "club", "enchant_level": 0, "condition": 100},
+        {"iid": "strong", "item_id": "blade", "enchant_level": 0, "condition": 100},
+    ]
+
+    monkeypatch.setattr(monster_actions.itemsreg, "list_instances_at", lambda *_: ground_items)
+    monkeypatch.setattr(monster_actions.itemsreg, "clear_position_at", lambda iid, *args: iid == "strong")
+    monkeypatch.setattr(monster_actions.itemsreg, "get_instance", lambda iid: next((inst for inst in ground_items if inst["iid"] == iid), None))
+    monkeypatch.setattr(monster_actions, "_load_catalog", lambda: {"club": {"base_power": 3}, "blade": {"base_power": 9}})
+
+    _force_action(monkeypatch, "pickup")
+
+    monster_actions.execute_random_action(monster, ctx, rng=_FixedRng([0.0]))
+
+    bag = monster.get("bag") or []
+    assert any(entry.get("iid") == "strong" for entry in bag)
+    assert "strong" in monster_actions._picked_up_iids(monster)
+
+
+def test_convert_only_uses_picked_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    monster = {
+        "id": "lich#1",
+        "hp": {"current": 8, "max": 8},
+        "bag": [
+            {"iid": "native", "item_id": "dagger", "enchant_level": 0},
+            {"iid": "pickup", "item_id": "wand", "enchant_level": 0},
+        ],
+        "ions": 0,
+    }
+    monster_actions._add_picked_up(monster, "pickup")
+
+    bus = _DummyBus()
+    ctx: Dict[str, Any] = {"feedback_bus": bus}
+
+    monkeypatch.setattr(monster_actions, "_load_catalog", lambda: {"wand": {"convert_ions": 1200}})
+    monkeypatch.setattr(monster_actions.itemsreg, "delete_instance", lambda iid: iid == "pickup")
+    monkeypatch.setattr(monster_actions.itemsreg, "get_instance", lambda iid: {"iid": iid, "item_id": "wand"})
+
+    _force_action(monkeypatch, "convert")
+
+    monster_actions.execute_random_action(monster, ctx, rng=_FixedRng([0.0]))
+
+    assert monster["ions"] == 1200
+    assert all(entry.get("iid") != "pickup" for entry in monster["bag"])
+    assert "pickup" not in monster_actions._picked_up_iids(monster)
+    flash_messages = [text for _, text in bus.events if "blinding white flash" in text]
+    assert flash_messages, "convert should emit the blinding white flash line"
+
+
+def test_remove_broken_armour(monkeypatch: pytest.MonkeyPatch) -> None:
+    monster = {
+        "id": "goblin#1",
+        "hp": {"current": 5, "max": 5},
+        "stats": {"dex": 20},
+        "derived": {"dex_bonus": 2, "armour_class": 2},
+        "armour_slot": {"iid": "broken", "item_id": monster_actions.itemsreg.BROKEN_ARMOUR_ID},
+    }
+    bus = _DummyBus()
+    ctx: Dict[str, Any] = {"feedback_bus": bus}
+
+    monkeypatch.setattr(monster_actions, "_load_catalog", lambda: {})
+    monkeypatch.setattr(monster_actions.itemsreg, "get_instance", lambda iid: {"iid": iid, "item_id": monster_actions.itemsreg.BROKEN_ARMOUR_ID})
+
+    _force_action(monkeypatch, "remove_armour")
+
+    monster_actions.execute_random_action(monster, ctx, rng=_FixedRng([0.0]))
+
+    assert monster.get("armour_slot") is None
+    derived = monster.get("derived", {})
+    assert derived.get("armour_class") == derived.get("dex_bonus")
+    assert any("broken armour" in text.lower() for _, text in bus.events)


### PR DESCRIPTION
## Summary
- implement deterministic monster action selection including attack, pickup, convert, armour removal, and heal stub
- update monster attack logic to apply player damage, weapon wear, and conversion messaging
- add unit tests covering monster action behaviours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40490ef80832b9f11c23e954f7a39