### PR TITLE
Implement combat loot rewards and death penalties

### DIFF
--- a/src/mutants/services/combat_loot.py
+++ b/src/mutants/services/combat_loot.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import uuid
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from mutants.registries import items_instances as itemsreg
+from mutants.services.item_transfer import GROUND_CAP
+from mutants.ui.item_display import item_label
+
+
+def _coerce_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _resolve_item_id(entry: Mapping[str, object]) -> str:
+    for key in ("item_id", "catalog_id", "id"):
+        raw = entry.get(key)
+        if isinstance(raw, str) and raw:
+            return raw
+        if raw is not None:
+            return str(raw)
+    return ""
+
+
+def coerce_pos(value, fallback: tuple[int, int, int] | None = None) -> tuple[int, int, int] | None:
+    if isinstance(value, Mapping):
+        coords: Sequence[object] = (
+            value.get("year"),
+            value.get("x"),
+            value.get("y"),
+        )
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        coords = value
+    else:
+        return fallback
+
+    if len(coords) != 3:
+        return fallback
+
+    try:
+        year, x, y = int(coords[0]), int(coords[1]), int(coords[2])
+    except (TypeError, ValueError):
+        return fallback
+    return year, x, y
+
+
+def _persist_instances() -> None:
+    try:
+        itemsreg.save_instances()
+    except Exception:
+        # Persist best-effort; failures are logged by registry helpers.
+        pass
+
+
+def drop_new_entries(
+    entries: Iterable[Mapping[str, object]],
+    pos: tuple[int, int, int],
+    *,
+    origin: str = "monster_drop",
+) -> list[str]:
+    year, x, y = pos
+    minted: list[str] = []
+    raw = itemsreg._cache()  # type: ignore[attr-defined]
+    for entry in entries:
+        item_id = _resolve_item_id(entry)
+        if not item_id:
+            continue
+
+        iid_raw = entry.get("iid") or entry.get("instance_id")
+        iid = str(iid_raw).strip() if iid_raw else ""
+        inst: MutableMapping[str, object] | None = itemsreg.get_instance(iid) if iid else None
+        if inst is None:
+            minted_iid = f"{item_id or 'loot'}#{uuid.uuid4().hex[:8]}"
+            inst = {"iid": minted_iid, "instance_id": minted_iid, "origin": origin}
+            raw.append(inst)
+            iid = minted_iid
+        else:
+            iid = str(inst.get("iid") or inst.get("instance_id") or iid)
+
+        inst["item_id"] = item_id
+        enchant = max(0, _coerce_int(entry.get("enchant_level"), 0))
+        inst["enchant_level"] = enchant
+        inst["enchanted"] = "yes" if enchant > 0 else "no"
+
+        condition = entry.get("condition")
+        if condition is None and enchant > 0:
+            inst.pop("condition", None)
+        elif condition is not None:
+            inst["condition"] = max(0, _coerce_int(condition, 0))
+        else:
+            inst.setdefault("condition", 100)
+
+        tags = entry.get("tags")
+        if isinstance(tags, Iterable) and not isinstance(tags, (str, bytes)):
+            inst["tags"] = [str(tag) for tag in tags if isinstance(tag, str) and tag]
+
+        if entry.get("notes") is not None:
+            inst["notes"] = entry.get("notes")
+
+        inst.setdefault("origin", origin)
+        inst["pos"] = {"year": year, "x": x, "y": y}
+        inst["year"] = year
+        inst["x"] = x
+        inst["y"] = y
+        minted.append(iid)
+
+    _persist_instances()
+    return minted
+
+
+def drop_existing_iids(iids: Iterable[str], pos: tuple[int, int, int]) -> list[str]:
+    year, x, y = pos
+    dropped: list[str] = []
+    for iid in iids:
+        if not iid:
+            continue
+        inst = itemsreg.get_instance(iid)
+        if not inst:
+            continue
+        itemsreg.set_position(iid, year, x, y)
+        inst["pos"] = {"year": year, "x": x, "y": y}
+        inst["year"] = year
+        inst["x"] = x
+        inst["y"] = y
+        dropped.append(str(inst.get("iid") or iid))
+
+    if dropped:
+        _persist_instances()
+    return dropped
+
+
+def spawn_skull(pos: tuple[int, int, int], *, origin: str = "monster_drop") -> list[str]:
+    return drop_new_entries([{"item_id": "skull"}], pos, origin=origin)
+
+
+def _instance_label(inst: Mapping[str, object] | None, catalog: Mapping[str, Mapping[str, object]] | None) -> str:
+    if not inst:
+        return "the item"
+    item_id = str(inst.get("item_id") or inst.get("catalog_id") or inst.get("id") or "item")
+    template = catalog.get(item_id) if isinstance(catalog, Mapping) else {}
+    return item_label(inst, template or {}, show_charges=False)
+
+
+def enforce_capacity(
+    pos: tuple[int, int, int],
+    new_iids: Iterable[str],
+    *,
+    bus=None,
+    catalog: Mapping[str, Mapping[str, object]] | None = None,
+) -> list[str]:
+    year, x, y = pos
+    ground = itemsreg.list_instances_at(year, x, y)
+    overflow = len(ground) - GROUND_CAP
+    if overflow <= 0:
+        return []
+
+    candidates = [iid for iid in new_iids if iid]
+    removed: list[str] = []
+    idx = len(candidates) - 1
+    while overflow > 0 and idx >= 0:
+        iid = candidates[idx]
+        inst = itemsreg.get_instance(iid)
+        if inst:
+            label = _instance_label(inst, catalog)
+            itemsreg.delete_instance(iid)
+            removed.append(iid)
+            overflow -= 1
+            if hasattr(bus, "push"):
+                bus.push("COMBAT/INFO", f"There is no room for {label}; it vaporizes.")
+        idx -= 1
+
+    if removed:
+        _persist_instances()
+    return removed
+

--- a/tests/test_monster_actions.py
+++ b/tests/test_monster_actions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Mapping
+import copy
+from typing import Any, Dict, Iterable, Mapping, MutableMapping
 
 import pytest
 
@@ -142,3 +143,137 @@ def test_remove_broken_armour(monkeypatch: pytest.MonkeyPatch) -> None:
     derived = monster.get("derived", {})
     assert derived.get("armour_class") == derived.get("dex_bonus")
     assert any("broken armour" in text.lower() for _, text in bus.events)
+
+
+def test_monster_kill_player_transfers_loot(monkeypatch: pytest.MonkeyPatch) -> None:
+    data: list[dict[str, Any]] = []
+
+    def fake_cache() -> list[dict[str, Any]]:
+        return data
+
+    monkeypatch.setattr(monster_actions.itemsreg, "_cache", fake_cache)
+    monkeypatch.setattr(monster_actions.itemsreg, "_save_instances_raw", lambda raw: None)
+    monkeypatch.setattr(monster_actions.itemsreg, "save_instances", lambda: None)
+
+    monster = {
+        "id": "ogre#1",
+        "hp": {"current": 10, "max": 10},
+        "pos": [2000, 1, 1],
+        "ions": 3,
+        "riblets": 4,
+    }
+
+    stats = {"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 10, "cha": 10}
+    hp = {"current": 1, "max": 20}
+    active = {
+        "id": "player#1",
+        "class": "Thief",
+        "pos": [2000, 1, 1],
+        "stats": dict(stats),
+        "hp": dict(hp),
+        "inventory": ["dagger#1"],
+        "bags": {"Thief": ["dagger#1"]},
+        "bags_by_class": {"Thief": ["dagger#1"]},
+        "equipment_by_class": {"Thief": {"armour": None}},
+        "wielded_by_class": {"Thief": None},
+        "ions": 15,
+        "Ions": 15,
+        "riblets": 9,
+        "Riblets": 9,
+    }
+    state = {
+        "players": [copy.deepcopy(active)],
+        "active_id": "player#1",
+        "active": copy.deepcopy(active),
+        "inventory": ["dagger#1"],
+        "bags": {"Thief": ["dagger#1"]},
+        "bags_by_class": {"Thief": ["dagger#1"]},
+        "equipment_by_class": {"Thief": {"armour": None}},
+        "wielded_by_class": {"Thief": None},
+        "stats_by_class": {"Thief": dict(stats)},
+        "hp_by_class": {"Thief": dict(hp)},
+        "ions_by_class": {"Thief": 15},
+        "riblets_by_class": {"Thief": 9},
+        "ions": 15,
+        "riblets": 9,
+        "Ions": 15,
+        "Riblets": 9,
+        "pos": [2000, 1, 1],
+    }
+
+    data.append({
+        "iid": "dagger#1",
+        "instance_id": "dagger#1",
+        "item_id": "dagger",
+        "enchant_level": 0,
+        "condition": 80,
+    })
+
+    monkeypatch.setattr(monster_actions.pstate, "get_active_pair", lambda hint=None: (state, active))
+
+    def fake_set_hp(st: Mapping[str, Any], hp_block: Mapping[str, Any]) -> Mapping[str, Any]:
+        state["hp_by_class"]["Thief"] = dict(hp_block)
+        state["active"]["hp"] = dict(hp_block)
+        active["hp"] = dict(hp_block)
+        return dict(hp_block)
+
+    monkeypatch.setattr(monster_actions.pstate, "set_hp_for_active", fake_set_hp)
+    monkeypatch.setattr(monster_actions.pstate, "save_state", lambda payload: None)
+    monkeypatch.setattr(monster_actions.pstate, "clear_ready_target_for_active", lambda reason=None: None)
+    monkeypatch.setattr(monster_actions.pstate, "get_ions_for_active", lambda st: int(st.get("ions", 0)))
+
+    def _fake_set_ions(st: MutableMapping[str, Any], amount: int) -> int:
+        value = int(amount)
+        st["ions"] = value
+        st.setdefault("Ions", value)
+        ions_map = st.setdefault("ions_by_class", {})
+        if isinstance(ions_map, MutableMapping):
+            ions_map["Thief"] = value
+        active_scope = st.setdefault("active", {})
+        if isinstance(active_scope, MutableMapping):
+            active_scope["ions"] = value
+            active_scope["Ions"] = value
+        return value
+
+    monkeypatch.setattr(monster_actions.pstate, "set_ions_for_active", _fake_set_ions)
+    monkeypatch.setattr(monster_actions.pstate, "get_riblets_for_active", lambda st: int(st.get("riblets", 0)))
+
+    def _fake_set_riblets(st: MutableMapping[str, Any], amount: int) -> int:
+        value = int(amount)
+        st["riblets"] = value
+        st.setdefault("Riblets", value)
+        rib_map = st.setdefault("riblets_by_class", {})
+        if isinstance(rib_map, MutableMapping):
+            rib_map["Thief"] = value
+        active_scope = st.setdefault("active", {})
+        if isinstance(active_scope, MutableMapping):
+            active_scope["riblets"] = value
+            active_scope["Riblets"] = value
+        return value
+
+    monkeypatch.setattr(monster_actions.pstate, "set_riblets_for_active", _fake_set_riblets)
+
+    monkeypatch.setattr(monster_actions.damage_engine, "compute_base_damage", lambda *args, **kwargs: 999)
+    monkeypatch.setattr(monster_actions.items_wear, "wear_from_event", lambda payload: 0)
+    monkeypatch.setattr(monster_actions, "_apply_weapon_wear", lambda *args, **kwargs: None)
+    monkeypatch.setattr(monster_actions, "_load_catalog", lambda: {"dagger": {"name": "Dagger"}})
+
+    bus = _DummyBus()
+    ctx: Dict[str, Any] = {"feedback_bus": bus}
+
+    assert monster_actions.pstate.get_ions_for_active(state) == 15
+    assert monster_actions.pstate.get_riblets_for_active(state) == 9
+
+    _force_action(monkeypatch, "attack")
+
+    monster_actions.execute_random_action(monster, ctx, rng=_FixedRng([0.0]))
+
+    assert monster.get("ions") == 18
+    assert monster.get("riblets") == 13
+    assert monster_actions.pstate.get_ions_for_active(state) == 0
+    assert monster_actions.pstate.get_riblets_for_active(state) == 0
+    assert state["inventory"] == []
+    assert state["bags"]["Thief"] == []
+    ground_items = monster_actions.itemsreg.list_instances_at(2000, 1, 1)
+    assert any(inst.get("iid") == "dagger#1" for inst in ground_items)
+    assert any(kind == "COMBAT/KILL" for kind, _ in bus.events)


### PR DESCRIPTION
## Summary
- add a combat_loot service to mint drop instances, spawn skulls, and enforce ground capacity with vaporization messaging
- update strike command to pay out monster currencies, award experience, drop loot plus skulls, and emit kill events before clearing targets
- ensure monsters inheriting currencies and dropping player gear when they kill a player, including kill event emission
- extend combat tests to cover new reward, vaporization, and monster kill scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40c626e90832b956b98042c7be704