### PR TITLE
Track monster gear origins for convert logic

### DIFF
--- a/src/mutants/commands/convert.py
+++ b/src/mutants/commands/convert.py
@@ -12,6 +12,8 @@ from ..util.textnorm import normalize_item_query
 
 LOG_P = logging.getLogger("mutants.playersdbg")
 
+_ORIGIN_WORLD = "world"
+
 
 def _legacy_ions(payload: Dict[str, Any]) -> int:
     if not isinstance(payload, dict):
@@ -114,6 +116,9 @@ def _choose_inventory_item(
     for iid in inventory:
         inst = itemsreg.get_instance(iid)
         if not inst:
+            continue
+        origin = inst.get("origin")
+        if not isinstance(origin, str) or origin.strip().lower() != _ORIGIN_WORLD:
             continue
         item_id = (
             inst.get("item_id")

--- a/src/mutants/services/combat_loot.py
+++ b/src/mutants/services/combat_loot.py
@@ -100,7 +100,11 @@ def drop_new_entries(
         if entry.get("notes") is not None:
             inst["notes"] = entry.get("notes")
 
-        inst.setdefault("origin", origin)
+        entry_origin = entry.get("origin")
+        if isinstance(entry_origin, str) and entry_origin:
+            inst["origin"] = str(entry_origin)
+        else:
+            inst.setdefault("origin", origin)
         inst["pos"] = {"year": year, "x": x, "y": y}
         inst["year"] = year
         inst["x"] = x

--- a/src/mutants/services/item_transfer.py
+++ b/src/mutants/services/item_transfer.py
@@ -4,7 +4,7 @@ import logging
 import os
 import random
 import time
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Tuple
 from ..ui import item_display as idisp
 from ..registries import items_catalog as catreg
 from ..registries import items_instances as itemsreg
@@ -466,6 +466,11 @@ def pick_from_ground(ctx, prefix: str, *, seed: Optional[int] = None) -> Dict:
     ok = itemsreg.clear_position_at(chosen_iid, year, x, y)
     if not ok:
         return {"ok": False, "reason": "That item is no longer on the ground here."}
+    if isinstance(chosen_inst, MutableMapping):
+        chosen_inst["origin"] = "world"
+    actual_inst = itemsreg.get_instance(chosen_iid)
+    if isinstance(actual_inst, MutableMapping):
+        actual_inst["origin"] = "world"
     inv = list(player.get("inventory", []))
     inv.append(chosen_iid)
     player["inventory"] = inv

--- a/src/mutants/services/monster_spawner.py
+++ b/src/mutants/services/monster_spawner.py
@@ -129,6 +129,11 @@ def _clone_inventory(template: Mapping[str, Any]) -> tuple[List[Dict[str, Any]],
             entry["qty"] = qty
         minted = _mint_item_instance_id(template, raw)
         entry["instance_id"] = minted
+        origin_raw = raw.get("origin")
+        if isinstance(origin_raw, str) and origin_raw.strip():
+            entry["origin"] = origin_raw.strip().lower()
+        else:
+            entry["origin"] = "native"
         iid = raw.get("iid")
         if isinstance(iid, str) and iid:
             iid_map[iid] = minted
@@ -151,6 +156,11 @@ def _clone_inventory(template: Mapping[str, Any]) -> tuple[List[Dict[str, Any]],
             entry: Dict[str, Any] = {"instance_id": armour_iid}
             if armour.get("item_id"):
                 entry["item_id"] = str(armour["item_id"])
+            origin_raw = armour.get("origin") if isinstance(armour, Mapping) else None
+            if isinstance(origin_raw, str) and origin_raw.strip():
+                entry["origin"] = origin_raw.strip().lower()
+            else:
+                entry["origin"] = "native"
             if len(inventory) >= 4:
                 # drop the oldest non-armour item to make room
                 inventory.pop(0)

--- a/src/mutants/services/monsters_state.py
+++ b/src/mutants/services/monsters_state.py
@@ -162,6 +162,17 @@ def _normalize_item(
         changed = True
     sanitized["iid"] = iid
 
+    origin_raw = item.get("origin")
+    if isinstance(origin_raw, str):
+        origin_token = origin_raw.strip().lower()
+    else:
+        origin_token = ""
+    if not origin_token:
+        origin_token = "native"
+    if origin_raw != origin_token:
+        changed = True
+    sanitized["origin"] = origin_token
+
     tags = _normalize_tags(item.get("tags"))
     if tags:
         sanitized["tags"] = tags

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -42,3 +42,37 @@ def test_convert_payout_handles_mixed_enchant_levels(monkeypatch):
 
     assert convert._convert_payout("knife_plain", "knife", catalog) == 14000
     assert convert._convert_payout("knife_plus3", "knife", catalog) == 44300
+
+
+def test_choose_inventory_item_skips_non_world(monkeypatch):
+    player = {"inventory": ["native#1", "world#2"]}
+    catalog = _catalog({"sword": {"name": "Sword"}})
+
+    def fake_get_instance(iid: str) -> dict | None:
+        if iid == "native#1":
+            return {"iid": iid, "item_id": "sword", "origin": "native"}
+        if iid == "world#2":
+            return {"iid": iid, "item_id": "sword", "origin": "world"}
+        return None
+
+    monkeypatch.setattr(convert.itemsreg, "get_instance", fake_get_instance)
+
+    iid, item_id = convert._choose_inventory_item(player, "swo", catalog)
+
+    assert iid == "world#2"
+    assert item_id == "sword"
+
+
+def test_choose_inventory_item_returns_none_when_no_world(monkeypatch):
+    player = {"inventory": ["native#1"]}
+    catalog = _catalog({"sword": {"name": "Sword"}})
+
+    monkeypatch.setattr(
+        convert.itemsreg,
+        "get_instance",
+        lambda iid: {"iid": iid, "item_id": "sword", "origin": "native"},
+    )
+
+    iid, item_id = convert._choose_inventory_item(player, "swo", catalog)
+
+    assert iid is None and item_id is None

--- a/tests/test_monster_actions.py
+++ b/tests/test_monster_actions.py
@@ -88,6 +88,7 @@ def test_pickup_prefers_stronger_item(monkeypatch: pytest.MonkeyPatch) -> None:
 
     bag = monster.get("bag") or []
     assert any(entry.get("iid") == "strong" for entry in bag)
+    assert any(entry.get("origin") == "world" for entry in bag if entry.get("iid") == "strong")
     assert "strong" in monster_actions._picked_up_iids(monster)
 
 
@@ -96,8 +97,8 @@ def test_convert_only_uses_picked_items(monkeypatch: pytest.MonkeyPatch) -> None
         "id": "lich#1",
         "hp": {"current": 8, "max": 8},
         "bag": [
-            {"iid": "native", "item_id": "dagger", "enchant_level": 0},
-            {"iid": "pickup", "item_id": "wand", "enchant_level": 0},
+            {"iid": "native", "item_id": "dagger", "enchant_level": 0, "origin": "native"},
+            {"iid": "pickup", "item_id": "wand", "enchant_level": 0, "origin": "world"},
         ],
         "ions": 0,
     }

--- a/tests/test_monster_spawner.py
+++ b/tests/test_monster_spawner.py
@@ -96,6 +96,7 @@ def test_spawner_respects_rate_limit_and_floor(instances):
     assert spawn["ions"] == 5 and spawn["riblets"] == 3
     assert spawn["innate_attack"]["name"] == "Slash"
     assert spawn["armour_wearing"] in {entry.get("instance_id") for entry in spawn["inventory"]}
+    assert all(entry.get("origin") == "native" for entry in spawn["inventory"] if isinstance(entry, dict))
 
     scheduled = controller._years[2000].next_spawn_at
     assert 45 <= scheduled <= 75

--- a/tests/test_monsters_importer.py
+++ b/tests/test_monsters_importer.py
@@ -99,6 +99,7 @@ def test_import_monsters_real_run_persists_and_normalizes(tmp_path, monkeypatch)
     assert monster["id"] == "bandit#1"
     bag_iid = monster["bag"][0]["iid"]
     assert bag_iid
+    assert monster["bag"][0]["origin"] == "native"
     assert monster["wielded"] == bag_iid
     assert report.imported_count == 1
     assert report.minted_iids >= 1

--- a/tests/test_monsters_state.py
+++ b/tests/test_monsters_state.py
@@ -66,12 +66,14 @@ def test_load_state_normalizes_monster_records(tmp_path, monkeypatch):
     assert weapon["condition"] == 100  # enchanted items are non-degrading
     assert weapon["derived"]["effective_weight"] == 20
     assert weapon["derived"]["base_damage"] == 13
+    assert weapon["origin"] == "native"
 
     armour = monster["armour_slot"]
     assert armour is not None
     assert armour["iid"] == "leather#bag"
     assert armour["condition"] == 100
     assert armour["derived"]["armour_class"] == 4
+    assert armour["origin"] == "native"
 
     assert monster["wielded"] == weapon["iid"]
 
@@ -150,6 +152,8 @@ def test_kill_monster_drops_items_and_clears_record(tmp_path):
     armour = monster["armour_slot"]
     weapon["condition"] = 17
     armour["condition"] = 12
+    assert weapon["origin"] == "native"
+    assert armour["origin"] == "native"
 
     summary = state.kill_monster("ogre#1")
 


### PR DESCRIPTION
## Summary
- tag monster bag and armour items with a native origin during normalization and spawning
- carry origin metadata through drops and pickups, marking world pickups on both monsters and players
- gate convert actions to world-origin items and extend tests to cover origin persistence and filtering

## Testing
- pytest tests/test_monsters_state.py tests/test_monster_actions.py tests/test_convert.py tests/test_monsters_importer.py tests/test_monster_spawner.py tests/test_item_transfer_pickup.py

------
https://chatgpt.com/codex/tasks/task_e_68d41937fc74832b90588e89ae93df40