### PR TITLE
Enforce explicit enchantability handling

### DIFF
--- a/src/mutants/registries/items_instances.py
+++ b/src/mutants/registries/items_instances.py
@@ -19,14 +19,9 @@ BROKEN_WEAPON_ID = "broken_weapon"
 BROKEN_ARMOUR_ID = "broken_armour"
 _BROKEN_ITEM_IDS = {BROKEN_WEAPON_ID, BROKEN_ARMOUR_ID}
 
-_SPELL_COMPONENT_KEYS = ("spell_component", "spell_components")
-
 NOT_ENCHANTABLE_REASONS = (
-    "ranged",
-    "spell_component",
+    "not_enchantable",
     "condition",
-    "potion",
-    "spawnable",
     "broken",
     "max_enchant",
 )
@@ -120,26 +115,17 @@ def _normalize_instances(instances: Iterable[Dict[str, Any]]) -> bool:
     return changed
 
 
-def _has_spell_component(template: Optional[Dict[str, Any]]) -> bool:
-    if not isinstance(template, dict):
-        return False
-    return any(_coerce_bool(template.get(key)) for key in _SPELL_COMPONENT_KEYS)
-
-
 def _collect_enchant_blockers(
     inst: Dict[str, Any], template: Optional[Dict[str, Any]]
 ) -> List[str]:
     reasons: List[str] = []
     tpl = template if isinstance(template, dict) else {}
 
-    if _coerce_bool(tpl.get("ranged")):
-        reasons.append("ranged")
-    if _has_spell_component(tpl):
-        reasons.append("spell_component")
-    if _coerce_bool(tpl.get("potion")):
-        reasons.append("potion")
-    if _coerce_bool(tpl.get("spawnable")):
-        reasons.append("spawnable")
+    if tpl:
+        if not _coerce_bool(tpl.get("enchantable")):
+            reasons.append("not_enchantable")
+    else:
+        reasons.append("not_enchantable")
 
     broken = _is_broken_instance(inst) or _is_broken_item_id(str(tpl.get("item_id", "")))
     if broken:

--- a/tests/test_items_catalog.py
+++ b/tests/test_items_catalog.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from mutants.registries import items_catalog
+
+
+def test_normalize_items_rejects_enchantable_ranged():
+    items = [
+        {
+            "item_id": "longbow",
+            "ranged": True,
+            "enchantable": True,
+        }
+    ]
+
+    _warnings, errors = items_catalog._normalize_items(items)
+
+    assert errors
+    assert (
+        "longbow: ranged items must declare enchantable: false." in errors
+    )
+
+
+def test_normalize_items_allows_enchantable_for_unflagged_items():
+    items = [
+        {
+            "item_id": "amulet",
+            "enchantable": True,
+        }
+    ]
+
+    warnings, errors = items_catalog._normalize_items(items)
+
+    assert not errors
+    assert warnings == []


### PR DESCRIPTION
## Summary
- enforce explicit enchantability validation in the catalog normalizer and reject disallowed flag combinations
- remove implicit enchant blockers from item instances so enchanting depends only on catalog data
- cover the new linter and enchanting behaviour with unit tests

## Testing
- pytest tests/test_items_catalog.py tests/test_items_instances.py

------
https://chatgpt.com/codex/tasks/task_e_68d493bc0fb0832b94faf9690e31a42f