### PR TITLE
Centralize state path resolution

### DIFF
--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping
 
-import os, logging
+import logging
+import os
 
 from mutants.bootstrap.lazyinit import ensure_player_state
 from mutants.bootstrap.runtime import ensure_runtime
 from mutants.data.room_headers import ROOM_HEADERS, STORE_FOR_SALE_IDX
 from mutants.registries.world import load_nearest_year
+from mutants.state import state_path
 from mutants.ui import renderer
 from mutants.debug.turnlog import TurnObserver
 from mutants.debug import items_probe
@@ -46,7 +48,7 @@ def _resolve_header_text(tile: dict, year: int) -> str:
 # ---------------------------------------------------------------------------
 
 # Paths
-DEFAULT_THEME_PATH = Path("state/ui/themes/bbs.json")
+DEFAULT_THEME_PATH = state_path("ui", "themes", "bbs.json")
 
 _CURRENT_CTX: Dict[str, Any] | None = None
 

--- a/src/mutants/app/trace.py
+++ b/src/mutants/app/trace.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 import json, os
 
-ROOT = os.getcwd()
-PATH = os.path.join(ROOT, "state", "runtime", "trace.json")
+import json
+import os
+
+from mutants.state import state_path
+
+PATH = state_path("runtime", "trace.json")
 
 
 def _load() -> dict:
     try:
-        with open(PATH, "r", encoding="utf-8") as f:
+        with PATH.open("r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         return {}
 
 
 def _save(d: dict) -> None:
-    os.makedirs(os.path.dirname(PATH), exist_ok=True)
-    tmp = PATH + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
+    PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = PATH.with_name(PATH.name + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
         json.dump(d, f, indent=2)
     os.replace(tmp, PATH)
 

--- a/src/mutants/bootstrap/daily_litter.py
+++ b/src/mutants/bootstrap/daily_litter.py
@@ -21,15 +21,20 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from mutants.registries import items_instances
+from mutants.state import STATE_ROOT
 
 
 LOG = logging.getLogger(__name__)
 
 
 def _paths(root: str | Path | None = None) -> Dict[str, Path]:
-    """Return important runtime paths relative to ``root`` (cwd by default)."""
-    r = Path(root) if root is not None else Path.cwd()
-    state = r / "state"
+    """Return important runtime paths relative to ``root`` (state root by default)."""
+
+    if root is None:
+        state = STATE_ROOT
+    else:
+        base = Path(root)
+        state = base if base.name == "state" else base / "state"
     items = state / "items"
     runtime = state / "runtime"
     world = state / "world"

--- a/src/mutants/bootstrap/runtime.py
+++ b/src/mutants/bootstrap/runtime.py
@@ -1,22 +1,28 @@
 from __future__ import annotations
-import json, re, os
-from pathlib import Path
-from typing import Dict, List, Optional, Iterable
-from mutants.io.atomic import atomic_write_json
-from . import daily_litter
+
+import json
+import os
+import re
 import logging
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from mutants.io.atomic import atomic_write_json
+from mutants.state import STATE_ROOT, state_path
+from . import daily_litter
 
 LOG = logging.getLogger(__name__)
 WORLD_DEBUG = os.getenv("WORLD_DEBUG") == "1"
 WORLD_STRICT = os.getenv("WORLD_STRICT") == "1"
 
-STATE = Path("state")
-WORLD_DIR = STATE / "world"
-ITEMS_DIR = STATE / "items"
-MONS_DIR = STATE / "monsters"
-THEMES_DIR = STATE / "ui" / "themes"
-LOGS_DIR = STATE / "logs"
-CONFIG_PATH = STATE / "config.json"
+STATE = STATE_ROOT
+WORLD_DIR = state_path("world")
+ITEMS_DIR = state_path("items")
+MONS_DIR = state_path("monsters")
+THEMES_DIR = state_path("ui", "themes")
+LOGS_DIR = state_path("logs")
+CONFIG_PATH = state_path("config.json")
+COLORS_PATH = str(state_path("ui", "colors.json"))
 
 # ---------- public API ----------
 def ensure_runtime() -> Dict:
@@ -109,7 +115,7 @@ def _bbs_theme() -> Dict[str, str]:
         "name": "bbs",
         "width": 80,
         "ansi_enabled": True,
-        "colors_path": "state/ui/colors.json",
+        "colors_path": COLORS_PATH,
     }
 
 
@@ -118,7 +124,7 @@ def _mono_theme() -> Dict[str, str]:
         "name": "mono",
         "width": 80,
         "ansi_enabled": False,
-        "colors_path": "state/ui/colors.json",
+        "colors_path": COLORS_PATH,
     }
 
 def create_minimal_world(year: int, size: int = 30, *, reason: str = "unspecified") -> None:

--- a/src/mutants/commands/theme.py
+++ b/src/mutants/commands/theme.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from mutants.state import state_path
 from mutants.ui.themes import load_theme
 from mutants.ui import styles as st
 
@@ -11,7 +12,7 @@ def theme_cmd(arg: str, ctx) -> None:
     if not name:
         ctx["feedback_bus"].push("SYSTEM/ERR", "Usage: theme <name>")
         return
-    path = Path("state/ui/themes") / f"{name}.json"
+    path = state_path("ui", "themes", f"{name}.json")
     try:
         theme = load_theme(str(path))
     except Exception:

--- a/src/mutants/commands/travel.py
+++ b/src/mutants/commands/travel.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterable, Optional
 
 from mutants.registries.world import load_nearest_year
 from mutants.services import player_state as pstate
+from mutants.state import state_path
 from ..services import item_transfer as itx
 
 
@@ -74,11 +75,12 @@ def _available_years(ctx: Dict[str, Any]) -> list[int]:
             except Exception:
                 continue
     else:
-        base_dir = ctx.get("world_dir", "state/world")
+        default_world_dir = state_path("world")
+        base_dir = ctx.get("world_dir", default_world_dir)
         try:
             base_path = Path(base_dir)
         except TypeError:
-            base_path = Path("state/world")
+            base_path = default_world_dir
         if base_path.exists():
             for fpath in base_path.glob("*.json"):
                 try:
@@ -93,7 +95,10 @@ def _resolved_year(ctx: Dict[str, Any], target: int) -> Optional[int]:
     try:
         world = loader(int(target))
     except FileNotFoundError:
-        ctx["feedback_bus"].push("SYSTEM/ERROR", "No worlds found in state/world/.")
+        ctx["feedback_bus"].push(
+            "SYSTEM/ERROR",
+            f"No worlds found in {state_path('world')}/.",
+        )
         return None
     return int(getattr(world, "year", int(target)))
 

--- a/src/mutants/debug/items_probe.py
+++ b/src/mutants/debug/items_probe.py
@@ -5,6 +5,8 @@ import os
 import sys
 from typing import Any, Dict, List, Tuple
 
+from mutants.state import state_path
+
 LOG = logging.getLogger("mutants.itemsdbg")
 
 
@@ -23,8 +25,9 @@ def setup_file_logging() -> None:
         if hasattr(handler, "baseFilename")
     ):
         return
-    os.makedirs("state/logs", exist_ok=True)
-    fh = logging.FileHandler("state/logs/items_debug.log", encoding="utf-8")
+    log_dir = state_path("logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    fh = logging.FileHandler(log_dir / "items_debug.log", encoding="utf-8")
     fmt = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
     fh.setFormatter(fmt)
     LOG.setLevel(logging.INFO)

--- a/src/mutants/registries/dynamics.py
+++ b/src/mutants/registries/dynamics.py
@@ -1,25 +1,28 @@
 from __future__ import annotations
-import json, os, time
+
+import json
+import os
+import time
 from typing import Dict, Optional
 
+from mutants.state import state_path
 from mutants.util.directions import DELTA as _DELTA, OPP as _OPP
 
-ROOT = os.getcwd()
-PATH = os.path.join(ROOT, "state", "world", "dynamics.json")
+PATH = state_path("world", "dynamics.json")
 
 
 def _load() -> Dict[str, Dict]:
     try:
-        with open(PATH, "r", encoding="utf-8") as f:
+        with PATH.open("r", encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         return {}
 
 
 def _save(data: Dict[str, Dict]) -> None:
-    tmp = PATH + ".tmp"
-    os.makedirs(os.path.dirname(PATH), exist_ok=True)
-    with open(tmp, "w", encoding="utf-8") as f:
+    tmp = PATH.with_name(PATH.name + ".tmp")
+    PATH.parent.mkdir(parents=True, exist_ok=True)
+    with tmp.open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
     os.replace(tmp, PATH)
 

--- a/src/mutants/registries/items_catalog.py
+++ b/src/mutants/registries/items_catalog.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
+
 import json
 import logging
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
-DEFAULT_CATALOG_PATH = "state/items/catalog.json"
-FALLBACK_CATALOG_PATH = "state/catalog.json"  # auto-fallback if the new path isn't used yet
+from mutants.state import state_path
+
+DEFAULT_CATALOG_PATH = state_path("items", "catalog.json")
+FALLBACK_CATALOG_PATH = state_path("catalog.json")  # auto-fallback if the new path isn't used yet
 
 DISALLOWED_ENCHANTABLE_FIELDS = (
     ("ranged", "ranged"),
@@ -109,7 +112,7 @@ def _normalize_items(items: List[Dict[str, Any]]) -> tuple[List[str], List[str]]
 
     return warnings, errors
 
-def load_catalog(path: str = DEFAULT_CATALOG_PATH) -> ItemsCatalog:
+def load_catalog(path: Path | str = DEFAULT_CATALOG_PATH) -> ItemsCatalog:
     primary = Path(path)
     fallback = Path(FALLBACK_CATALOG_PATH)
     if primary.exists():

--- a/src/mutants/registries/items_instances.py
+++ b/src/mutants/registries/items_instances.py
@@ -9,11 +9,12 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Tuple
 
 from mutants.io.atomic import atomic_write_json
+from mutants.state import state_path
 from . import items_catalog
 
-DEFAULT_INSTANCES_PATH = "state/items/instances.json"
-FALLBACK_INSTANCES_PATH = "state/instances.json"  # auto-fallback if the new path isn't used yet
-CATALOG_PATH = "state/items/catalog.json"
+DEFAULT_INSTANCES_PATH = state_path("items", "instances.json")
+FALLBACK_INSTANCES_PATH = state_path("instances.json")  # auto-fallback if the new path isn't used yet
+CATALOG_PATH = state_path("items", "catalog.json")
 
 LOG = logging.getLogger("mutants.itemsdbg")
 
@@ -334,7 +335,7 @@ class ItemsInstances:
             self._dirty = False
 
 
-def load_instances(path: str = DEFAULT_INSTANCES_PATH) -> ItemsInstances:
+def load_instances(path: Path | str = DEFAULT_INSTANCES_PATH) -> ItemsInstances:
     """
     Load instances from JSON.
     Supports either:

--- a/src/mutants/registries/monsters_catalog.py
+++ b/src/mutants/registries/monsters_catalog.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
+
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-DEFAULT_CATALOG_PATH = "state/monsters/catalog.json"
+from mutants.state import state_path
+
+DEFAULT_CATALOG_PATH = state_path("monsters", "catalog.json")
 
 # EXP formula (can be adjusted later in one place)
 def exp_for(level: int, exp_bonus: int = 0) -> int:
@@ -58,7 +61,7 @@ def _validate_base_monster(m: Dict[str, Any]) -> None:
             raise ValueError(f"innate_attack missing {f}")
     # ok
 
-def load_monsters_catalog(path: str = DEFAULT_CATALOG_PATH) -> MonstersCatalog:
+def load_monsters_catalog(path: Path | str = DEFAULT_CATALOG_PATH) -> MonstersCatalog:
     p = Path(path)
     if not p.exists():
         raise FileNotFoundError(f"Missing monsters catalog at {p}")

--- a/src/mutants/registries/monsters_instances.py
+++ b/src/mutants/registries/monsters_instances.py
@@ -5,9 +5,10 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from mutants.io.atomic import atomic_write_json
 from mutants.registries.monsters_catalog import MonstersCatalog, exp_for
+from mutants.state import state_path
 
-DEFAULT_INSTANCES_PATH = "state/monsters/instances.json"
-FALLBACK_INSTANCES_PATH = "state/monsters.json"  # optional fallback; rarely used
+DEFAULT_INSTANCES_PATH = state_path("monsters", "instances.json")
+FALLBACK_INSTANCES_PATH = state_path("monsters.json")  # optional fallback; rarely used
 
 class MonstersInstances:
     """
@@ -133,7 +134,7 @@ class MonstersInstances:
             atomic_write_json(self._path, self._items)
             self._dirty = False
 
-def load_monsters_instances(path: str = DEFAULT_INSTANCES_PATH) -> MonstersInstances:
+def load_monsters_instances(path: Path | str = DEFAULT_INSTANCES_PATH) -> MonstersInstances:
     primary = Path(path)
     fallback = Path(FALLBACK_INSTANCES_PATH)
     target = primary if primary.exists() else (fallback if fallback.exists() else primary)

--- a/src/mutants/registries/world.py
+++ b/src/mutants/registries/world.py
@@ -22,17 +22,20 @@ Edge model (per tile):
 
 from __future__ import annotations
 
-import json, os, logging
+import json
+import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from mutants.io.atomic import atomic_write_json
 from mutants.bootstrap.runtime import discover_world_years
+from mutants.io.atomic import atomic_write_json
+from mutants.state import state_path
 
 LOG = logging.getLogger(__name__)
 WORLD_DEBUG = os.getenv("WORLD_DEBUG") == "1"
 
-WORLD_DIR = Path("state/world")
+WORLD_DIR = state_path("world")
 
 # Direction helpers
 from mutants.util.directions import DELTA as _DELTA, OPP as _OPP

--- a/src/mutants/services/equip_debug.py
+++ b/src/mutants/services/equip_debug.py
@@ -4,6 +4,8 @@ import logging
 import os
 from typing import Any, Optional
 
+from mutants.state import state_path
+
 _LOGGER: Optional[logging.Logger] = None
 
 
@@ -20,14 +22,15 @@ def _edbg_setup_file_logging() -> logging.Logger:
     if _LOGGER is not None:
         return _LOGGER
 
-    os.makedirs(os.path.join("state", "logs"), exist_ok=True)
+    log_dir = state_path("logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
 
     logger = logging.getLogger("mutants.equipdbg")
     logger.setLevel(logging.INFO)
     logger.propagate = False
 
     if not logger.handlers:
-        handler = logging.FileHandler(os.path.join("state", "logs", "equip_debug.log"))
+        handler = logging.FileHandler(log_dir / "equip_debug.log")
         handler.setLevel(logging.INFO)
         handler.setFormatter(logging.Formatter("%(message)s"))
         logger.addHandler(handler)

--- a/src/mutants/services/monsters_state.py
+++ b/src/mutants/services/monsters_state.py
@@ -11,8 +11,9 @@ from mutants.registries import items_catalog
 from mutants.registries import items_instances
 from mutants.services import items_weight
 from mutants.services import player_state as pstate
+from mutants.state import state_path
 
-DEFAULT_MONSTERS_PATH = Path("state/monsters/instances.json")
+DEFAULT_MONSTERS_PATH = state_path("monsters", "instances.json")
 
 
 def _sanitize_int(value: Any, *, minimum: int = 0, maximum: Optional[int] = None, fallback: int = 0) -> int:

--- a/src/mutants/services/player_state.py
+++ b/src/mutants/services/player_state.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from mutants.io.atomic import atomic_write_json
 from mutants.registries import items_instances as itemsreg
+from mutants.state import state_path
 from .equip_debug import _edbg_enabled, _edbg_log
 
 
@@ -64,7 +65,7 @@ def _pdbg_setup_file_logging() -> None:
     if _PDBG_CONFIGURED or not _pdbg_enabled():
         return
     try:
-        log_dir = Path("state") / "logs"
+        log_dir = state_path("logs")
         log_dir.mkdir(parents=True, exist_ok=True)
         log_path = log_dir / "players_debug.log"
         if not any(
@@ -139,7 +140,7 @@ def _playersdbg_log(action: str, state: Dict[str, Any]) -> None:
         pass
 
 def _player_path() -> Path:
-    return Path(os.getcwd()) / "state" / "playerlivestate.json"
+    return state_path("playerlivestate.json")
 
 
 def _persist_canonical(state: Dict[str, Any]) -> None:

--- a/src/mutants/state.py
+++ b/src/mutants/state.py
@@ -1,0 +1,39 @@
+"""Helpers for resolving the on-disk state directory."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def default_repo_state() -> Path:
+    """Return the default path to the bundled ``state`` directory.
+
+    This anchors relative to the project repository instead of the current
+    working directory so tooling and runtime environments agree on the same
+    location by default.
+    """
+
+    return Path(__file__).resolve().parents[2] / "state"
+
+
+def _resolve_env_state_root(raw: str) -> Path:
+    """Return the state root specified via the ``GAME_STATE_ROOT`` env var."""
+
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path
+
+
+_STATE_ROOT_ENV = os.getenv("GAME_STATE_ROOT")
+if _STATE_ROOT_ENV:
+    STATE_ROOT = _resolve_env_state_root(_STATE_ROOT_ENV)
+else:
+    STATE_ROOT = default_repo_state()
+
+
+def state_path(*parts: os.PathLike[str] | str) -> Path:
+    """Join ``parts`` onto :data:`STATE_ROOT` as a :class:`pathlib.Path`."""
+
+    return STATE_ROOT.joinpath(*parts)

--- a/src/mutants/ui/item_display.py
+++ b/src/mutants/ui/item_display.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 
 import json
 import re
-from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from ..registries import items_catalog, items_instances as itemsreg
+from ..state import state_path
 
-ROOT = Path(__file__).resolve().parents[3]
-CATALOG_PATH = ROOT / "state" / "items" / "catalog.json"
-OVERRIDES_PATH = ROOT / "state" / "items" / "naming_overrides.json"
+CATALOG_PATH = state_path("items", "catalog.json")
+OVERRIDES_PATH = state_path("items", "naming_overrides.json")
 
 _CAT_CACHE: Dict[str, Dict] = {}
 _OVR_CACHE: Dict[str, str] = {}

--- a/src/mutants/ui/logsink.py
+++ b/src/mutants/ui/logsink.py
@@ -4,11 +4,13 @@ import os
 from pathlib import Path
 from typing import Dict, List
 
+from mutants.state import state_path
+
 
 class LogSink:
     """Ring buffer sink that also appends to a file."""
 
-    def __init__(self, capacity: int = 200, file_path: str | Path | None = "state/logs/game.log") -> None:
+    def __init__(self, capacity: int = 200, file_path: str | Path | None = state_path("logs", "game.log")) -> None:
         self.capacity = capacity
         self.file_path = Path(file_path) if file_path else None
         self.buffer: List[str] = []

--- a/src/mutants/ui/styles.py
+++ b/src/mutants/ui/styles.py
@@ -61,6 +61,8 @@ from typing import Optional
 import json
 import os
 
+from ..state import state_path
+
 # Back-compat: add group-aware color resolver without removing existing APIs.
 _COLORS_CACHE: Optional[Dict[str, str]] = None
 _DEFAULT_COLOR: str = "white"
@@ -78,7 +80,7 @@ def _colors_path() -> str:
     if p:
         return p
     # 3) default location
-    return os.path.join(os.getcwd(), "state", "ui", "colors.json")
+    return str(state_path("ui", "colors.json"))
 
 
 def _load_colors_map() -> Dict[str, str]:

--- a/tests/test_state_root.py
+++ b/tests/test_state_root.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+import mutants.state as state
+
+
+def _reload_state() -> ModuleType:
+    return importlib.reload(state)
+
+
+def test_default_state_root_matches_repo(monkeypatch):
+    monkeypatch.delenv("GAME_STATE_ROOT", raising=False)
+    module = _reload_state()
+    expected = Path(__file__).resolve().parents[1] / "state"
+    assert module.default_repo_state() == expected
+    assert module.STATE_ROOT == expected
+    assert module.state_path("players").parent == expected
+
+
+def test_state_root_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAME_STATE_ROOT", str(tmp_path))
+    module = _reload_state()
+    try:
+        assert module.STATE_ROOT == tmp_path
+        expected_file = module.state_path("foo.json")
+        assert expected_file.parent == tmp_path
+    finally:
+        monkeypatch.delenv("GAME_STATE_ROOT", raising=False)
+        _reload_state()


### PR DESCRIPTION
## Summary
- add a mutants.state helper that resolves the default state directory and honors GAME_STATE_ROOT
- update player, UI, registry, and runtime modules to build state paths via the shared helper
- add tests covering the default path and environment override behaviour

## Testing
- pytest tests/test_state_root.py
- pytest tests/test_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68d4fe00d3a8832b8cc1da0cedcd98f7