### PR TITLE
Refine ranged item schema and damage floors

### DIFF
--- a/src/mutants/commands/strike.py
+++ b/src/mutants/commands/strike.py
@@ -10,6 +10,7 @@ from mutants.debug import turnlog
 from mutants.ui.item_display import item_label
 
 MIN_INNATE_DAMAGE = 6
+MIN_BOLT_DAMAGE = 6
 
 
 def _load_monsters(ctx: Mapping[str, Any]) -> Any:
@@ -367,10 +368,10 @@ def strike_cmd(arg: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
     if not weapon_iid:
         weapon_iid = _extract_wielded_iid(pstate.load_state(), cls_name)
     damage_item = weapon_iid if weapon_iid else {}
-    raw_damage = damage_engine.compute_base_damage(damage_item, active, target)
-    final_damage = max(0, int(raw_damage))
-    if not weapon_iid:
-        final_damage = max(MIN_INNATE_DAMAGE, final_damage)
+    attack = damage_engine.resolve_attack(damage_item, active, target)
+    final_damage = max(0, int(attack.damage))
+    if attack.source == "bolt":
+        final_damage = max(MIN_BOLT_DAMAGE, final_damage)
 
     final_damage = _clamp_melee_damage(target, final_damage)
 

--- a/src/mutants/services/monsters_state.py
+++ b/src/mutants/services/monsters_state.py
@@ -187,9 +187,11 @@ def _normalize_item(
         base_ac = _sanitize_int(template.get("armour_class"), minimum=0, fallback=0)
         derived["armour_class"] = base_ac + enchant_level
 
-    if "base_power" in template:
-        base_power = _sanitize_int(template.get("base_power"), minimum=0, fallback=0)
-        derived["base_damage"] = base_power + (4 * enchant_level)
+    for key in ("base_power_melee", "base_power"):
+        if key in template:
+            base_power = _sanitize_int(template.get(key), minimum=0, fallback=0)
+            derived["base_damage"] = base_power + (4 * enchant_level)
+            break
 
     derived["can_degrade"] = enchant_level == 0 and not bool(template.get("nondegradable"))
 

--- a/tests/test_items_catalog.py
+++ b/tests/test_items_catalog.py
@@ -9,6 +9,8 @@ def test_normalize_items_rejects_enchantable_ranged():
             "item_id": "longbow",
             "ranged": True,
             "enchantable": True,
+            "base_power_melee": 5,
+            "base_power_bolt": 15,
         }
     ]
 
@@ -32,3 +34,46 @@ def test_normalize_items_allows_enchantable_for_unflagged_items():
 
     assert not errors
     assert warnings == []
+
+
+def test_normalize_items_requires_ranged_base_powers():
+    items = [
+        {
+            "item_id": "ion_wand",
+            "ranged": True,
+            "enchantable": False,
+        }
+    ]
+
+    _warnings, errors = items_catalog._normalize_items(items)
+
+    assert errors
+    assert (
+        "ion_wand: ranged items must define base_power_melee and base_power_bolt." in errors
+    )
+
+
+def test_normalize_items_copies_legacy_power_fields():
+    items = [
+        {
+            "item_id": "ion_wand",
+            "ranged": True,
+            "enchantable": False,
+            "base_power": 9,
+            "poisonous": True,
+            "poison_power": 2,
+        }
+    ]
+
+    warnings, errors = items_catalog._normalize_items(items)
+
+    assert not errors
+    assert warnings == []
+
+    entry = items[0]
+    assert entry["base_power_melee"] == 9
+    assert entry["base_power_bolt"] == 9
+    assert entry["poison_melee"] is True
+    assert entry["poison_bolt"] is True
+    assert entry["poison_melee_power"] == 2
+    assert entry["poison_bolt_power"] == 2

--- a/tests_legacy/registries/test_items_catalog.py
+++ b/tests_legacy/registries/test_items_catalog.py
@@ -57,6 +57,7 @@ def test_charges_alias_and_defaults(tmp_path: Path) -> None:
             "name": "Rod",
             "weight": 1,
             "ranged": True,
+            "base_power": 4,
             "charges_start": 5,
         }
     ]


### PR DESCRIPTION
## Summary
- add ranged-aware attack resolution, exposing the attack source for minimum damage floors
- enforce the expanded ranged schema in the catalog normalizer and copy legacy fields into the new layout
- update strike and monster combat along with regression tests for innate and bolt damage floors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d532cbdf3c832bb41b8dea9baa4f82