### PR TITLE
Implement deterministic monster loot drops with atomic vaping

### DIFF
--- a/src/mutants/services/monsters_state.py
+++ b/src/mutants/services/monsters_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import uuid
@@ -454,13 +455,17 @@ class MonstersState:
         if isinstance(bag, list):
             for item in bag:
                 if isinstance(item, Mapping):
-                    drops.append(item)
-                    bag_items.append(item)
+                    entry = copy.deepcopy(item)
+                    drops.append(entry)
+                    bag_items.append(entry)
 
         armour = monster.get("armour_slot")
         armour_dropped = isinstance(armour, Mapping)
         if armour_dropped:
-            drops.append(armour)
+            armour_entry = copy.deepcopy(armour)
+            drops.append(armour_entry)
+        else:
+            armour_entry = None
 
         monster["bag"] = []
         monster["armour_slot"] = None
@@ -496,6 +501,8 @@ class MonstersState:
             "monster": monster,
             "drops": drops,
             "pos": monster.get("pos"),
+            "bag_drops": bag_items,
+            "armour_drop": armour_entry,
         }
 
     def save(self) -> None:

--- a/tests/test_monsters_state.py
+++ b/tests/test_monsters_state.py
@@ -159,6 +159,8 @@ def test_kill_monster_drops_items_and_clears_record(tmp_path):
 
     assert summary["monster"]["id"] == "ogre#1"
     assert summary["drops"] == [weapon, armour]
+    assert summary["bag_drops"] == [weapon]
+    assert summary["armour_drop"] == armour
     assert summary["pos"] == [1999, 2, 3]
     assert summary["monster"]["bag"] == []
     assert summary["monster"]["armour_slot"] is None


### PR DESCRIPTION
## Summary
- expose bag and armour drop metadata when removing a monster so the drop order can be controlled downstream
- add `combat_loot.drop_monster_loot` to place bag items, skulls, and armour deterministically while respecting ground capacity and logging full-tile vapourization
- update the strike command to use the new helper and record minted/vaporized drops, plus extend strike tests to cover capacity scenarios and determinism

## Testing
- pytest tests/test_monsters_state.py tests/test_monster_playersdbg.py tests/test_commands_strike.py


------
https://chatgpt.com/codex/tasks/task_e_68d53a49f1f8832b8c96285b73994093