### PR TITLE
Require explicit spawnable flags in item catalog normalization

### DIFF
--- a/src/mutants/registries/items_catalog.py
+++ b/src/mutants/registries/items_catalog.py
@@ -120,8 +120,11 @@ def _normalize_items(items: List[Dict[str, Any]]) -> tuple[List[str], List[str]]
                         f"{iid}: {flag_name} items must declare enchantable: false."
                     )
 
-        if "spawnable" not in it:
-            it["spawnable"] = False
+        if "spawnable" in it:
+            if not isinstance(it.get("spawnable"), bool):
+                errors.append(f"{iid}: spawnable must be explicitly true or false.")
+        else:
+            errors.append(f"{iid}: spawnable must be explicitly true or false.")
 
         is_ranged = bool(it.get("ranged"))
 
@@ -148,6 +151,11 @@ def _normalize_items(items: List[Dict[str, Any]]) -> tuple[List[str], List[str]]
             it["base_power_bolt"] = bolt_value
         elif "base_power_bolt" in it:
             it.pop("base_power_bolt", None)
+
+        if is_ranged and it.get("spawnable") is True:
+            warnings.append(
+                f"{iid}: ranged items marked spawnable; ensure this is intentional."
+            )
 
         if is_ranged:
             if "base_power_melee" not in it or "base_power_bolt" not in it:

--- a/tests/test_items_catalog.py
+++ b/tests/test_items_catalog.py
@@ -11,6 +11,7 @@ def test_normalize_items_rejects_enchantable_ranged():
             "enchantable": True,
             "base_power_melee": 5,
             "base_power_bolt": 15,
+            "spawnable": False,
         }
     ]
 
@@ -27,6 +28,7 @@ def test_normalize_items_allows_enchantable_for_unflagged_items():
         {
             "item_id": "amulet",
             "enchantable": True,
+            "spawnable": False,
         }
     ]
 
@@ -42,6 +44,7 @@ def test_normalize_items_requires_ranged_base_powers():
             "item_id": "ion_wand",
             "ranged": True,
             "enchantable": False,
+            "spawnable": False,
         }
     ]
 
@@ -62,6 +65,7 @@ def test_normalize_items_copies_legacy_power_fields():
             "base_power": 9,
             "poisonous": True,
             "poison_power": 2,
+            "spawnable": False,
         }
     ]
 
@@ -77,3 +81,36 @@ def test_normalize_items_copies_legacy_power_fields():
     assert entry["poison_bolt"] is True
     assert entry["poison_melee_power"] == 2
     assert entry["poison_bolt_power"] == 2
+
+
+def test_normalize_items_requires_spawnable():
+    items = [
+        {
+            "item_id": "mystery_item",
+        }
+    ]
+
+    _warnings, errors = items_catalog._normalize_items(items)
+
+    assert "mystery_item: spawnable must be explicitly true or false." in errors
+
+
+def test_normalize_items_warns_on_spawnable_ranged():
+    items = [
+        {
+            "item_id": "laser_pistol",
+            "ranged": True,
+            "enchantable": False,
+            "base_power_melee": 1,
+            "base_power_bolt": 5,
+            "spawnable": True,
+        }
+    ]
+
+    warnings, errors = items_catalog._normalize_items(items)
+
+    assert not errors
+    assert (
+        "laser_pistol: ranged items marked spawnable; ensure this is intentional." in warnings
+    )
+    assert items[0]["spawnable"] is True

--- a/tests_legacy/registries/test_items_catalog.py
+++ b/tests_legacy/registries/test_items_catalog.py
@@ -59,6 +59,7 @@ def test_charges_alias_and_defaults(tmp_path: Path) -> None:
             "ranged": True,
             "base_power": 4,
             "charges_start": 5,
+            "spawnable": False,
         }
     ]
     catalog_path = tmp_path / "catalog.json"
@@ -78,6 +79,7 @@ def test_invalid_charges_error(tmp_path: Path) -> None:
             "weight": 1,
             "uses_charges": True,
             "charges_max": 0,
+            "spawnable": False,
         }
     ]
     catalog_path = tmp_path / "catalog.json"


### PR DESCRIPTION
## Summary
- require catalog entries to declare a boolean spawnable flag instead of defaulting silently
- add an informational warning when ranged items are marked spawnable
- update catalog normalization tests, including legacy coverage, to reflect the explicit requirement

## Testing
- `pytest`
- `pytest tests/test_items_catalog.py`


------
https://chatgpt.com/codex/tasks/task_e_68d53e84d744832ba49f67a288320fe6