### PR TITLE
Fix UI path resolution to use state root

### DIFF
--- a/src/mutants/app/context.py
+++ b/src/mutants/app/context.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping
 
 import logging
@@ -74,10 +73,7 @@ def build_context() -> Dict[str, Any]:
     theme = load_theme(str(theme_path))
     # Apply theme settings to styles (palette path + ANSI toggle)
     if theme.colors_path:
-        cp = Path(theme.colors_path)
-        if not cp.is_absolute():
-            cp = Path.cwd() / cp
-        st.set_colors_map_path(str(cp))
+        st.set_colors_map_path(theme.colors_path)
     else:
         st.set_colors_map_path(None)
     st.reload_colors_map()

--- a/src/mutants/commands/theme.py
+++ b/src/mutants/commands/theme.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from mutants.state import state_path
 from mutants.ui.themes import load_theme
 from mutants.ui import styles as st
@@ -22,10 +20,7 @@ def theme_cmd(arg: str, ctx) -> None:
 
     # Wire theme to palette + ANSI
     if theme.colors_path:
-        cp = Path(theme.colors_path)
-        if not cp.is_absolute():
-            cp = Path.cwd() / cp
-        st.set_colors_map_path(str(cp))
+        st.set_colors_map_path(theme.colors_path)
     else:
         st.set_colors_map_path(None)
     st.reload_colors_map()

--- a/src/mutants/ui/styles.py
+++ b/src/mutants/ui/styles.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
+from pathlib import Path
+
 Segment = Tuple[str, str]
 
 # Token names
@@ -71,6 +73,18 @@ _COLORS_PATH_OVERRIDE: Optional[str] = None  # programmatic override via theme
 _ANSI_ENABLED: bool = True  # allow theme to disable ANSI for clean transcripts
 
 
+def _normalize_colors_path(raw: str | os.PathLike[str]) -> str:
+    """Resolve *raw* relative to :data:`STATE_ROOT` when needed."""
+
+    candidate = Path(raw).expanduser()
+    if candidate.is_absolute():
+        return str(candidate)
+    parts = candidate.parts
+    if parts and parts[0] == "state":
+        parts = parts[1:]
+    return str(state_path(*parts))
+
+
 def _colors_path() -> str:
     # 1) explicit programmatic override (theme)
     if _COLORS_PATH_OVERRIDE:
@@ -78,7 +92,7 @@ def _colors_path() -> str:
     # 2) environment
     p = os.environ.get(_COLOR_FILE_ENV)
     if p:
-        return p
+        return _normalize_colors_path(p)
     # 3) default location
     return str(state_path("ui", "colors.json"))
 
@@ -107,7 +121,7 @@ def set_colors_map_path(path: Optional[str]) -> None:
     Pass None to clear the override and fall back to env/defaults.
     """
     global _COLORS_PATH_OVERRIDE, _COLORS_CACHE
-    _COLORS_PATH_OVERRIDE = path
+    _COLORS_PATH_OVERRIDE = _normalize_colors_path(path) if path else None
     _COLORS_CACHE = None  # force reload on next resolve
 
 

--- a/tests/test_ui_paths.py
+++ b/tests/test_ui_paths.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+import mutants.state as state_mod
+import mutants.registries.items_catalog as items_catalog
+import mutants.registries.items_instances as items_instances
+import mutants.ui.item_display as item_display
+import mutants.ui.styles as styles
+
+
+def _reload_state_modules() -> None:
+    importlib.reload(state_mod)
+    importlib.reload(items_catalog)
+    importlib.reload(items_instances)
+
+
+def test_item_display_uses_state_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAME_STATE_ROOT", str(tmp_path))
+
+    items_dir = tmp_path / "items"
+    items_dir.mkdir(parents=True)
+    catalog = {"items": {"widget": {"display_name": "Widget"}}}
+    overrides = {"widget": "Renamed Widget"}
+    (items_dir / "catalog.json").write_text(json.dumps(catalog), encoding="utf-8")
+    (items_dir / "naming_overrides.json").write_text(json.dumps(overrides), encoding="utf-8")
+
+    try:
+        _reload_state_modules()
+        importlib.reload(item_display)
+        assert item_display.canonical_name("widget") == "Renamed Widget"
+    finally:
+        monkeypatch.delenv("GAME_STATE_ROOT", raising=False)
+        _reload_state_modules()
+        importlib.reload(item_display)
+
+
+def test_styles_colors_path_resolves_within_state_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAME_STATE_ROOT", str(tmp_path))
+
+    colors_dir = tmp_path / "ui"
+    colors_dir.mkdir(parents=True)
+    colors = {"defaults": "white", "map": {"compass.line": "magenta"}}
+    (colors_dir / "colors.json").write_text(json.dumps(colors), encoding="utf-8")
+
+    try:
+        _reload_state_modules()
+        monkeypatch.setenv("MUTANTS_UI_COLORS_PATH", "state/ui/colors.json")
+        importlib.reload(styles)
+        styles.reload_colors_map()
+        assert styles.resolve_color_for_group("compass.line") == "magenta"
+    finally:
+        monkeypatch.delenv("MUTANTS_UI_COLORS_PATH", raising=False)
+        monkeypatch.delenv("GAME_STATE_ROOT", raising=False)
+        _reload_state_modules()
+        importlib.reload(styles)


### PR DESCRIPTION
## Summary
- normalize theme color map paths against the game state root so overrides work from any working directory
- rely on the shared color path normalizer when applying themes in the app context and CLI command
- add regression tests that reload UI helpers under a temporary GAME_STATE_ROOT

## Testing
- pytest tests/test_ui_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68d5402e2b14832bb0775231de1bd4f7