### PR TITLE
Reject legacy base_power field

### DIFF
--- a/src/mutants/registries/items_catalog.py
+++ b/src/mutants/registries/items_catalog.py
@@ -192,16 +192,9 @@ def _normalize_items(items: List[Dict[str, Any]]) -> tuple[List[str], List[str]]
         melee_power = it.get("base_power_melee")
         bolt_power = it.get("base_power_bolt")
 
-        if melee_power is None and bolt_power is None and legacy_power is not None:
-            legacy_value = _coerce_non_negative_int("base_power", legacy_power)
-            if legacy_value is not None:
-                it["base_power_melee"] = legacy_value
-                it["base_power_bolt"] = legacy_value
-                melee_power = legacy_value
-                bolt_power = legacy_value
         if legacy_power is not None:
-            warnings.append(
-                f"{iid}: base_power will become an error after 2024-09-01; "
+            errors.append(
+                f"{iid}: base_power is no longer allowed; "
                 "run scripts/expand_item_power_fields.py to migrate."
             )
 

--- a/tests/test_items_catalog.py
+++ b/tests/test_items_catalog.py
@@ -56,7 +56,7 @@ def test_normalize_items_requires_ranged_base_powers():
     )
 
 
-def test_normalize_items_copies_legacy_power_fields():
+def test_normalize_items_rejects_legacy_base_power():
     items = [
         {
             "item_id": "ion_wand",
@@ -71,17 +71,9 @@ def test_normalize_items_copies_legacy_power_fields():
 
     warnings, errors = items_catalog._normalize_items(items)
 
-    assert not errors
-    assert any("base_power will become an error" in msg for msg in warnings)
+    assert errors
+    assert any("base_power is no longer allowed" in msg for msg in errors)
     assert any("poisonous/poison_power will become errors" in msg for msg in warnings)
-
-    entry = items[0]
-    assert entry["base_power_melee"] == 9
-    assert entry["base_power_bolt"] == 9
-    assert entry["poison_melee"] is True
-    assert entry["poison_bolt"] is True
-    assert entry["poison_melee_power"] == 2
-    assert entry["poison_bolt_power"] == 2
 
 
 def test_normalize_items_requires_spawnable():

--- a/tests_legacy/registries/test_items_catalog.py
+++ b/tests_legacy/registries/test_items_catalog.py
@@ -57,7 +57,8 @@ def test_charges_alias_and_defaults(tmp_path: Path) -> None:
             "name": "Rod",
             "weight": 1,
             "ranged": True,
-            "base_power": 4,
+            "base_power_melee": 4,
+            "base_power_bolt": 4,
             "charges_start": 5,
             "spawnable": False,
         }


### PR DESCRIPTION
## Summary
- treat legacy `base_power` as a hard validation error during catalog normalization
- remove automatic copying from `base_power` to melee/bolt fields and update tests
- adjust legacy regression test catalog fixture to use explicit power fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5cc9a7dc8832b81e3fd4b9d2bf097