### PR TITLE
Tighten error handling for daily litter and theme loading

### DIFF
--- a/src/mutants/commands/theme.py
+++ b/src/mutants/commands/theme.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from mutants.state import state_path
 from mutants.ui.themes import load_theme
 from mutants.ui import styles as st
@@ -13,8 +15,11 @@ def theme_cmd(arg: str, ctx) -> None:
     path = state_path("ui", "themes", f"{name}.json")
     try:
         theme = load_theme(str(path))
-    except Exception:
+    except (FileNotFoundError, PermissionError, IsADirectoryError):
         ctx["feedback_bus"].push("SYSTEM/ERR", f"Theme not found: {name}")
+        return
+    except json.JSONDecodeError:
+        ctx["feedback_bus"].push("SYSTEM/ERR", f"Theme file is invalid JSON: {name}")
         return
     ctx["theme"] = theme
 

--- a/src/mutants/services/monster_actions.py
+++ b/src/mutants/services/monster_actions.py
@@ -438,10 +438,7 @@ def _handle_player_death(
     )
 
     _clear_player_inventory(state, active, victim_class)
-    try:
-        pstate.clear_ready_target_for_active(reason="player-dead")
-    except Exception:
-        pass
+    pstate.clear_ready_target_for_active(reason="player-dead")
     pstate.save_state(state)
     _mark_monsters_dirty(ctx)
 
@@ -455,7 +452,8 @@ def _apply_player_damage(
     state_hint = ctx.get("player_state") if isinstance(ctx.get("player_state"), Mapping) else None
     try:
         state, active = pstate.get_active_pair(state_hint)
-    except Exception:
+    except (TypeError, ValueError, KeyError, AttributeError):
+        LOG.debug("Falling back to canonical active pair lookup", exc_info=True)
         state, active = pstate.get_active_pair()
     if not isinstance(active, Mapping) or not active:
         return False

--- a/src/mutants/ui/themes.py
+++ b/src/mutants/ui/themes.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Any
+
+
+LOG = logging.getLogger(__name__)
 
 
 DEFAULT_WIDTH = 80
@@ -25,9 +29,15 @@ def load_theme(path: str) -> Theme:
     data: Dict[str, Any] = {}
     if p.exists():
         try:
-            data = json.loads(p.read_text(encoding="utf-8"))
-        except Exception:
-            data = {}
+            text = p.read_text(encoding="utf-8")
+        except (OSError, IOError):
+            LOG.error("Failed to read theme file %s", p, exc_info=True)
+            raise
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            LOG.error("Theme file %s contains invalid JSON", p, exc_info=True)
+            raise
 
     width_raw = data.get("width", data.get("WIDTH", DEFAULT_WIDTH))
     try:


### PR DESCRIPTION
## Summary
- ensure daily litter bootstrap raises and logs concrete IO/JSON failures instead of silently defaulting
- surface JSON/IO problems when loading UI themes and provide user-facing feedback for invalid files
- harden item registry and monster actions helpers to log invalid state while avoiding blanket exception handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5d129899c832b87863c58148f1c43