### PR TITLE
Replace print usage in bootstrap bootstrap lazyinit and importer

### DIFF
--- a/src/mutants/bootstrap/lazyinit.py
+++ b/src/mutants/bootstrap/lazyinit.py
@@ -21,6 +21,7 @@ Notes:
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -33,6 +34,9 @@ try:
 except Exception:  # pragma: no cover
     import importlib_resources  # type: ignore
     files = importlib_resources.files  # type: ignore
+
+
+LOG = logging.getLogger(__name__)
 
 
 # ---------- Domain helpers ----------
@@ -166,8 +170,11 @@ def ensure_player_state(state_dir: str = "state",
             if isinstance(data, dict) and "players" in data and "active_id" in data:
                 return data
             raise ValueError("missing required keys: players/active_id")
-        except Exception as e:
-            print(f"[warn] {out_path} invalid or unreadable ({e}); rebuilding from templates...", flush=True)
+        except Exception:
+            LOG.warning(
+                "%s invalid or unreadable; rebuilding from templates", out_path,
+                exc_info=True,
+            )
             # Move the bad file aside so we don't overwrite it.
             try:
                 bad_path = out_path.with_suffix(out_path.suffix + ".bad")
@@ -206,6 +213,11 @@ def ensure_player_state(state_dir: str = "state",
 
 if __name__ == "__main__":
     # Ensure basic item state alongside player state when run directly.
+    logging.basicConfig(level=logging.INFO)
     ensure_item_state()
     st = ensure_player_state()
-    print(f"playerlivestate.json ready with {len(st.get('players', []))} classes; active_id={st.get('active_id')}")
+    LOG.info(
+        "playerlivestate.json ready with %s classes; active_id=%s",
+        len(st.get("players", [])),
+        st.get("active_id"),
+    )

--- a/src/mutants/services/monsters_importer.py
+++ b/src/mutants/services/monsters_importer.py
@@ -369,19 +369,19 @@ def format_report_table(records: List[RecordResult]) -> str:
 
 def print_report(report: ImportReport, *, dry_run: bool, out: TextIO = sys.stdout) -> None:
     table = format_report_table(report.records)
-    print(table, file=out)
-    print(file=out)
+    out.write(f"{table}\n")
+    out.write("\n")
 
     if report.imported_count:
-        print(f"Imported {report.imported_count} monster(s).", file=out)
+        out.write(f"Imported {report.imported_count} monster(s).\n")
         if report.per_year:
-            print("Per year:", file=out)
+            out.write("Per year:\n")
             for year, count in report.per_year.items():
-                print(f"  {year}: {count}", file=out)
-        print(f"Minted {report.minted_iids} item IID(s).", file=out)
+                out.write(f"  {year}: {count}\n")
+        out.write(f"Minted {report.minted_iids} item IID(s).\n")
 
     if report.rejected_count:
-        print(f"Rejected {report.rejected_count} monster(s).", file=out)
+        out.write(f"Rejected {report.rejected_count} monster(s).\n")
 
     if dry_run:
-        print("Dry-run: no changes were written.", file=out)
+        out.write("Dry-run: no changes were written.\n")


### PR DESCRIPTION
## Summary
- replace bootstrap lazyinit warning prints with logging and reconfigure the script entrypoint to use logging output
- avoid direct prints in the monsters importer report writer by writing to the provided TextIO stream

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5d359fca4832b9649fc7b4dcf78cc